### PR TITLE
chore(p0): add android/.idea/ to gitignore + remove .eslintrc.json artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,9 @@ out/
 *.jks
 
 
+# Android Studio IDE files
+android/.idea/
+
 # Claude AI local files
 .claude/
 


### PR DESCRIPTION
## Summary

Two housekeeping items clearing the way for the Android scaffold PR.

## Changes

- `.gitignore` — add `android/.idea/` (Android Studio IDE files, generated when opening android/ folder)
- `.eslintrc.json` — deleted locally; was untracked legacy config, never committed, conflicts with `desktop/eslint.config.mjs`

## Checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#54)
- [x] No code changes
- [x] No secrets committed
- [x] Gemini/Vertex untouched
- [x] Squash merge only

Closes #54