### PR TITLE
Add CI workflow for Node.js and Android builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
 
   android:
     name: Android (JDK 17, Gradle)
+    if: ${{ hashFiles('**/gradlew') != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This CI configuration includes jobs for Node.js, Android, and GitHub Secret Scan. It ensures builds are only triggered on pull requests and feature branch pushes.

-ci: add robust, agent-guarded workflow (Node.js, Android, secret scan, no main push)