### PR TITLE
feat(p2): OUI asset loader + vendor lookup (#104)

### DIFF
--- a/android/core/src/main/assets/oui.csv
+++ b/android/core/src/main/assets/oui.csv
@@ -1,0 +1,11 @@
+Registry,Assignment,Organization Name,Organization Address
+MA-L,B827EB,Raspberry Pi Trading Ltd,Somewhere
+MA-L,DCA632,Raspberry Pi Trading Ltd,Somewhere
+MA-L,E45F01,Raspberry Pi Trading Ltd,Somewhere
+MA-L,2CCF67,Raspberry Pi Trading Ltd,Somewhere
+MA-L,240AC4,Espressif Inc.,Somewhere
+MA-L,30AEA4,Espressif Inc.,Somewhere
+MA-L,A4CF12,Espressif Inc.,Somewhere
+MA-L,CC50E3,Espressif Inc.,Somewhere
+MA-L,0CFA22,Flipper Devices Inc.,Somewhere
+MA-L,00C0CA,Alfa Network Inc.,Somewhere

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/OuiAssetLoader.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/OuiAssetLoader.kt
@@ -1,0 +1,28 @@
+package com.wscanplus.core.threat
+
+import android.content.Context
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+object OuiAssetLoader {
+    fun load(context: Context): OuiLookup {
+        val map: MutableMap<String, String> = mutableMapOf()
+        context.assets.open("oui.csv").use { stream ->
+            BufferedReader(InputStreamReader(stream)).use { reader ->
+                reader
+                    .lineSequence()
+                    .drop(1)
+                    .forEach { line ->
+                        val parts = line.split(",", limit = 4)
+                        if (parts.size < 3) return@forEach
+                        val oui = parts[1].trim().uppercase()
+                        val vendor = parts[2].trim().trim('"')
+                        if (oui.length == 6 && vendor.isNotEmpty()) {
+                            map[oui] = vendor
+                        }
+                    }
+            }
+        }
+        return OuiLookup(map)
+    }
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/OuiLookup.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/OuiLookup.kt
@@ -1,0 +1,55 @@
+package com.wscanplus.core.threat
+
+class OuiLookup(
+    private val ouiMap: Map<String, String>,
+) {
+    private val suspiciousOuis =
+        setOf(
+            "B827EB",
+            "DCA632",
+            "E45F01",
+            "2CCF67",
+            "D83ADD",
+            "240AC4",
+            "30AEA4",
+            "A4CF12",
+            "CC50E3",
+            "0CFA22",
+            "00C0CA",
+        )
+
+    fun lookup(bssid: String): String? {
+        val prefix = normalizePrefix(bssid) ?: return null
+        return ouiMap[prefix]
+    }
+
+    fun isSuspiciousVendor(bssid: String): Boolean {
+        val prefix = normalizePrefix(bssid) ?: return false
+        return prefix in suspiciousOuis
+    }
+
+    fun isLocallyAdministered(bssid: String): Boolean {
+        val normalized = normalizeBssid(bssid) ?: return false
+        if (normalized.length < 2) return false
+        val firstOctet = normalized.substring(0, 2).toIntOrNull(16) ?: return false
+        return (firstOctet and 0x02) != 0
+    }
+
+    private fun normalizePrefix(bssid: String): String? {
+        val normalized = normalizeBssid(bssid) ?: return null
+        if (normalized.length < 6) return null
+        return normalized.substring(0, 6)
+    }
+
+    private fun normalizeBssid(bssid: String): String? {
+        val cleaned =
+            bssid
+                .trim()
+                .uppercase()
+                .replace(":", "")
+                .replace("-", "")
+        if (cleaned.length < 6) return null
+        if (cleaned.any { it !in '0'..'9' && it !in 'A'..'F' }) return null
+        return cleaned
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/OuiLookupTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/OuiLookupTest.kt
@@ -1,0 +1,60 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OuiLookupTest {
+    private val lookup =
+        OuiLookup(
+            mapOf(
+                "B827EB" to "Raspberry Pi Trading Ltd",
+                "240AC4" to "Espressif Inc.",
+            ),
+        )
+
+    @Test
+    fun `lookup returns vendor for known OUI`() {
+        val vendor = lookup.lookup("B8:27:EB:11:22:33")
+        assertEquals("Raspberry Pi Trading Ltd", vendor)
+    }
+
+    @Test
+    fun `lookup returns null for unknown OUI`() {
+        val vendor = lookup.lookup("AA:BB:CC:11:22:33")
+        assertNull(vendor)
+    }
+
+    @Test
+    fun `suspicious vendor detected`() {
+        assertTrue(lookup.isSuspiciousVendor("B8:27:EB:11:22:33"))
+    }
+
+    @Test
+    fun `non suspicious vendor returns false`() {
+        assertFalse(lookup.isSuspiciousVendor("AA:BB:CC:11:22:33"))
+    }
+
+    @Test
+    fun `locally administered mac detected`() {
+        assertTrue(lookup.isLocallyAdministered("02:11:22:33:44:55"))
+    }
+
+    @Test
+    fun `globally administered mac returns false`() {
+        assertFalse(lookup.isLocallyAdministered("00:11:22:33:44:55"))
+    }
+
+    @Test
+    fun `malformed mac returns false`() {
+        assertFalse(lookup.isLocallyAdministered("ZZ"))
+    }
+
+    @Test
+    fun `lowercase bssid works`() {
+        val vendor = lookup.lookup("b8:27:eb:aa:bb:cc")
+        assertEquals("Raspberry Pi Trading Ltd", vendor)
+    }
+}


### PR DESCRIPTION
## Summary
- add Map-backed OUI lookup with suspicious vendor/local-admin checks
- add asset loader for oui.csv in assets
- add oui.csv sample entries + unit tests

## Testing
- cd android && ./gradlew :core:ktlintFormat :core:test :core:ktlintCheck

## Notes
- Agent: Copilot/Codex
- Rules: followed docs/AGENTS.md (one PR, issue #104, branch prefix)

Refs #104