### PR TITLE
feat(android): StandardScanner implementation + WifiScanResult data model

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/ScannerChain.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/ScannerChain.kt
@@ -19,10 +19,13 @@ import androidx.annotation.RequiresPermission
  * TODO (Phase 1): implement USB adapter detection and chain switching.
  * TODO (Phase 1): wire scan results to WatchdogService via callback or channel.
  */
-class ScannerChain(private val context: Context) {
+class ScannerChain(
+    private val context: Context,
+    private val resultsListener: ScanResultsListener = ScanResultsListener { }
+) {
 
     private val usbScanner = UsbScanner(context)
-    private val standardScanner = StandardScanner(context)
+    private val standardScanner = StandardScanner(context, resultsListener)
     // RootScanner is never instantiated in the chain — dev opt-in only.
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_FINE_LOCATION])

--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/StandardScanner.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/StandardScanner.kt
@@ -8,7 +8,10 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.wifi.WifiManager
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * StandardScanner is the guaranteed baseline scanner — works on all devices, all API levels.
@@ -17,7 +20,7 @@ import androidx.annotation.RequiresPermission
  *   API 30+: registerScanResultsCallback() (non-deprecated, preferred)
  *   API 24–29: BroadcastReceiver for SCAN_RESULTS_AVAILABLE_ACTION + getScanResults()
  *
- * Note: WifiManager.startScan() is deprecated API 28 — NOT used here.
+ * Note: WifiManager.startScan() is deprecated API 28 — only used on API < 28.
  *
  * Runtime permissions required (declared in Phase 1 permissions PR):
  *   ACCESS_FINE_LOCATION (all API levels), NEARBY_WIFI_DEVICES with neverForLocation (API 33+)
@@ -25,22 +28,44 @@ import androidx.annotation.RequiresPermission
  * Threading rule: start() and stop() MUST be called from a background thread.
  * start() is idempotent — safe to call multiple times.
  *
- * TODO (Phase 1): implement registerScanResultsCallback() path for API 30+.
- * TODO (Phase 1): forward scan results via callback or channel to ScannerChain.
  * TODO (Phase 1): handle permission-not-granted case gracefully.
  */
-class StandardScanner(private val context: Context) {
+class StandardScanner(
+    context: Context,
+    private val resultsListener: ScanResultsListener = ScanResultsListener { }
+) {
 
+    private val appContext = context.applicationContext
+    private val wifiManager = appContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
     private var receiver: BroadcastReceiver? = null
+    private var scanResultsCallback: WifiManager.ScanResultsCallback? = null
+    private var scanCallbackExecutor: ExecutorService? = null
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_FINE_LOCATION])
     fun start() {
-        if (receiver != null) return  // idempotent — already started
+        if (receiver != null || scanResultsCallback != null) return  // idempotent — already started
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // API 30+: use registerScanResultsCallback — TODO implement
+            startWithScanResultsCallback()
         } else {
             startWithBroadcastReceiver()
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    @SuppressLint("MissingPermission")
+    private fun startWithScanResultsCallback() {
+        val executor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "wscanplus-standard-scanner")
+        }
+        val callback = object : WifiManager.ScanResultsCallback() {
+            override fun onScanResultsAvailable() {
+                val results = wifiManager.scanResults
+                resultsListener.onResults(results.map { it.toWifiScanResult() })
+            }
+        }
+        scanCallbackExecutor = executor
+        scanResultsCallback = callback
+        wifiManager.registerScanResultsCallback(executor, callback)
     }
 
     private fun startWithBroadcastReceiver() {
@@ -50,17 +75,18 @@ class StandardScanner(private val context: Context) {
             @SuppressLint("MissingPermission")
             override fun onReceive(ctx: Context, intent: Intent) {
                 if (intent.action != WifiManager.SCAN_RESULTS_AVAILABLE_ACTION) return
-                val wifiManager = ctx.applicationContext
-                    .getSystemService(Context.WIFI_SERVICE) as WifiManager
-                @Suppress("DEPRECATION", "UNUSED_VARIABLE")
                 val results = wifiManager.scanResults
-                // TODO: forward results to ScannerChain callback
+                resultsListener.onResults(results.map { it.toWifiScanResult() })
             }
         }
-        context.registerReceiver(
+        appContext.registerReceiver(
             receiver,
             IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION)
         )
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            @Suppress("DEPRECATION")
+            wifiManager.startScan()
+        }
     }
 
     fun stop() {
@@ -69,12 +95,38 @@ class StandardScanner(private val context: Context) {
         // defensively in case of unexpected lifecycle edge cases.
         receiver?.let {
             try {
-                context.unregisterReceiver(it)
+                appContext.unregisterReceiver(it)
             } catch (e: IllegalArgumentException) {
                 // Receiver was not registered — log in future when logging is available
             }
             receiver = null
         }
-        // TODO: unregister registerScanResultsCallback when API 30+ path is implemented
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            scanResultsCallback?.let { callback ->
+                @SuppressLint("MissingPermission")
+                // Permission was held at start() time — same WifiManager session.
+                fun unregister() = wifiManager.unregisterScanResultsCallback(callback)
+                unregister()
+            }
+        }
+        scanResultsCallback = null
+        scanCallbackExecutor?.shutdown()
+        scanCallbackExecutor = null
+    }
+
+    @Suppress("DEPRECATION")
+    private fun android.net.wifi.ScanResult.toWifiScanResult(): WifiScanResult {
+        val ssid = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            wifiSsid?.toString()
+        } else {
+            SSID
+        }
+        return WifiScanResult(
+            ssid = ssid ?: "",
+            bssid = BSSID ?: "",
+            signalLevel = level,
+            frequencyMhz = frequency,
+            capabilities = capabilities ?: ""
+        )
     }
 }

--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/WifiScanResult.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/WifiScanResult.kt
@@ -1,0 +1,17 @@
+package com.wscanplus.core.scanner
+
+/**
+ * Phase 1 minimal Wi-Fi scan result model.
+ * Additional fields can be added as needed in later phases.
+ */
+data class WifiScanResult(
+    val ssid: String,
+    val bssid: String,
+    val signalLevel: Int,
+    val frequencyMhz: Int,
+    val capabilities: String
+)
+
+fun interface ScanResultsListener {
+    fun onResults(results: List<WifiScanResult>)
+}


### PR DESCRIPTION
## Summary

Written by Codex (GPT 5.2), reviewed + API-guarded by Claude.

**`WifiScanResult.kt`** (new file):
- Minimal Phase 1 data model: `ssid`, `bssid`, `signalLevel`, `frequencyMhz`, `capabilities` — all safe with `ACCESS_WIFI_STATE` + `ACCESS_FINE_LOCATION`
- `fun interface ScanResultsListener` — lambda-friendly callback boundary between scanner and service

**`ScannerChain.kt`:**
- `ScanResultsListener` constructor param (default no-op) passed through to `StandardScanner`

**`StandardScanner.kt`** (full implementation):
- **API 30+:** `registerScanResultsCallback()` on a named single-thread executor (`Executors.newSingleThreadExecutor()`) — no coroutines dep needed; satisfies the executor contract for the callback
- **API 24–29:** `BroadcastReceiver` for `SCAN_RESULTS_AVAILABLE_ACTION` + `getScanResults()`
- `startScan()` called **only on API < 28** — deprecated at API 28, passive scans sufficient on 28+
- `toWifiScanResult()`: `wifiSsid` (API 33+) with `SSID` field fallback; `@Suppress("DEPRECATION")` on `SSID` access
- `stop()`: balanced unregister for both paths, executor shutdown
- `@RequiresApi(Build.VERSION_CODES.R)` on `startWithScanResultsCallback()` — satisfies `NewApi` lint for `ScanResultsCallback` class + `register`/`unregister` calls
- API version guard in `stop()` before `unregisterScanResultsCallback()`

**Lint:** 0 errors, 5 warnings (icon + `dataExtractionRules` + 3× `SetTextI18n` — Phase 2 UI work, not blocking)

## Test plan

- [ ] CI: `./gradlew assembleDebug` passes
- [ ] CI: `./gradlew lint` returns 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)