### PR TITLE
feat(p2): threat data models (#95)

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/ScanContext.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/ScanContext.kt
@@ -1,0 +1,32 @@
+package com.wscanplus.core.threat
+
+data class BssidProfile(
+    val bssid: String,
+    val firstSeenAt: Long,
+    val lastSeenAt: Long,
+    val ssids: Set<String>,
+    val capabilitiesHistory: List<String>,
+    val observationCount: Int,
+    val ouiVendor: String?,
+)
+
+enum class EnvironmentType { RESIDENTIAL, OFFICE, PUBLIC }
+
+data class ScanInput(
+    val bssid: String,
+    val ssid: String,
+    val isHidden: Boolean,
+    val capabilities: String,
+    val rssiDbm: Int,
+    val frequencyMhz: Int,
+    val channelWidth: Int,
+    val timestamp: Long,
+)
+
+data class ScanContext(
+    val currentResults: List<ScanInput>,
+    val knownProfiles: Map<String, BssidProfile>,
+    val baselineNetworkCount: Int?,
+    val baselineStdDev: Double?,
+    val environmentType: EnvironmentType,
+)

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/SecurityType.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/SecurityType.kt
@@ -1,0 +1,12 @@
+package com.wscanplus.core.threat
+
+enum class SecurityType(
+    val rank: Int,
+) {
+    WPA3(4),
+    OWE(3),
+    WPA2(3),
+    WPA(2),
+    WEP(1),
+    OPEN(0),
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/ThreatSignal.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/ThreatSignal.kt
@@ -1,0 +1,32 @@
+package com.wscanplus.core.threat
+
+enum class ThreatSource { LOCAL_HEURISTIC, CROWDSEC_CTI, GEMINI }
+
+enum class HeuristicType {
+    WEP_OPEN,
+    EVIL_TWIN,
+    ENCRYPTION_DOWNGRADE,
+    KARMA_ATTACK,
+    SSID_FLOODING,
+    RSSI_ANOMALY,
+    BSSID_FINGERPRINT,
+}
+
+data class ThreatSignal(
+    val confidence: Float,
+    val source: ThreatSource,
+    val reasons: List<String>,
+    val heuristicType: HeuristicType?,
+    val bssid: String,
+    val detectedAt: Long = System.currentTimeMillis(),
+    val schemaVersion: Int = 1,
+) {
+    init {
+        require(confidence in 0.0f..0.95f) {
+            "Confidence must be 0.0\u20130.95, was $confidence"
+        }
+        require(reasons.size <= 3) {
+            "Maximum 3 reasons, was ${reasons.size}"
+        }
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/ThreatSignalTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/ThreatSignalTest.kt
@@ -1,0 +1,86 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ThreatSignalTest {
+    private val signal =
+        ThreatSignal(
+            confidence = 0.75f,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf("WEP detected"),
+            heuristicType = HeuristicType.WEP_OPEN,
+            bssid = "AA:BB:CC:DD:EE:FF",
+            detectedAt = 1000L,
+        )
+
+    @Test
+    fun `confidence at lower bound passes`() {
+        val low = signal.copy(confidence = 0.0f)
+        assertEquals(0.0f, low.confidence, 0.001f)
+    }
+
+    @Test
+    fun `confidence at upper bound passes`() {
+        val high = signal.copy(confidence = 0.95f)
+        assertEquals(0.95f, high.confidence, 0.001f)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `confidence above 0_95 throws`() {
+        signal.copy(confidence = 0.96f)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `confidence below 0_0 throws`() {
+        signal.copy(confidence = -0.01f)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `more than 3 reasons throws`() {
+        signal.copy(reasons = listOf("a", "b", "c", "d"))
+    }
+
+    @Test
+    fun `schemaVersion defaults to 1`() {
+        val defaultSchema =
+            ThreatSignal(
+                confidence = 0.5f,
+                source = ThreatSource.LOCAL_HEURISTIC,
+                reasons = listOf("test"),
+                heuristicType = null,
+                bssid = "00:11:22:33:44:55",
+            )
+        assertEquals(1, defaultSchema.schemaVersion)
+    }
+
+    @Test
+    fun `heuristicType nullable for CTI signals`() {
+        val cti = signal.copy(source = ThreatSource.CROWDSEC_CTI, heuristicType = null)
+        assertNull(cti.heuristicType)
+    }
+
+    @Test
+    fun `heuristicType nullable for Gemini signals`() {
+        val gemini = signal.copy(source = ThreatSource.GEMINI, heuristicType = null)
+        assertNull(gemini.heuristicType)
+    }
+
+    @Test
+    fun `data class equality on matching fields`() {
+        val copy = signal.copy()
+        assertEquals(signal, copy)
+        assertEquals(signal.hashCode(), copy.hashCode())
+    }
+
+    @Test
+    fun `SecurityType rank values are correct`() {
+        assertEquals(4, SecurityType.WPA3.rank)
+        assertEquals(3, SecurityType.OWE.rank)
+        assertEquals(3, SecurityType.WPA2.rank)
+        assertEquals(2, SecurityType.WPA.rank)
+        assertEquals(1, SecurityType.WEP.rank)
+        assertEquals(0, SecurityType.OPEN.rank)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 Task 1: Pure Kotlin data models for the threat detection engine in the `:core` module.

- **ThreatSignal** — core signal type with confidence (0.0–0.95), source enum (LOCAL_HEURISTIC, CROWDSEC_CTI, GEMINI), heuristic type, reasons (max 3), and schema version
- **SecurityType** — ranked enum for WiFi security types (WPA3 > OWE/WPA2 > WPA > WEP > OPEN)
- **ScanContext** — input types for the heuristic engine: ScanInput, BssidProfile, ScanContext, EnvironmentType

All collections are immutable (List, Set, Map). Validation enforced via `init` blocks.

## Agent

Made by **Claude** (primary coding agent).

## References

Closes #95

## Checklist

- [x] Branch follows naming convention (`claude/p2-threat-data-models`)
- [x] Commit message follows format (`feat(p2): ...`)
- [x] References exactly one GitHub Issue (#95)
- [x] Unit tests included (10 tests in ThreatSignalTest)
- [x] `./gradlew :core:test` passes
- [x] `./gradlew :core:ktlintCheck` passes (zero violations)
- [x] No secrets committed
- [x] All collections immutable (List, Set, Map — no Mutable variants)
- [x] < 200 lines changed (tests excluded)

## Test Plan

- [x] Confidence boundary validation (0.0 and 0.95 pass; -0.01 and 0.96 throw)
- [x] Reasons count validation (>3 throws)
- [x] Schema version defaults to 1
- [x] Nullable heuristicType for CTI/Gemini signals
- [x] Data class equality
- [x] SecurityType rank values correct