### PR TITLE
feat(p2): Evil Twin + Encryption Downgrade heuristics (#99)

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/EncryptionDowngradeHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/EncryptionDowngradeHeuristic.kt
@@ -1,0 +1,47 @@
+package com.wscanplus.core.threat
+
+class EncryptionDowngradeHeuristic : Heuristic {
+    override val type: HeuristicType = HeuristicType.ENCRYPTION_DOWNGRADE
+
+    override fun evaluate(
+        input: ScanInput,
+        context: ScanContext,
+    ): ThreatSignal? {
+        val profile: BssidProfile = context.knownProfiles[input.bssid] ?: return null
+        if (profile.observationCount < 3) return null
+
+        val twoDaysMs: Long = 2L * 86_400_000L
+        if (profile.lastSeenAt - profile.firstSeenAt < twoDaysMs) return null
+
+        val currentSecurity: SecurityType = SecurityType.parse(input.capabilities)
+        val historicalMax: SecurityType =
+            profile.capabilitiesHistory
+                .map { caps: String -> SecurityType.parse(caps) }
+                .maxByOrNull { sec: SecurityType -> sec.rank }
+                ?: return null
+
+        if (currentSecurity.rank >= historicalMax.rank) return null
+
+        val confidence: Float = downgradeConfidence(historicalMax.rank, currentSecurity.rank)
+        val reason: String = "Security downgrade: $historicalMax \u2192 $currentSecurity"
+
+        return ThreatSignal(
+            confidence = confidence,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf(reason),
+            heuristicType = type,
+            bssid = input.bssid,
+        )
+    }
+
+    private fun downgradeConfidence(
+        historicalRank: Int,
+        currentRank: Int,
+    ): Float =
+        when {
+            historicalRank >= 3 && currentRank == 0 -> 0.85f
+            historicalRank >= 3 && currentRank == 1 -> 0.75f
+            historicalRank == 2 && currentRank == 0 -> 0.5f
+            else -> 0.3f
+        }
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/EvilTwinHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/EvilTwinHeuristic.kt
@@ -1,0 +1,136 @@
+package com.wscanplus.core.threat
+
+class EvilTwinHeuristic(
+    private val vendorLookup: ((String) -> String?)? = null,
+) : Heuristic {
+    override val type: HeuristicType = HeuristicType.EVIL_TWIN
+
+    override fun evaluate(
+        input: ScanInput,
+        context: ScanContext,
+    ): ThreatSignal? {
+        val peers: List<ScanInput> =
+            context.currentResults.filter { other: ScanInput ->
+                other.ssid == input.ssid && other.bssid != input.bssid
+            }
+        if (peers.isEmpty()) return null
+
+        var best: ThreatSignal? = null
+        for (peer: ScanInput in peers) {
+            val signal: ThreatSignal? = evaluatePair(input, peer, context)
+            if (signal != null && (best == null || signal.confidence > best.confidence)) {
+                best = signal
+            }
+        }
+        return best
+    }
+
+    private fun evaluatePair(
+        input: ScanInput,
+        peer: ScanInput,
+        context: ScanContext,
+    ): ThreatSignal? {
+        if (shareHardwarePrefix(input.bssid, peer.bssid)) return null
+
+        val scores: MutableList<Float> = mutableListOf()
+        val reasons: MutableList<String> = mutableListOf()
+
+        val ouiScore: Float = ouiMismatchScore(input.bssid, peer.bssid)
+        if (ouiScore > 0f) {
+            scores.add(ouiScore)
+            reasons.add("OUI vendor mismatch")
+        }
+
+        val capScore: Float = capabilityMismatchScore(input.capabilities, peer.capabilities)
+        if (capScore > 0f) {
+            scores.add(capScore)
+            reasons.add("Security capability mismatch")
+        }
+
+        val chanScore: Float = sameChannelScore(input.frequencyMhz, peer.frequencyMhz)
+        if (chanScore > 0f) {
+            scores.add(chanScore)
+            reasons.add("Same channel")
+        }
+
+        val newBssidScore: Float = newBssidScore(input, peer, context)
+        if (newBssidScore > 0f) {
+            scores.add(newBssidScore)
+            reasons.add("New BSSID for established SSID")
+        }
+
+        val rssiScore: Float = rssiAnomalyScore(input.rssiDbm, peer.rssiDbm)
+        if (rssiScore > 0f) {
+            scores.add(rssiScore)
+            reasons.add("RSSI anomaly between twin APs")
+        }
+
+        if (scores.isEmpty()) return null
+
+        val confidence: Float = combinedConfidence(scores)
+        return ThreatSignal(
+            confidence = confidence,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = reasons.take(3),
+            heuristicType = type,
+            bssid = input.bssid,
+        )
+    }
+
+    private fun shareHardwarePrefix(
+        a: String,
+        b: String,
+    ): Boolean = a.length >= 14 && b.length >= 14 && a.substring(0, 14) == b.substring(0, 14)
+
+    private fun ouiMismatchScore(
+        bssidA: String,
+        bssidB: String,
+    ): Float {
+        val lookup: ((String) -> String?) = vendorLookup ?: return 0f
+        val ouiA: String = bssidA.take(8)
+        val ouiB: String = bssidB.take(8)
+        val vendorA: String = lookup(ouiA) ?: return 0f
+        val vendorB: String = lookup(ouiB) ?: return 0f
+        return if (vendorA != vendorB) 0.3f else 0f
+    }
+
+    private fun capabilityMismatchScore(
+        capsA: String,
+        capsB: String,
+    ): Float {
+        val secA: SecurityType = SecurityType.parse(capsA)
+        val secB: SecurityType = SecurityType.parse(capsB)
+        return if (secA != secB) 0.35f else 0f
+    }
+
+    private fun sameChannelScore(
+        freqA: Int,
+        freqB: Int,
+    ): Float = if (freqA == freqB) 0.1f else 0f
+
+    private fun newBssidScore(
+        input: ScanInput,
+        peer: ScanInput,
+        context: ScanContext,
+    ): Float {
+        val inputKnown: Boolean = context.knownProfiles.containsKey(input.bssid)
+        val peerKnown: Boolean = context.knownProfiles.containsKey(peer.bssid)
+        return if (!inputKnown && peerKnown) 0.2f else 0f
+    }
+
+    private fun rssiAnomalyScore(
+        rssiA: Int,
+        rssiB: Int,
+    ): Float {
+        val diff: Int = kotlin.math.abs(rssiA - rssiB)
+        return if (diff > 20) 0.15f else 0f
+    }
+
+    private fun combinedConfidence(scores: List<Float>): Float {
+        var product = 1.0f
+        for (s: Float in scores) {
+            product *= (1f - s)
+        }
+        return (1f - product).coerceAtMost(0.95f)
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/EncryptionDowngradeHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/EncryptionDowngradeHeuristicTest.kt
@@ -1,0 +1,151 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EncryptionDowngradeHeuristicTest {
+    private val heuristic = EncryptionDowngradeHeuristic()
+
+    private fun scan(
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+        capabilities: String = "[ESS]",
+    ): ScanInput =
+        ScanInput(
+            bssid = bssid,
+            ssid = "TestNet",
+            isHidden = false,
+            capabilities = capabilities,
+            rssiDbm = -50,
+            frequencyMhz = 2412,
+            channelWidth = 20,
+            timestamp = System.currentTimeMillis(),
+        )
+
+    private fun profile(
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+        capabilitiesHistory: List<String> = listOf("[WPA2-PSK-CCMP]"),
+        observationCount: Int = 10,
+        daySpan: Int = 5,
+    ): BssidProfile {
+        val now: Long = System.currentTimeMillis()
+        return BssidProfile(
+            bssid = bssid,
+            firstSeenAt = now - daySpan.toLong() * 86_400_000L,
+            lastSeenAt = now,
+            ssids = setOf("TestNet"),
+            capabilitiesHistory = capabilitiesHistory,
+            observationCount = observationCount,
+            ouiVendor = null,
+        )
+    }
+
+    private fun context(
+        results: List<ScanInput> = emptyList(),
+        profiles: Map<String, BssidProfile> = emptyMap(),
+    ): ScanContext =
+        ScanContext(
+            currentResults = results,
+            knownProfiles = profiles,
+            baselineNetworkCount = null,
+            baselineStdDev = null,
+            environmentType = EnvironmentType.RESIDENTIAL,
+        )
+
+    @Test
+    fun `wpa2 to open returns 0_85`() {
+        val input: ScanInput = scan(capabilities = "[ESS]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNotNull(signal)
+        assertEquals(0.85f, signal!!.confidence, 0.001f)
+    }
+
+    @Test
+    fun `wpa3 to wep returns 0_75`() {
+        val input: ScanInput = scan(capabilities = "[WEP]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[RSN-SAE-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNotNull(signal)
+        assertEquals(0.75f, signal!!.confidence, 0.001f)
+    }
+
+    @Test
+    fun `wpa to open returns 0_5`() {
+        val input: ScanInput = scan(capabilities = "[ESS]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA-PSK-TKIP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNotNull(signal)
+        assertEquals(0.5f, signal!!.confidence, 0.001f)
+    }
+
+    @Test
+    fun `wpa2 to wpa returns 0_3`() {
+        val input: ScanInput = scan(capabilities = "[WPA-PSK-TKIP]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNotNull(signal)
+        assertEquals(0.3f, signal!!.confidence, 0.001f)
+    }
+
+    @Test
+    fun `owe to wpa2 same rank returns null`() {
+        val input: ScanInput = scan(capabilities = "[WPA2-PSK-CCMP]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[RSN-OWE-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNull(signal)
+    }
+
+    @Test
+    fun `wpa2 to wpa3 upgrade returns null`() {
+        val input: ScanInput = scan(capabilities = "[RSN-SAE-CCMP]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNull(signal)
+    }
+
+    @Test
+    fun `no profile in context returns null`() {
+        val input: ScanInput = scan()
+        assertNull(heuristic.evaluate(input, context()))
+    }
+
+    @Test
+    fun `profile with less than 3 observations returns null`() {
+        val input: ScanInput = scan(capabilities = "[ESS]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"), observationCount = 2)
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNull(signal)
+    }
+
+    @Test
+    fun `profile spanning less than 2 days returns null`() {
+        val input: ScanInput = scan(capabilities = "[ESS]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"), daySpan = 1)
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNull(signal)
+    }
+
+    @Test
+    fun `reason contains downgrade description`() {
+        val input: ScanInput = scan(capabilities = "[ESS]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNotNull(signal)
+        assertTrue(signal!!.reasons[0].contains("downgrade"))
+        assertTrue(signal.reasons[0].contains("WPA2"))
+        assertTrue(signal.reasons[0].contains("OPEN"))
+    }
+
+    @Test
+    fun `signal has correct source and type`() {
+        val input: ScanInput = scan(capabilities = "[ESS]")
+        val p: BssidProfile = profile(capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"))
+        val signal: ThreatSignal? = heuristic.evaluate(input, context(profiles = mapOf(input.bssid to p)))
+        assertNotNull(signal)
+        assertEquals(ThreatSource.LOCAL_HEURISTIC, signal!!.source)
+        assertEquals(HeuristicType.ENCRYPTION_DOWNGRADE, signal.heuristicType)
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/EvilTwinHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/EvilTwinHeuristicTest.kt
@@ -1,0 +1,182 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EvilTwinHeuristicTest {
+    private val heuristic = EvilTwinHeuristic()
+
+    private fun scan(
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+        ssid: String = "TestNet",
+        capabilities: String = "[WPA2-PSK-CCMP][RSN-PSK-CCMP]",
+        rssiDbm: Int = -50,
+        frequencyMhz: Int = 2412,
+    ): ScanInput =
+        ScanInput(
+            bssid = bssid,
+            ssid = ssid,
+            isHidden = false,
+            capabilities = capabilities,
+            rssiDbm = rssiDbm,
+            frequencyMhz = frequencyMhz,
+            channelWidth = 20,
+            timestamp = System.currentTimeMillis(),
+        )
+
+    private fun context(
+        results: List<ScanInput> = emptyList(),
+        profiles: Map<String, BssidProfile> = emptyMap(),
+    ): ScanContext =
+        ScanContext(
+            currentResults = results,
+            knownProfiles = profiles,
+            baselineNetworkCount = null,
+            baselineStdDev = null,
+            environmentType = EnvironmentType.RESIDENTIAL,
+        )
+
+    private fun testProfile(bssid: String = "11:22:33:44:55:66"): BssidProfile =
+        BssidProfile(
+            bssid = bssid,
+            firstSeenAt = 0L,
+            lastSeenAt = 1L,
+            ssids = setOf("TestNet"),
+            capabilitiesHistory = listOf("[WPA2-PSK-CCMP]"),
+            observationCount = 10,
+            ouiVendor = "VendorB",
+        )
+
+    @Test
+    fun `single network with no duplicate SSID returns null`() {
+        val input: ScanInput = scan()
+        val ctx: ScanContext = context(results = listOf(input))
+        assertNull(heuristic.evaluate(input, ctx))
+    }
+
+    @Test
+    fun `guest network with shared first 5 octets returns null`() {
+        val input: ScanInput = scan(bssid = "AA:BB:CC:DD:EE:01")
+        val peer: ScanInput = scan(bssid = "AA:BB:CC:DD:EE:02", capabilities = "[ESS]")
+        val ctx: ScanContext = context(results = listOf(input, peer))
+        assertNull(heuristic.evaluate(input, ctx))
+    }
+
+    @Test
+    fun `capability mismatch alone fires with confidence 0_35`() {
+        val input: ScanInput =
+            scan(bssid = "AA:BB:CC:DD:EE:FF", capabilities = "[WPA2-PSK-CCMP]", frequencyMhz = 2412)
+        val peer: ScanInput =
+            scan(bssid = "11:22:33:44:55:66", capabilities = "[ESS]", frequencyMhz = 5180)
+        val ctx: ScanContext = context(results = listOf(input, peer))
+        val signal: ThreatSignal? = heuristic.evaluate(input, ctx)
+        assertNotNull(signal)
+        assertEquals(0.35f, signal!!.confidence, 0.001f)
+    }
+
+    @Test
+    fun `oui plus capability mismatch combines to about 0_545`() {
+        val lookup: (String) -> String? = { prefix: String ->
+            when (prefix) {
+                "AA:BB:CC" -> "VendorA"
+                "11:22:33" -> "VendorB"
+                else -> null
+            }
+        }
+        val h = EvilTwinHeuristic(vendorLookup = lookup)
+        val input: ScanInput =
+            scan(bssid = "AA:BB:CC:DD:EE:FF", capabilities = "[WPA2-PSK-CCMP]", frequencyMhz = 2412)
+        val peer: ScanInput =
+            scan(bssid = "11:22:33:44:55:66", capabilities = "[ESS]", frequencyMhz = 5180)
+        val ctx: ScanContext = context(results = listOf(input, peer))
+        val signal: ThreatSignal? = h.evaluate(input, ctx)
+        assertNotNull(signal)
+        val expected: Float = 1f - (1f - 0.3f) * (1f - 0.35f)
+        assertEquals(expected, signal!!.confidence, 0.001f)
+    }
+
+    @Test
+    fun `null vendorLookup skips OUI sub-signal`() {
+        val input: ScanInput = scan(bssid = "AA:BB:CC:DD:EE:FF", capabilities = "[WPA2-PSK-CCMP]")
+        val peer: ScanInput =
+            scan(bssid = "11:22:33:44:55:66", capabilities = "[WPA2-PSK-CCMP]", frequencyMhz = 5180)
+        val ctx: ScanContext = context(results = listOf(input, peer))
+        val signal: ThreatSignal? = heuristic.evaluate(input, ctx)
+        assertNull(signal)
+    }
+
+    @Test
+    fun `enterprise multi-AP same OUI still evaluates sub-signals`() {
+        val input: ScanInput =
+            scan(bssid = "AA:BB:CC:11:11:11", capabilities = "[WPA2-PSK-CCMP]", rssiDbm = -30)
+        val peer: ScanInput =
+            scan(bssid = "AA:BB:CC:22:22:22", capabilities = "[ESS]", rssiDbm = -60)
+        val ctx: ScanContext = context(results = listOf(input, peer))
+        val signal: ThreatSignal? = heuristic.evaluate(input, ctx)
+        assertNotNull(signal)
+        assertTrue(signal!!.confidence > 0f)
+    }
+
+    @Test
+    fun `confidence capped at 0_95`() {
+        val lookup: (String) -> String? = { prefix: String ->
+            when (prefix) {
+                "AA:BB:CC" -> "VendorA"
+                "11:22:33" -> "VendorB"
+                else -> null
+            }
+        }
+        val h = EvilTwinHeuristic(vendorLookup = lookup)
+        val profile: BssidProfile = testProfile()
+        val input: ScanInput =
+            scan(bssid = "AA:BB:CC:DD:EE:FF", capabilities = "[ESS]", rssiDbm = -20)
+        val peer: ScanInput =
+            scan(bssid = "11:22:33:44:55:66", capabilities = "[WPA2-PSK-CCMP]", rssiDbm = -70)
+        val ctx: ScanContext =
+            context(
+                results = listOf(input, peer),
+                profiles = mapOf("11:22:33:44:55:66" to profile),
+            )
+        val signal: ThreatSignal? = h.evaluate(input, ctx)
+        assertNotNull(signal)
+        assertTrue(signal!!.confidence <= 0.95f)
+    }
+
+    @Test
+    fun `reasons list has max 3 entries`() {
+        val lookup: (String) -> String? = { prefix: String ->
+            when (prefix) {
+                "AA:BB:CC" -> "VendorA"
+                "11:22:33" -> "VendorB"
+                else -> null
+            }
+        }
+        val h = EvilTwinHeuristic(vendorLookup = lookup)
+        val profile: BssidProfile = testProfile()
+        val input: ScanInput =
+            scan(bssid = "AA:BB:CC:DD:EE:FF", capabilities = "[ESS]", rssiDbm = -20)
+        val peer: ScanInput =
+            scan(bssid = "11:22:33:44:55:66", capabilities = "[WPA2-PSK-CCMP]", rssiDbm = -70)
+        val ctx: ScanContext =
+            context(
+                results = listOf(input, peer),
+                profiles = mapOf("11:22:33:44:55:66" to profile),
+            )
+        val signal: ThreatSignal? = h.evaluate(input, ctx)
+        assertNotNull(signal)
+        assertTrue(signal!!.reasons.size <= 3)
+    }
+
+    @Test
+    fun `reasons contain descriptive text`() {
+        val input: ScanInput = scan(bssid = "AA:BB:CC:DD:EE:FF", capabilities = "[WPA2-PSK-CCMP]")
+        val peer: ScanInput = scan(bssid = "11:22:33:44:55:66", capabilities = "[ESS]")
+        val ctx: ScanContext = context(results = listOf(input, peer))
+        val signal: ThreatSignal? = heuristic.evaluate(input, ctx)
+        assertNotNull(signal)
+        assertTrue(signal!!.reasons.any { reason: String -> reason.contains("capability") })
+    }
+}


### PR DESCRIPTION
## Summary

- Add `EvilTwinHeuristic` with 5 sub-signals (OUI vendor mismatch, security capability mismatch, same channel, new BSSID for established SSID, RSSI anomaly) using probabilistic confidence combination capped at 0.95
- Add `EncryptionDowngradeHeuristic` detecting security downgrades against historical BssidProfile with tiered confidence (0.85/0.75/0.5/0.3) requiring 3+ observations over 2+ days
- Guest network filter: APs sharing first 5 BSSID octets are not flagged as evil twins
- Vendor lookup uses nullable `(String) -> String?` lambda — no OuiLookup dependency until OUI PR merges

## Test plan

- [x] `EvilTwinHeuristicTest` — 9 tests covering: single network null, guest network filter, capability mismatch alone, OUI + capability combination, null vendorLookup, enterprise multi-AP, confidence cap, reasons limit, reasons content
- [x] `EncryptionDowngradeHeuristicTest` — 10 tests covering: WPA2→Open, WPA3→WEP, WPA→Open, WPA2→WPA, OWE↔WPA2 same-rank null, upgrade null, no profile null, low observation null, short timespan null, reason text + signal metadata
- [x] `./gradlew :core:test -q` — 58 tests pass (0 failures)
- [x] `./gradlew :core:ktlintCheck -q` — 0 violations

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)