### PR TITLE
docs(p0): draft PR workflow + CLI merge workflow correction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,5 +12,6 @@ Hard rules:
 3. Tests-first; CI must be green.
 4. No shell injection risks: use spawn array form only; validate args.
 5. Do not add new CI scanners (CodeQL/Sonar/Semgrep/etc.) unless explicitly requested.
+6. Open all PRs as DRAFT (`gh pr create --draft`); mark 'Ready for Review' only when CI is green and all checklist items are complete.
 
 If a request risks breaking builds or expands scope, STOP and file an Issue proposing a safe phased plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Only these agents may write or modify code, docs, and config in this repo:
 - As sole human maintainer, @dvntone must technically bypass this enforced requirement to self-merge, but PRs should still satisfy the code-owner review rule.
 - **This is a known friction point.** Do not recommend re-enabling auto-merge or relaxing
   branch protection rules — the bypass is intentional and preferable to removing the guardrail.
-- Agents cannot approve their own PRs or merge via API. All merges require human action on GitHub web.
+- Agents cannot approve their own PRs. Merges are performed by @dvntone via `gh pr merge --admin --squash` from the Claude Code CLI (not the GitHub web UI).
 
 ## Required checks before "done"
 
@@ -98,7 +98,7 @@ Every change must be traceable. This means:
 
 ### PR Policy
 - PRs restricted to collaborators only.
-- Auto-merge: OFF (disabled 2026-03-14 per Copilot recommendation) — every PR requires manual merge by `@dvntone`.
+- Auto-merge: OFF (disabled 2026-03-14 per Copilot recommendation) — every PR is merged manually by @dvntone via `gh pr merge --admin --squash` from the Claude Code CLI.
 - Auto-delete head branches: ON — branches auto-delete after merge.
 
 ### Branch Protection (main)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -73,6 +73,19 @@ Every change must be fully traceable back to the agent that made it:
 - Every PR must reference exactly one GitHub Issue
 - Never open a new PR while CI is failing — fix the broken build first
 
+## Section 1.1: Draft PR Workflow
+
+- **All PRs must be opened as DRAFT** using `gh pr create --draft`.
+- Draft status signals work in progress — CI must run, but reviewers must not review draft PRs.
+- A PR may be marked **Ready for Review** only when ALL of the following are true:
+  1. All CI checks have passed (no failures, no pending jobs)
+  2. Every item in the PR description checklist is complete
+  3. No unresolved `blocker` or `security` issues are open
+  4. The PR references exactly one GitHub Issue
+  5. No secrets are committed
+- After marking Ready for Review, wait for Copilot review to complete before merging.
+- Never mark a draft Ready for Review to force a faster merge — if CI is red, fix it first.
+
 ## 1a. Merge Strategy — Squash Only
 
 - **Only squash merge is enabled on this repository.** Merge commits and rebase are disabled.


### PR DESCRIPTION
## Summary

Docs-only maintenance PR. Three corrections before Phase 1 begins.

## Changes

1. **`docs/AGENTS.md` §1.1** — New section: all PRs must open as DRAFT. Defines the 5 conditions required before marking Ready for Review (CI green, checklist complete, no open blocker/security, issue referenced, no secrets). Specifies Copilot review must complete before merge.

2. **`.github/copilot-instructions.md` rule 6** — Open all PRs as DRAFT; mark Ready for Review only when CI is green and checklist is complete.

3. **`AGENTS.md` (root) lines 59 + 101** — Corrected inaccuracy. Previously said "all merges require human action on GitHub web." Correct workflow is `gh pr merge --admin --squash` from the Claude Code CLI authenticated as @dvntone.

## What was NOT done (with rationale)

- `KNOWN_ISSUES.md` typo (`WONT FIX` → `WON'T FIX`): string does not exist in the current repo. Was only in the wscanplus-backup. No action needed.
- `.gitignore` `firebase-debug.log`: already covered by `*.log` on line 4. No action needed.

## Checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#48)
- [x] One maintenance change set (docs only)
- [x] < 200 LOC changed (16 insertions, 2 deletions)
- [x] No new dependencies
- [x] No code changes — docs only, no tests required
- [x] No secrets committed
- [x] `.env` / `local.properties` NOT committed
- [x] Gemini/Vertex integration untouched
- [x] Merged via **Squash and merge** only

## Rules guiding decisions

- docs/AGENTS.md §1, §1.1 (new), §7 (maintenance PR)
- CLAUDE.md: Hard Rules, Workflow section
- `feedback_pr_process.md` memory: wait for CI + Copilot before merging

Closes #48