### PR TITLE
feat(p1): add app icon + dataExtractionRules

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,9 @@
 
     <application
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="wscan+"
         android:supportsRtl="true">
 

--- a/android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:pathData="M0,0h108v108h-108z"
+        android:fillColor="#1A237E" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <!-- WiFi signal arcs — centered in adaptive icon safe zone (24dp inset) -->
+    <group
+        android:translateX="54"
+        android:translateY="58">
+        <!-- Outer arc -->
+        <path
+            android:pathData="M-24,-20 A34,34 0 0,1 24,-20"
+            android:strokeWidth="4"
+            android:strokeColor="#FFFFFF"
+            android:fillColor="#00000000"
+            android:strokeLineCap="round" />
+        <!-- Middle arc -->
+        <path
+            android:pathData="M-16,-14 A22,22 0 0,1 16,-14"
+            android:strokeWidth="4"
+            android:strokeColor="#FFFFFF"
+            android:fillColor="#00000000"
+            android:strokeLineCap="round" />
+        <!-- Inner arc -->
+        <path
+            android:pathData="M-8,-8 A11,11 0 0,1 8,-8"
+            android:strokeWidth="4"
+            android:strokeColor="#FFFFFF"
+            android:fillColor="#00000000"
+            android:strokeLineCap="round" />
+        <!-- Center dot -->
+        <path
+            android:pathData="M0,0 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0"
+            android:fillColor="#FFFFFF" />
+    </group>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Cloud backup rules for Android 12+ (replaces deprecated android:allowBackup).
+    wscan+ does not back up any data — scan results and threat data stay on-device.
+    Phase 6 may revisit if user-exportable data is added.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

- Add adaptive icon: WiFi signal arcs (white) on indigo (#1A237E) background
- Add `data_extraction_rules.xml` — excludes all data from cloud backup/device transfer
- Add `android:icon`, `android:roundIcon`, `android:dataExtractionRules` to AndroidManifest
- Resolves 2 remaining lint warnings from quality gate (pending since PR #69)

Closes #87

## Checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#87)
- [ ] CI is green
- [x] One feature (icon + extraction rules — both lint warning fixes)
- [x] < 200 LOC changed — 74 insertions
- [x] No new dependencies
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)