### PR TITLE
feat(android): stub MainActivity — permission flow + WatchdogService start

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,10 +19,11 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <!--
-        NEARBY_WIFI_DEVICES (API 33+): replaces the location permission requirement
-        for getScanResults() on API 33+. neverForLocation flag ensures this permission
-        is not used to derive the user's location. Declare alongside ACCESS_FINE_LOCATION
-        for API 24–32 fallback coverage.
+        NEARBY_WIFI_DEVICES (API 33+): required for WiFi P2P, WiFi Aware, and hotspot
+        APIs on API 33+. Does NOT replace ACCESS_FINE_LOCATION for getScanResults() —
+        that method was explicitly excluded from the NEARBY_WIFI_DEVICES migration and
+        requires ACCESS_FINE_LOCATION on all API levels. neverForLocation ensures this
+        permission is not used to derive location from WiFi data.
     -->
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
@@ -55,6 +56,15 @@
         android:allowBackup="false"
         android:label="wscan+"
         android:supportsRtl="true">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
         <!--
             WatchdogService — foreground service managing the scanner chain + ADB socket.

--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -1,0 +1,71 @@
+package com.wscanplus.app
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+
+class MainActivity : Activity() {
+
+    private lateinit var statusView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        statusView = TextView(this).apply {
+            text = "wscan+ needs Wi-Fi scan permissions to start the scanner."
+        }
+        setContentView(statusView)
+
+        if (hasAllPermissions()) {
+            startWatchdog()
+        } else {
+            requestPermissions(requiredPermissions(), REQUEST_CODE)
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode != REQUEST_CODE) {
+            return
+        }
+        if (hasAllPermissions()) {
+            startWatchdog()
+        } else {
+            statusView.text =
+                "Permissions denied. Grant Wi-Fi and location permissions in Settings to start."
+        }
+    }
+
+    private fun requiredPermissions(): Array<String> {
+        val base = mutableListOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            base.add(Manifest.permission.NEARBY_WIFI_DEVICES)
+        }
+        return base.toTypedArray()
+    }
+
+    private fun hasAllPermissions(): Boolean =
+        requiredPermissions().all { permission ->
+            ContextCompat.checkSelfPermission(this, permission) ==
+                PackageManager.PERMISSION_GRANTED
+        }
+
+    private fun startWatchdog() {
+        statusView.text = "Starting scanner..."
+        val intent = Intent(this, WatchdogService::class.java)
+        ContextCompat.startForegroundService(this, intent)
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 1001
+    }
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/ScannerChain.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/ScannerChain.kt
@@ -25,7 +25,7 @@ class ScannerChain(private val context: Context) {
     private val standardScanner = StandardScanner(context)
     // RootScanner is never instantiated in the chain — dev opt-in only.
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_COARSE_LOCATION])
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_FINE_LOCATION])
     fun start() {
         if (usbScanner.isAvailable()) {
             usbScanner.start()

--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/StandardScanner.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/StandardScanner.kt
@@ -33,7 +33,7 @@ class StandardScanner(private val context: Context) {
 
     private var receiver: BroadcastReceiver? = null
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_COARSE_LOCATION])
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_FINE_LOCATION])
     fun start() {
         if (receiver != null) return  // idempotent — already started
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {


### PR DESCRIPTION
## Summary

Implements the minimum Activity required for `startForegroundService()` — Android 12+ FGS-from-background restriction means the service must be started from a visible Activity.

**MainActivity** (written by Codex, reviewed + corrected by Claude):
- Requests `ACCESS_FINE_LOCATION` on all API levels — confirmed required for `getScanResults()` on targetSdk 36 across all API levels (deep research via Android docs; `getScanResults()` was explicitly excluded from the `NEARBY_WIFI_DEVICES` migration)
- Also requests `NEARBY_WIFI_DEVICES` on API 33+ for future P2P/Aware APIs
- Legacy `requestPermissions()` + `onRequestPermissionsResult()` — correct given no `activity-ktx` dep (`ActivityResultContracts` requires `ComponentActivity`)
- `ContextCompat.startForegroundService()` on grant
- `hasAllPermissions()` re-checked before start (handles already-granted case)
- Registered as `MAIN`/`LAUNCHER` in `AndroidManifest`

**Corrections applied to Codex output:**
- `AndroidManifest` `NEARBY_WIFI_DEVICES` comment: corrected false claim that it "replaces" location for `getScanResults()` — confirmed explicitly excluded from `NEARBY_WIFI_DEVICES` migration by Android docs
- `@RequiresPermission` on `ScannerChain.start()` + `StandardScanner.start()`: `ACCESS_COARSE_LOCATION` → `ACCESS_FINE_LOCATION` (deep research confirms FINE is required for `getScanResults()` on targetSdk 36, not COARSE)

**Lint:** 0 errors, 5 warnings (icon + `dataExtractionRules` + 3× `SetTextI18n` hardcoded strings — all Phase 2 UI work, not blocking)

## Test plan

- [ ] CI: `./gradlew assembleDebug` passes
- [ ] CI: `./gradlew lint` returns 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)