### PR TITLE
deps(android): Gradle 9.3.1 → 9.4.0 + espresso-core 3.6.1 → 3.7.0

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -64,5 +64,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
 
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }

--- a/android/core/build.gradle.kts
+++ b/android/core/build.gradle.kts
@@ -27,5 +27,5 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=60ea723356d81263e8002fec0fcf9e2b0eee0c0850c7a3d7ab0a63f2ccc601f3
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- Gradle wrapper `9.3.1` → `9.4.0` — stable release (2026-03-04), no breaking changes, compatible with AGP 9.1.0. SHA-256 pinned in `gradle-wrapper.properties`.
- `espresso-core:3.6.1` → `3.7.0` — stable, minSdk bumped to 21 (project minSdk 24), compatible with `androidx.test.ext:junit:1.3.0`. Updated in both `:app` and `:core`.

Both versions Codex-verified (GPT 5.2, 2026-03-16). Resolves the two `GradleDependency`/`AndroidGradlePluginVersion` advisory lint warnings.

**Lint after change:** 0 errors, 2 advisory warnings (missing icon + `dataExtractionRules` — Phase 2 UI work, not blocking).

## Test plan

- [ ] CI: `./gradlew assembleDebug` passes on Gradle 9.4.0
- [ ] CI: `./gradlew lint` returns 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)