### PR TITLE
feat(p2): Karma + SSID Flooding heuristics

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/KarmaHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/KarmaHeuristic.kt
@@ -7,42 +7,47 @@ class KarmaHeuristic : Heuristic {
         input: ScanInput,
         context: ScanContext,
     ): ThreatSignal? {
-        val group: List<ScanInput> = context.currentResults.filter { entry: ScanInput ->
-            entry.bssid == input.bssid
-        }
+        val group: List<ScanInput> =
+            context.currentResults.filter { entry: ScanInput ->
+                entry.bssid == input.bssid
+            }
 
         val first: ScanInput = group.firstOrNull() ?: return null
         if (input !== first) return null
 
-        val distinctSsids: Set<String> = group
-            .filter { entry: ScanInput -> !entry.isHidden }
-            .map { entry: ScanInput -> entry.ssid }
-            .toSet()
+        val distinctSsids: Set<String> =
+            group
+                .filter { entry: ScanInput -> !entry.isHidden }
+                .map { entry: ScanInput -> entry.ssid }
+                .toSet()
 
         val count: Int = distinctSsids.size
         if (count < 3) return null
 
-        val baseConfidence: Float = when {
-            count >= 10 -> 0.95f
-            count >= 5 -> 0.75f
-            else -> 0.45f
-        }
+        val baseConfidence: Float =
+            when {
+                count >= 10 -> 0.95f
+                count >= 5 -> 0.75f
+                else -> 0.45f
+            }
 
-        val reasons: MutableList<String> = mutableListOf(
-            "BSSID ${input.bssid} broadcasting $count distinct SSIDs",
-        )
+        val reasons: MutableList<String> =
+            mutableListOf(
+                "BSSID ${input.bssid} broadcasting $count distinct SSIDs",
+            )
 
         val frequencies: Set<Int> = group.map { entry: ScanInput -> entry.frequencyMhz }.toSet()
         val rssiValues: List<Int> = group.map { entry: ScanInput -> entry.rssiDbm }
         val rssiRange: Int = (rssiValues.max() - rssiValues.min())
         val hasBonus: Boolean = frequencies.size == 1 && rssiRange <= 6
 
-        val confidence: Float = if (hasBonus) {
-            reasons.add("Same channel + tight RSSI cluster")
-            (baseConfidence + 0.1f).coerceAtMost(0.95f)
-        } else {
-            baseConfidence
-        }
+        val confidence: Float =
+            if (hasBonus) {
+                reasons.add("Same channel + tight RSSI cluster")
+                (baseConfidence + 0.1f).coerceAtMost(0.95f)
+            } else {
+                baseConfidence
+            }
 
         return ThreatSignal(
             confidence = confidence,

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/SsidFloodingHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/SsidFloodingHeuristic.kt
@@ -17,21 +17,23 @@ class SsidFloodingHeuristic : Heuristic {
         val currentCount: Int = context.currentResults.size
         val zScore: Double = (currentCount.toDouble() - baseline.toDouble()) / stdDev
 
-        val confidence: Float = when {
-            zScore >= 5.0 || currentCount > 200 -> 0.90f
-            zScore >= 3.5 -> 0.70f
-            zScore >= 2.5 -> 0.50f
-            else -> return null
-        }
+        val confidence: Float =
+            when {
+                zScore >= 5.0 || currentCount > 200 -> 0.90f
+                zScore >= 3.5 -> 0.70f
+                zScore >= 2.5 -> 0.50f
+                else -> return null
+            }
 
         val zFormatted: String = "%.2f".format(zScore)
 
         return ThreatSignal(
             confidence = confidence,
             source = ThreatSource.LOCAL_HEURISTIC,
-            reasons = listOf(
-                "Abnormal network count: $currentCount (baseline: $baseline, z-score: $zFormatted)",
-            ),
+            reasons =
+                listOf(
+                    "Abnormal network count: $currentCount (baseline: $baseline, z-score: $zFormatted)",
+                ),
             heuristicType = type,
             bssid = "SCAN_LEVEL",
         )

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/KarmaHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/KarmaHeuristicTest.kt
@@ -38,21 +38,23 @@ class KarmaHeuristicTest {
 
     @Test
     fun `2 SSIDs on same BSSID returns null`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", frequencyMhz = 2412),
-            scan(ssid = "Net2", frequencyMhz = 5180),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", frequencyMhz = 2412),
+                scan(ssid = "Net2", frequencyMhz = 5180),
+            )
         val ctx: ScanContext = context(results)
         assertNull(heuristic.evaluate(results[0], ctx))
     }
 
     @Test
     fun `3 distinct SSIDs on same BSSID returns confidence 0_45`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", frequencyMhz = 2412),
-            scan(ssid = "Net2", frequencyMhz = 5180),
-            scan(ssid = "Net3", frequencyMhz = 2437),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", frequencyMhz = 2412),
+                scan(ssid = "Net2", frequencyMhz = 5180),
+                scan(ssid = "Net3", frequencyMhz = 2437),
+            )
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -61,9 +63,10 @@ class KarmaHeuristicTest {
 
     @Test
     fun `5 distinct SSIDs returns confidence 0_75`() {
-        val results: List<ScanInput> = (1..5).map { i: Int ->
-            scan(ssid = "Net$i", frequencyMhz = 2412 + i * 5)
-        }
+        val results: List<ScanInput> =
+            (1..5).map { i: Int ->
+                scan(ssid = "Net$i", frequencyMhz = 2412 + i * 5)
+            }
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -72,9 +75,10 @@ class KarmaHeuristicTest {
 
     @Test
     fun `10 distinct SSIDs returns confidence 0_95`() {
-        val results: List<ScanInput> = (1..10).map { i: Int ->
-            scan(ssid = "Net$i", frequencyMhz = 2412 + i * 5)
-        }
+        val results: List<ScanInput> =
+            (1..10).map { i: Int ->
+                scan(ssid = "Net$i", frequencyMhz = 2412 + i * 5)
+            }
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -83,13 +87,14 @@ class KarmaHeuristicTest {
 
     @Test
     fun `hidden SSIDs excluded from count`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", frequencyMhz = 2412),
-            scan(ssid = "Net2", frequencyMhz = 5180),
-            scan(ssid = "Net3", frequencyMhz = 2437),
-            scan(ssid = "Hidden1", isHidden = true, frequencyMhz = 5200),
-            scan(ssid = "Hidden2", isHidden = true, frequencyMhz = 5220),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", frequencyMhz = 2412),
+                scan(ssid = "Net2", frequencyMhz = 5180),
+                scan(ssid = "Net3", frequencyMhz = 2437),
+                scan(ssid = "Hidden1", isHidden = true, frequencyMhz = 5200),
+                scan(ssid = "Hidden2", isHidden = true, frequencyMhz = 5220),
+            )
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -98,11 +103,12 @@ class KarmaHeuristicTest {
 
     @Test
     fun `same channel and tight RSSI applies bonus`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", rssiDbm = -50, frequencyMhz = 2412),
-            scan(ssid = "Net2", rssiDbm = -48, frequencyMhz = 2412),
-            scan(ssid = "Net3", rssiDbm = -52, frequencyMhz = 2412),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", rssiDbm = -50, frequencyMhz = 2412),
+                scan(ssid = "Net2", rssiDbm = -48, frequencyMhz = 2412),
+                scan(ssid = "Net3", rssiDbm = -52, frequencyMhz = 2412),
+            )
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -112,11 +118,12 @@ class KarmaHeuristicTest {
 
     @Test
     fun `wide RSSI spread no bonus`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", rssiDbm = -30, frequencyMhz = 2412),
-            scan(ssid = "Net2", rssiDbm = -50, frequencyMhz = 2412),
-            scan(ssid = "Net3", rssiDbm = -70, frequencyMhz = 2412),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", rssiDbm = -30, frequencyMhz = 2412),
+                scan(ssid = "Net2", rssiDbm = -50, frequencyMhz = 2412),
+                scan(ssid = "Net3", rssiDbm = -70, frequencyMhz = 2412),
+            )
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -128,14 +135,15 @@ class KarmaHeuristicTest {
     fun `multiple qualifying BSSIDs produce separate signals`() {
         val bssid1 = "AA:AA:AA:AA:AA:AA"
         val bssid2 = "BB:BB:BB:BB:BB:BB"
-        val results: List<ScanInput> = listOf(
-            scan(bssid = bssid1, ssid = "A1"),
-            scan(bssid = bssid1, ssid = "A2"),
-            scan(bssid = bssid1, ssid = "A3"),
-            scan(bssid = bssid2, ssid = "B1"),
-            scan(bssid = bssid2, ssid = "B2"),
-            scan(bssid = bssid2, ssid = "B3"),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(bssid = bssid1, ssid = "A1"),
+                scan(bssid = bssid1, ssid = "A2"),
+                scan(bssid = bssid1, ssid = "A3"),
+                scan(bssid = bssid2, ssid = "B1"),
+                scan(bssid = bssid2, ssid = "B2"),
+                scan(bssid = bssid2, ssid = "B3"),
+            )
         val ctx: ScanContext = context(results)
         val signal1: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         val signal2: ThreatSignal? = heuristic.evaluate(results[3], ctx)
@@ -147,12 +155,13 @@ class KarmaHeuristicTest {
 
     @Test
     fun `duplicate SSIDs on same BSSID counted once`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", frequencyMhz = 2412),
-            scan(ssid = "Net1", frequencyMhz = 5180),
-            scan(ssid = "Net2", frequencyMhz = 2437),
-            scan(ssid = "Net3", frequencyMhz = 5200),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", frequencyMhz = 2412),
+                scan(ssid = "Net1", frequencyMhz = 5180),
+                scan(ssid = "Net2", frequencyMhz = 2437),
+                scan(ssid = "Net3", frequencyMhz = 5200),
+            )
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)
@@ -162,20 +171,22 @@ class KarmaHeuristicTest {
 
     @Test
     fun `non-first entry for same BSSID returns null`() {
-        val results: List<ScanInput> = listOf(
-            scan(ssid = "Net1", frequencyMhz = 2412),
-            scan(ssid = "Net2", frequencyMhz = 5180),
-            scan(ssid = "Net3", frequencyMhz = 2437),
-        )
+        val results: List<ScanInput> =
+            listOf(
+                scan(ssid = "Net1", frequencyMhz = 2412),
+                scan(ssid = "Net2", frequencyMhz = 5180),
+                scan(ssid = "Net3", frequencyMhz = 2437),
+            )
         val ctx: ScanContext = context(results)
         assertNull(heuristic.evaluate(results[1], ctx))
     }
 
     @Test
     fun `bonus capped at 0_95 for 10 SSIDs with tight cluster`() {
-        val results: List<ScanInput> = (1..10).map { i: Int ->
-            scan(ssid = "Net$i", rssiDbm = -50, frequencyMhz = 2412)
-        }
+        val results: List<ScanInput> =
+            (1..10).map { i: Int ->
+                scan(ssid = "Net$i", rssiDbm = -50, frequencyMhz = 2412)
+            }
         val ctx: ScanContext = context(results)
         val signal: ThreatSignal? = heuristic.evaluate(results[0], ctx)
         assertNotNull(signal)

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/SsidFloodingHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/SsidFloodingHeuristicTest.kt
@@ -29,9 +29,10 @@ class SsidFloodingHeuristicTest {
         baseline: Int? = 20,
         stdDev: Double? = 5.0,
     ): ScanContext {
-        val results: List<ScanInput> = (1..count).map { i: Int ->
-            scan(bssid = "AA:BB:CC:DD:EE:%02X".format(i % 256), ssid = "Net$i")
-        }
+        val results: List<ScanInput> =
+            (1..count).map { i: Int ->
+                scan(bssid = "AA:BB:CC:DD:EE:%02X".format(i % 256), ssid = "Net$i")
+            }
         return ScanContext(
             currentResults = results,
             knownProfiles = emptyMap(),


### PR DESCRIPTION
## Summary
- **KarmaHeuristic**: Detects single BSSID broadcasting 3+ distinct SSIDs (Karma/honeypot attack pattern). Confidence tiers: 3+ SSIDs → 0.45, 5+ → 0.75, 10+ → 0.95. Bonus +0.1 for same-channel + tight RSSI cluster (<=6dBm range). Hidden SSIDs excluded from count.
- **SsidFloodingHeuristic**: Z-score based detection using baseline network count and standard deviation. Thresholds: z≥2.5 → 0.50, z≥3.5 → 0.70, z≥5.0 or >200 absolute → 0.90. Uses SCAN_LEVEL sentinel BSSID (scan-wide, not per-network).
- 22 new tests (11 Karma + 11 Flooding), all passing

Phase 2 Task 4 of 9. Closes #101.

## Test plan
- [ ] CI passes (`:core:test` — 80 total tests)
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)