### PR TITLE
feat(android): WatchdogService startForeground + notification channel

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -1,14 +1,24 @@
 package com.wscanplus.app
 
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import com.wscanplus.core.scanner.ScannerChain
 
 /**
  * WatchdogService manages the scanner chain and the ADB communication socket.
  *
  * Foreground service — foregroundServiceType="dataSync" (declared in AndroidManifest).
+ * Must call startForeground() within a few seconds of startForegroundService() or the
+ * system throws ForegroundServiceDidNotStartInTimeException (API 31+).
+ *
  * Serial number is the primary device key in all data structures.
  *
  * Android 15 constraint: dataSync foreground services have a 6-hour max runtime.
@@ -17,8 +27,6 @@ import com.wscanplus.core.scanner.ScannerChain
  * Threading rule: scanner chain and ServerSocket operations MUST run on background
  * threads. Never call scanners or socket operations on the main thread.
  *
- * TODO (Phase 1 — permissions PR): call startForeground() with a notification once
- * FOREGROUND_SERVICE and FOREGROUND_SERVICE_DATA_SYNC permissions are declared.
  * TODO (Phase 1): launch scanner chain on a background thread (HandlerThread or coroutine).
  * TODO (Phase 3): open ServerSocket(9000) on a background thread for ADB comms.
  */
@@ -26,13 +34,27 @@ class WatchdogService : Service() {
 
     private var scannerChain: ScannerChain? = null
 
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 
+    // FOREGROUND_SERVICE_TYPE_DATA_SYNC is API 29 — safe to inline: ServiceCompat.startForeground()
+    // guards the type parameter internally and falls back to startForeground(id, notification)
+    // on API < 29. The constant value is copied at compile time and causes no runtime issue.
+    @SuppressLint("InlinedApi")
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // TODO: startForeground(NOTIFICATION_ID, buildNotification()) — requires permissions PR
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            buildNotification(),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        )
         if (scannerChain == null) {
             scannerChain = ScannerChain(applicationContext)
-            // TODO: scannerChain!!.start() on a background thread
+            // TODO (Phase 1): scannerChain!!.start() on a background thread
         }
         return START_STICKY
     }
@@ -40,7 +62,33 @@ class WatchdogService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         scannerChain?.stop()
-        // TODO: close ServerSocket (Phase 3)
+        // TODO (Phase 3): close ServerSocket
         scannerChain = null
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "wscan+ Scanner",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Active while the WiFi scanner chain is running"
+            }
+            getSystemService(NotificationManager::class.java)
+                .createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification() = NotificationCompat.Builder(this, CHANNEL_ID)
+        .setContentTitle("wscan+ scanning")
+        // Placeholder system icon — replace with app icon in Phase 2
+        .setSmallIcon(android.R.drawable.ic_menu_search)
+        .setOngoing(true)
+        .build()
+
+    companion object {
+        private const val CHANNEL_ID = "wscanplus_watchdog"
+        private const val NOTIFICATION_ID = 1
     }
 }


### PR DESCRIPTION
## Summary

Implements the foreground service promotion required before `MainActivity` can call `startForegroundService()`. Without `startForeground()` being called within seconds of service start, Android throws `ForegroundServiceDidNotStartInTimeException` on API 31+.

- `createNotificationChannel()` called in `onCreate()` — `IMPORTANCE_LOW` (no sound/vibration), guarded with `Build.VERSION.SDK_INT >= O` for minSdk 24 compatibility
- `ServiceCompat.startForeground()` called immediately at top of `onStartCommand()` with `FOREGROUND_SERVICE_TYPE_DATA_SYNC`
- `@SuppressLint("InlinedApi")` on `onStartCommand()` — `FOREGROUND_SERVICE_TYPE_DATA_SYNC` is API 29 but `ServiceCompat` guards the type parameter internally; the constant is safe to inline on API 24+
- Placeholder small icon (`android.R.drawable.ic_menu_search`) — to be replaced with real app icon in Phase 2 UI work

**Lint:** 0 errors, 2 warnings (missing icon + `dataExtractionRules` — Phase 2 deferred, not blocking)

## Test plan

- [ ] CI: `./gradlew assembleDebug` passes
- [ ] CI: `./gradlew lint` returns 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)