### PR TITLE
test(p1): first unit tests for :core module

### DIFF
--- a/android/core/src/test/kotlin/com/wscanplus/core/scanner/ScanResultsListenerTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/scanner/ScanResultsListenerTest.kt
@@ -1,0 +1,57 @@
+package com.wscanplus.core.scanner
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScanResultsListenerTest {
+    @Test
+    fun `listener receives results via lambda`() {
+        val received = mutableListOf<List<WifiScanResult>>()
+        val listener = ScanResultsListener { results -> received.add(results) }
+
+        val testResults =
+            listOf(
+                WifiScanResult(
+                    ssid = "Net1",
+                    bssid = "AA:BB:CC:DD:EE:01",
+                    signalLevel = -50,
+                    frequencyMhz = 2412,
+                    capabilities = "[WPA2-PSK]",
+                    timestamp = 100L,
+                    channelWidth = 0,
+                    centerFreq0 = 2412,
+                    centerFreq1 = 0,
+                ),
+            )
+
+        listener.onResults(testResults)
+        assertEquals(1, received.size)
+        assertEquals("Net1", received[0][0].ssid)
+    }
+
+    @Test
+    fun `empty results list does not throw`() {
+        val listener = ScanResultsListener { _ -> }
+        listener.onResults(emptyList())
+    }
+
+    @Test
+    fun `listener called multiple times accumulates calls`() {
+        var callCount = 0
+        val listener = ScanResultsListener { _ -> callCount++ }
+
+        listener.onResults(emptyList())
+        listener.onResults(emptyList())
+        listener.onResults(emptyList())
+
+        assertEquals(3, callCount)
+    }
+
+    @Test
+    fun `no-op listener compiles and runs`() {
+        val listener = ScanResultsListener { }
+        listener.onResults(emptyList())
+        assertTrue(true)
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/scanner/WifiScanResultTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/scanner/WifiScanResultTest.kt
@@ -1,0 +1,64 @@
+package com.wscanplus.core.scanner
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class WifiScanResultTest {
+    private val result =
+        WifiScanResult(
+            ssid = "TestNetwork",
+            bssid = "AA:BB:CC:DD:EE:FF",
+            signalLevel = -65,
+            frequencyMhz = 5180,
+            capabilities = "[WPA2-PSK-CCMP][ESS]",
+            timestamp = 1234567890L,
+            channelWidth = 1,
+            centerFreq0 = 5190,
+            centerFreq1 = 0,
+        )
+
+    @Test
+    fun `data class equality works on matching fields`() {
+        val copy = result.copy()
+        assertEquals(result, copy)
+        assertEquals(result.hashCode(), copy.hashCode())
+    }
+
+    @Test
+    fun `data class inequality on different BSSID`() {
+        val different = result.copy(bssid = "11:22:33:44:55:66")
+        assertNotEquals(result, different)
+    }
+
+    @Test
+    fun `fields are accessible and match constructor values`() {
+        assertEquals("TestNetwork", result.ssid)
+        assertEquals("AA:BB:CC:DD:EE:FF", result.bssid)
+        assertEquals(-65, result.signalLevel)
+        assertEquals(5180, result.frequencyMhz)
+        assertEquals("[WPA2-PSK-CCMP][ESS]", result.capabilities)
+        assertEquals(1234567890L, result.timestamp)
+        assertEquals(1, result.channelWidth)
+        assertEquals(5190, result.centerFreq0)
+        assertEquals(0, result.centerFreq1)
+    }
+
+    @Test
+    fun `empty SSID is valid (hidden network)`() {
+        val hidden = result.copy(ssid = "")
+        assertEquals("", hidden.ssid)
+    }
+
+    @Test
+    fun `negative signal level represents weak signal`() {
+        val weak = result.copy(signalLevel = -90)
+        assertEquals(-90, weak.signalLevel)
+    }
+
+    @Test
+    fun `2_4GHz frequency range`() {
+        val result24 = result.copy(frequencyMhz = 2437)
+        assertEquals(2437, result24.frequencyMhz)
+    }
+}


### PR DESCRIPTION
## Summary

- Add first real unit tests for the project
- WifiScanResult: equality, inequality, field access, hidden network, signal level, frequency ranges (6 tests)
- ScanResultsListener: lambda invocation, empty results, call counting, no-op listener (4 tests)
- Pure JVM tests — no Android framework needed
- CI already runs `./gradlew :core:test`

Closes #93

## Checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#93)
- [ ] CI is green
- [x] One feature (unit tests)
- [x] < 200 LOC changed — 121 insertions
- [x] No new dependencies
- [x] Meaningful tests included
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)