### PR TITLE
feat(p2): SecurityType parser + WEP/Open heuristic

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/Heuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/Heuristic.kt
@@ -1,0 +1,10 @@
+package com.wscanplus.core.threat
+
+interface Heuristic {
+    val type: HeuristicType
+
+    fun evaluate(
+        input: ScanInput,
+        context: ScanContext,
+    ): ThreatSignal?
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/SecurityType.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/SecurityType.kt
@@ -9,4 +9,19 @@ enum class SecurityType(
     WPA(2),
     WEP(1),
     OPEN(0),
+    ;
+
+    companion object {
+        fun parse(capabilities: String): SecurityType {
+            val caps = capabilities.uppercase()
+            return when {
+                caps.contains("SAE") -> WPA3
+                caps.contains("OWE") -> OWE
+                caps.contains("RSN") || caps.contains("WPA2") -> WPA2
+                caps.contains("WPA") -> WPA
+                caps.contains("WEP") -> WEP
+                else -> OPEN
+            }
+        }
+    }
 }

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/WepOpenHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/WepOpenHeuristic.kt
@@ -1,0 +1,34 @@
+package com.wscanplus.core.threat
+
+class WepOpenHeuristic : Heuristic {
+    override val type: HeuristicType = HeuristicType.WEP_OPEN
+
+    override fun evaluate(
+        input: ScanInput,
+        context: ScanContext,
+    ): ThreatSignal? {
+        val security: SecurityType = SecurityType.parse(input.capabilities)
+        val confidence: Float =
+            when (security) {
+                SecurityType.OPEN -> 0.4f
+                SecurityType.WEP -> 0.6f
+                SecurityType.WPA -> 0.2f
+                SecurityType.WPA2, SecurityType.OWE, SecurityType.WPA3 -> return null
+            }
+        return ThreatSignal(
+            confidence = confidence,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf(reasonFor(security)),
+            heuristicType = type,
+            bssid = input.bssid,
+        )
+    }
+
+    private fun reasonFor(security: SecurityType): String =
+        when (security) {
+            SecurityType.OPEN -> "Open network — no encryption"
+            SecurityType.WEP -> "WEP encryption — trivially crackable"
+            SecurityType.WPA -> "WPA (original) — deprecated, known vulnerabilities"
+            else -> ""
+        }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/SecurityTypeTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/SecurityTypeTest.kt
@@ -1,0 +1,61 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SecurityTypeTest {
+    @Test
+    fun `parse WPA2 capabilities`() {
+        val result: SecurityType = SecurityType.parse("[WPA2-PSK-CCMP][RSN-PSK-CCMP][ESS]")
+        assertEquals(SecurityType.WPA2, result)
+    }
+
+    @Test
+    fun `parse WPA3 SAE takes precedence`() {
+        val result: SecurityType =
+            SecurityType.parse("[WPA3-SAE+SAE-EXT-KEY][RSN-SAE+SAE-EXT-KEY-CCMP]")
+        assertEquals(SecurityType.WPA3, result)
+    }
+
+    @Test
+    fun `parse OWE Enhanced Open`() {
+        val result: SecurityType = SecurityType.parse("[RSN-OWE-CCMP]")
+        assertEquals(SecurityType.OWE, result)
+    }
+
+    @Test
+    fun `parse WPA original`() {
+        val result: SecurityType = SecurityType.parse("[WPA-PSK-TKIP]")
+        assertEquals(SecurityType.WPA, result)
+    }
+
+    @Test
+    fun `parse WEP`() {
+        val result: SecurityType = SecurityType.parse("[WEP]")
+        assertEquals(SecurityType.WEP, result)
+    }
+
+    @Test
+    fun `parse empty string returns OPEN`() {
+        val result: SecurityType = SecurityType.parse("")
+        assertEquals(SecurityType.OPEN, result)
+    }
+
+    @Test
+    fun `parse ESS only returns OPEN`() {
+        val result: SecurityType = SecurityType.parse("[ESS]")
+        assertEquals(SecurityType.OPEN, result)
+    }
+
+    @Test
+    fun `parse case insensitive`() {
+        val result: SecurityType = SecurityType.parse("[wpa2-psk-ccmp]")
+        assertEquals(SecurityType.WPA2, result)
+    }
+
+    @Test
+    fun `parse SAE wins over WPA in mixed string`() {
+        val result: SecurityType = SecurityType.parse("[WPA-PSK][SAE]")
+        assertEquals(SecurityType.WPA3, result)
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/WepOpenHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/WepOpenHeuristicTest.kt
@@ -1,0 +1,102 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WepOpenHeuristicTest {
+    private val heuristic = WepOpenHeuristic()
+
+    private fun scanInput(
+        capabilities: String,
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+    ): ScanInput =
+        ScanInput(
+            bssid = bssid,
+            ssid = "TestNetwork",
+            isHidden = false,
+            capabilities = capabilities,
+            rssiDbm = -50,
+            frequencyMhz = 2412,
+            channelWidth = 20,
+            timestamp = System.currentTimeMillis(),
+        )
+
+    private val emptyContext =
+        ScanContext(
+            currentResults = emptyList(),
+            knownProfiles = emptyMap(),
+            baselineNetworkCount = null,
+            baselineStdDev = null,
+            environmentType = EnvironmentType.RESIDENTIAL,
+        )
+
+    @Test
+    fun `open network returns confidence 0_4`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[ESS]"), emptyContext)
+        assertNotNull(signal)
+        assertEquals(0.4f, signal!!.confidence)
+        assertTrue(signal.reasons[0].contains("no encryption"))
+    }
+
+    @Test
+    fun `wep network returns confidence 0_6`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[WEP]"), emptyContext)
+        assertNotNull(signal)
+        assertEquals(0.6f, signal!!.confidence)
+        assertTrue(signal.reasons[0].contains("crackable"))
+    }
+
+    @Test
+    fun `wpa network returns confidence 0_2`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[WPA-PSK-TKIP]"), emptyContext)
+        assertNotNull(signal)
+        assertEquals(0.2f, signal!!.confidence)
+        assertTrue(signal.reasons[0].contains("deprecated"))
+    }
+
+    @Test
+    fun `wpa2 network returns null`() {
+        val signal: ThreatSignal? =
+            heuristic.evaluate(scanInput("[WPA2-PSK-CCMP][RSN-PSK-CCMP]"), emptyContext)
+        assertNull(signal)
+    }
+
+    @Test
+    fun `wpa3 network returns null`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[SAE][RSN-SAE-CCMP]"), emptyContext)
+        assertNull(signal)
+    }
+
+    @Test
+    fun `owe enhanced open returns null`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[RSN-OWE-CCMP]"), emptyContext)
+        assertNull(signal)
+    }
+
+    @Test
+    fun `signals have correct source and heuristic type`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[ESS]"), emptyContext)
+        assertNotNull(signal)
+        assertEquals(ThreatSource.LOCAL_HEURISTIC, signal!!.source)
+        assertEquals(HeuristicType.WEP_OPEN, signal.heuristicType)
+    }
+
+    @Test
+    fun `signals have exactly one reason`() {
+        val signal: ThreatSignal? = heuristic.evaluate(scanInput("[WEP]"), emptyContext)
+        assertNotNull(signal)
+        assertEquals(1, signal!!.reasons.size)
+    }
+
+    @Test
+    fun `signal contains correct bssid`() {
+        val bssid = "11:22:33:44:55:66"
+        val signal: ThreatSignal? =
+            heuristic.evaluate(scanInput("[ESS]", bssid = bssid), emptyContext)
+        assertNotNull(signal)
+        assertEquals(bssid, signal!!.bssid)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #97

- Add `SecurityType.parse(capabilities)` companion function to parse Android WiFi capability strings into security type enums (priority: SAE > OWE > RSN/WPA2 > WPA > WEP > OPEN)
- Add `Heuristic` interface defining the contract for all threat heuristics
- Add `WepOpenHeuristic` — first concrete heuristic implementation, flags OPEN (0.4), WEP (0.6), and WPA (0.2) networks; returns null for WPA2/WPA3/OWE (not threats)

## Agent

Claude (primary coding agent)

## What changed and why

Phase 2 Task 2: local threat intelligence pipeline needs a capabilities parser and the first heuristic. `SecurityType.parse()` converts raw Android `ScanResult.capabilities` strings into the existing `SecurityType` enum. `WepOpenHeuristic` uses that parser to produce `ThreatSignal` for weak/open networks. OWE (Enhanced Open) correctly returns null — it is encrypted.

## Rules guiding decisions

- AGENTS.md Section 2: small atomic PR, one feature
- AGENTS.md Section 4: meaningful tests included (18 test cases)
- CLAUDE.md: no implicit types in Kotlin lambdas
- CLAUDE.md: OWE is NOT a threat

## Test plan

- [x] `./gradlew :core:test -q` — all 18 new tests pass (9 SecurityTypeTest + 9 WepOpenHeuristicTest)
- [x] `./gradlew :core:ktlintCheck -q` — zero violations
- [ ] CI checks pass on remote

## Checklist

- [x] Branch follows naming convention (`claude/p2-wep-open-heuristic`)
- [x] References exactly one issue (#97)
- [x] Tests included with meaningful assertions
- [x] No secrets committed
- [x] ktlint passes with zero violations
- [x] < 200 lines changed (excluding tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)