### PR TITLE
docs(p1): post-quality-gate update — SESSION_STATE + KNOWN_ISSUES

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,5 +1,25 @@
 # Known Issues
 
+## 2026-03-16: Lint errors found in quality check — resolved PR #69
+
+**Issues found:** Two lint errors + stale key name references discovered during pre-feature quality check.
+
+1. **`CoarseFineLocation` error** (`AndroidManifest.xml`) — Android 12+ requires both `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` to be declared. Only `ACCESS_FINE_LOCATION` was present. App must handle COARSE-only grants gracefully.
+2. **`MissingPermission` error** (`StandardScanner.kt`) — `wifiManager.scanResults` called inside `BroadcastReceiver.onReceive()` without `@RequiresPermission` annotation. Lint cannot trace permission contract through system callbacks.
+3. **Stale key name** — `MAPS_API_KEY` referenced in `AndroidManifest` comment and `build.gradle.kts` comment after rename to `GOOGLE_MAPS_API_KEY` in PR #68.
+
+**Additional:** Local `desktop/node_modules` was corrupt (`exit-x` missing). Fixed with `npm ci`.
+
+**Status:** ✅ RESOLVED — PR #69 merged 2026-03-16 (commit `10f753f`). Lint now reports 0 errors.
+
+**Remaining advisory warnings (non-blocking):**
+- espresso-core 3.6.1 → 3.7.0 available
+- Gradle 9.3.1 → 9.4.0 available
+- Missing `android:icon` on `<application>` — Phase 2 UI work
+- `android:allowBackup` deprecated (Android 12+) — add `android:dataExtractionRules` — Phase 2 UI work
+
+---
+
 ## 2026-03-16: Firebase AI scaffold — google-services.json required before runtime init
 
 **Issue:** `google-services.json` is gitignored (`**/google-services.json` in root `.gitignore`). The google-services plugin (`com.google.gms.google-services:4.4.4`) is declared in `android/build.gradle.kts` with `apply false` but NOT yet applied in `:app` — applying it without the JSON file causes a build failure.

--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -88,7 +88,7 @@ wscanplus/
 
 ## Phase
 
-**Phase 1 (Android Source)** — scaffold merged, first Kotlin sources next
+**Phase 1 (Android Source)** — scaffold complete, quality checks passed, feature work next
 
 ---
 
@@ -169,23 +169,43 @@ AGP 9.x ships with built-in Kotlin. No `org.jetbrains.kotlin.android` plugin nee
 - `WifiManager.startScan()` deprecated API 28 — do not use for new scanner implementations.
 - **Standard scanner pattern:** `BroadcastReceiver` for `WifiManager.SCAN_RESULTS_AVAILABLE_ACTION` + `wifiManager.getScanResults()`.
 - `registerScanResultsCallback()` API 30+ only — guard with API level check.
-- **Permissions (full set for API 24–36):** `ACCESS_WIFI_STATE`, `CHANGE_WIFI_STATE`, `ACCESS_FINE_LOCATION` (runtime), `NEARBY_WIFI_DEVICES` with `neverForLocation` flag (API 33+ only, declare in manifest).
+- **Permissions (full set for API 24–36):** `ACCESS_WIFI_STATE`, `CHANGE_WIFI_STATE`, `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION` (both required at runtime — Android 12+ mandates both declared; user may grant only COARSE and app must handle that gracefully), `NEARBY_WIFI_DEVICES` with `neverForLocation` flag (API 33+ only, declare in manifest).
 - **USB adapter detection:** `android.hardware.usb.*` USB Host API (API 12+) — detect OTG adapters by vendor/product ID. No root required.
 
 ### Desktop test tooling (Codex verified — 2026-03-16)
 
 - **Jest:** 29.7.0 → **30.3.0** (fixes CVE-2024-21538). `--experimental-vm-modules` no longer needed in Jest 30.
 - **Updated test script:** `"test": "jest --runInBand --passWithNoTests"`
-- **New file:** `jest.config.mjs` — `export default { testEnvironment: "node", transform: {}, extensionsToTreatAsEsm: [".js", ".mjs"] }`
+- **New file:** `jest.config.mjs` — `export default { testEnvironment: "node", transform: {} }` — `extensionsToTreatAsEsm` is NOT needed for `.js`/`.mjs` with `"type": "module"` in Jest 30.
 
-### Phase 1 Remaining Actions (PR sequence)
+### Phase 1 Scaffold — Complete ✅
 
-1. ~~**[PR #62 — DEPENDENCY, CVE blocker]** jest 29.7.0 → 30.3.0 + `jest.config.mjs` + test script update + Android test dep updates~~ ✅ merged e95a880
-2. ~~**[PR #63 — DEPENDENCY]** AGP 9.0.0 → 9.1.0~~ ✅ merged e7e9fbe
-3. **[PR — FEATURE]** WatchdogService stub + scanner chain skeleton (USB > Standard; Root dev-opt-in stub)
-4. **[PR — FEATURE]** AndroidManifest permissions (USE_BIOMETRIC, ACCESS_FINE_LOCATION, FOREGROUND_SERVICE, FOREGROUND_SERVICE_DATA_SYNC, INTERNET, NEARBY_WIFI_DEVICES)
-5. **[PR — FEATURE]** Firebase AI Logic scaffold (`firebase-bom:34.10.0` + `firebase-ai`, google-services plugin, `google-services.json` placeholder)
-6. **[PR — FEATURE]** Google Maps scaffold
+All scaffold PRs merged to main (head: `10f753f`):
+
+1. ~~**[PR #62]** jest 29.7.0 → 30.3.0 (CVE-2024-21538) + Android test dep updates~~ ✅ e95a880
+2. ~~**[PR #63]** AGP 9.0.0 → 9.1.0~~ ✅ e7e9fbe
+3. ~~**[PR #64]** Dependency audit + doc alignment~~ ✅ 3ebd218
+4. ~~**[PR #65]** WatchdogService stub + scanner chain skeleton~~ ✅ 4ea62e2
+5. ~~**[PR #66]** AndroidManifest permissions (full set)~~ ✅ 4fd20fc
+6. ~~**[PR #67]** Firebase AI Logic scaffold (firebase-bom:34.10.0 + firebase-ai)~~ ✅ 94c5c59
+7. ~~**[PR #68]** Google Maps scaffold (play-services-maps:20.0.0, GOOGLE_MAPS_API_KEY)~~ ✅ 1218a1e
+8. ~~**[PR #69]** Lint fix — ACCESS_COARSE_LOCATION + @RequiresPermission annotations~~ ✅ 10f753f
+
+### Quality Gate Results (2026-03-16)
+
+| Check | Result |
+|-------|--------|
+| `./gradlew assembleDebug` | ✅ BUILD SUCCESSFUL |
+| `npm test` (desktop) | ✅ Pass (`npm ci` resolved corrupt node_modules) |
+| `./gradlew lint` | ✅ 0 errors (2 errors caught + fixed in PR #69) |
+
+**Advisory warnings (non-blocking, future dep PR):** espresso-core 3.6.1 → 3.7.0, Gradle 9.3.1 → 9.4.0, missing app icon + `android:dataExtractionRules` (Phase 2 UI work).
+
+### Phase 1 Next — Feature Work
+
+- StandardScanner real implementation: `BroadcastReceiver` + `getScanResults()` → results callback
+- Plan runtime permission request flow (which component requests `ACCESS_COARSE_LOCATION` / `NEARBY_WIFI_DEVICES`)
+- WatchdogService startup trigger (what calls `startForegroundService()`)
 
 ---
 


### PR DESCRIPTION
## Summary

- **SESSION_STATE.md:** Mark Phase 1 scaffold complete; list all PRs #62–#69 merged; add quality gate results table; correct `jest.config.mjs` note (`extensionsToTreatAsEsm` not needed in Jest 30); add `ACCESS_COARSE_LOCATION` to WiFi permissions section; document Phase 1 next steps
- **KNOWN_ISSUES.md:** Add PR #69 lint fix entry (2 real errors resolved: `CoarseFineLocation`, `MissingPermission`; stale key name); document advisory warnings deferred to Phase 2 UI work; note `npm ci` fix for corrupt local node_modules

## Test plan

- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)