### PR TITLE
feat(p2): PolicyGate + HeuristicEngine + WatchdogService wiring

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -16,6 +16,20 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.wscanplus.core.scanner.ScannerChain
+import com.wscanplus.core.scanner.WifiScanResult
+import com.wscanplus.core.scanner.toScanInput
+import com.wscanplus.core.threat.BssidFingerprintHeuristic
+import com.wscanplus.core.threat.EncryptionDowngradeHeuristic
+import com.wscanplus.core.threat.EnvironmentType
+import com.wscanplus.core.threat.EvilTwinHeuristic
+import com.wscanplus.core.threat.HeuristicEngine
+import com.wscanplus.core.threat.KarmaHeuristic
+import com.wscanplus.core.threat.PolicyGate
+import com.wscanplus.core.threat.RssiAnomalyHeuristic
+import com.wscanplus.core.threat.ScanContext
+import com.wscanplus.core.threat.ScanInput
+import com.wscanplus.core.threat.SsidFloodingHeuristic
+import com.wscanplus.core.threat.WepOpenHeuristic
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -45,6 +59,19 @@ class WatchdogService : Service() {
     private var startTimeMillis: Long = 0L
     private val handler = Handler(Looper.getMainLooper())
     private val restartRunnable = Runnable { performScheduledRestart() }
+    private val engine =
+        HeuristicEngine(
+            listOf(
+                WepOpenHeuristic(),
+                EvilTwinHeuristic(),
+                EncryptionDowngradeHeuristic(),
+                KarmaHeuristic(),
+                SsidFloodingHeuristic(),
+                RssiAnomalyHeuristic(),
+                BssidFingerprintHeuristic(ouiLookup = null),
+            ),
+        )
+    private val policyGate = PolicyGate()
 
     override fun onCreate() {
         super.onCreate()
@@ -76,8 +103,25 @@ class WatchdogService : Service() {
                 }
             scannerExecutor = executor
             scannerChain =
-                ScannerChain(applicationContext) { _ ->
-                    // Phase 1 stub — TODO (Phase 2): forward results to data layer / ADB channel.
+                ScannerChain(applicationContext) { results: List<WifiScanResult> ->
+                    val scanInputs: List<ScanInput> =
+                        results.map { result: WifiScanResult ->
+                            result.toScanInput()
+                        }
+                    val context =
+                        ScanContext(
+                            currentResults = scanInputs,
+                            knownProfiles = emptyMap(),
+                            baselineNetworkCount = null,
+                            baselineStdDev = null,
+                            environmentType = EnvironmentType.RESIDENTIAL,
+                        )
+                    val rawSignals = engine.analyze(context)
+                    val filtered = policyGate.filter(rawSignals)
+                    Log.d(
+                        "WatchdogService",
+                        "Threats: ${filtered.size} of ${rawSignals.size} signals passed policy gate",
+                    )
                 }
             startFuture = executor.submit { startChain(scannerChain!!) }
             scheduleDataSyncRestart()

--- a/android/core/src/main/kotlin/com/wscanplus/core/db/WscanDatabase.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/db/WscanDatabase.kt
@@ -58,7 +58,7 @@ abstract class WscanDatabase : RoomDatabase() {
                     context.applicationContext,
                     WscanDatabase::class.java,
                     "wscan.db",
-                ).fallbackToDestructiveMigration()
+                ).fallbackToDestructiveMigration(dropAllTables = true)
                 .build()
     }
 }

--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/WifiScanResult.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/WifiScanResult.kt
@@ -1,5 +1,7 @@
 package com.wscanplus.core.scanner
 
+import com.wscanplus.core.threat.ScanInput
+
 /**
  * Phase 1 Wi-Fi scan result model.
  *
@@ -25,6 +27,18 @@ data class WifiScanResult(
     val centerFreq0: Int,
     val centerFreq1: Int,
 )
+
+fun WifiScanResult.toScanInput(): ScanInput =
+    ScanInput(
+        bssid = bssid,
+        ssid = ssid,
+        isHidden = ssid.isBlank(),
+        capabilities = capabilities,
+        rssiDbm = signalLevel,
+        frequencyMhz = frequencyMhz,
+        channelWidth = channelWidth,
+        timestamp = timestamp,
+    )
 
 fun interface ScanResultsListener {
     fun onResults(results: List<WifiScanResult>)

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/HeuristicEngine.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/HeuristicEngine.kt
@@ -1,0 +1,12 @@
+package com.wscanplus.core.threat
+
+class HeuristicEngine(
+    private val heuristics: List<Heuristic>,
+) {
+    fun analyze(context: ScanContext): List<ThreatSignal> =
+        context.currentResults.flatMap { input: ScanInput ->
+            heuristics.mapNotNull { heuristic: Heuristic ->
+                heuristic.evaluate(input, context)
+            }
+        }
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/PolicyGate.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/PolicyGate.kt
@@ -1,0 +1,15 @@
+package com.wscanplus.core.threat
+
+data class PolicyConfig(
+    val minimumConfidence: Float = 0.3f,
+    val falsePositiveBrakes: Boolean = true,
+)
+
+class PolicyGate(
+    private val config: PolicyConfig = PolicyConfig(),
+) {
+    fun filter(signals: List<ThreatSignal>): List<ThreatSignal> =
+        signals.filter { signal: ThreatSignal ->
+            signal.confidence >= config.minimumConfidence
+        }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/HeuristicEngineTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/HeuristicEngineTest.kt
@@ -1,0 +1,100 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HeuristicEngineTest {
+    private val sampleInput =
+        ScanInput(
+            bssid = "AA:BB:CC:DD:EE:FF",
+            ssid = "TestNet",
+            isHidden = false,
+            capabilities = "[WPA2-PSK-CCMP][ESS]",
+            rssiDbm = -42,
+            frequencyMhz = 2412,
+            channelWidth = 20,
+            timestamp = 123456L,
+        )
+
+    private val sampleContext =
+        ScanContext(
+            currentResults = listOf(sampleInput),
+            knownProfiles = emptyMap(),
+            baselineNetworkCount = null,
+            baselineStdDev = null,
+            environmentType = EnvironmentType.RESIDENTIAL,
+        )
+
+    @Test
+    fun `empty heuristic list returns empty`() {
+        val engine = HeuristicEngine(emptyList())
+        val output = engine.analyze(sampleContext)
+        assertEquals(emptyList<ThreatSignal>(), output)
+    }
+
+    @Test
+    fun `single heuristic returns signal`() {
+        val heuristic =
+            FakeHeuristic(
+                HeuristicType.WEP_OPEN,
+                threatSignalFor(sampleInput.bssid, HeuristicType.WEP_OPEN),
+            )
+        val engine = HeuristicEngine(listOf(heuristic))
+        val output = engine.analyze(sampleContext)
+        assertEquals(1, output.size)
+        assertEquals(HeuristicType.WEP_OPEN, output.first().heuristicType)
+    }
+
+    @Test
+    fun `multiple heuristics combine signals`() {
+        val a =
+            FakeHeuristic(
+                HeuristicType.WEP_OPEN,
+                threatSignalFor(sampleInput.bssid, HeuristicType.WEP_OPEN),
+            )
+        val b =
+            FakeHeuristic(
+                HeuristicType.RSSI_ANOMALY,
+                threatSignalFor(sampleInput.bssid, HeuristicType.RSSI_ANOMALY),
+            )
+        val engine = HeuristicEngine(listOf(a, b))
+        val output = engine.analyze(sampleContext)
+        assertEquals(2, output.size)
+    }
+
+    @Test
+    fun `null heuristic results are excluded`() {
+        val nullHeuristic = FakeHeuristic(HeuristicType.WEP_OPEN, null)
+        val positiveHeuristic =
+            FakeHeuristic(
+                HeuristicType.RSSI_ANOMALY,
+                threatSignalFor(sampleInput.bssid, HeuristicType.RSSI_ANOMALY),
+            )
+        val engine = HeuristicEngine(listOf(nullHeuristic, positiveHeuristic))
+        val output = engine.analyze(sampleContext)
+        assertEquals(1, output.size)
+        assertEquals(HeuristicType.RSSI_ANOMALY, output.first().heuristicType)
+    }
+
+    private fun threatSignalFor(
+        bssid: String,
+        type: HeuristicType,
+    ): ThreatSignal =
+        ThreatSignal(
+            confidence = 0.7f,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf("test"),
+            heuristicType = type,
+            bssid = bssid,
+        )
+
+    private class FakeHeuristic(
+        override val type: HeuristicType,
+        private val result: ThreatSignal?,
+    ) : Heuristic {
+        override fun evaluate(
+            input: ScanInput,
+            context: ScanContext,
+        ): ThreatSignal? = result
+    }
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/PolicyGateTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/PolicyGateTest.kt
@@ -1,0 +1,68 @@
+package com.wscanplus.core.threat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PolicyGateTest {
+    private val sampleSignalLow =
+        ThreatSignal(
+            confidence = 0.2f,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf("low"),
+            heuristicType = HeuristicType.WEP_OPEN,
+            bssid = "AA:BB:CC:DD:EE:01",
+        )
+
+    private val sampleSignalMid =
+        ThreatSignal(
+            confidence = 0.5f,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf("mid"),
+            heuristicType = HeuristicType.WEP_OPEN,
+            bssid = "AA:BB:CC:DD:EE:02",
+        )
+
+    private val sampleSignalHigh =
+        ThreatSignal(
+            confidence = 0.8f,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf("high"),
+            heuristicType = HeuristicType.WEP_OPEN,
+            bssid = "AA:BB:CC:DD:EE:03",
+        )
+
+    @Test
+    fun `default config filters signals below point three`() {
+        val gate = PolicyGate()
+        val filtered = gate.filter(listOf(sampleSignalLow, sampleSignalMid, sampleSignalHigh))
+        assertEquals(listOf(sampleSignalMid, sampleSignalHigh), filtered)
+    }
+
+    @Test
+    fun `custom threshold filters correctly`() {
+        val gate = PolicyGate(PolicyConfig(minimumConfidence = 0.7f))
+        val filtered = gate.filter(listOf(sampleSignalLow, sampleSignalMid, sampleSignalHigh))
+        assertEquals(listOf(sampleSignalHigh), filtered)
+    }
+
+    @Test
+    fun `empty list returns empty`() {
+        val gate = PolicyGate()
+        val filtered = gate.filter(emptyList())
+        assertEquals(emptyList<ThreatSignal>(), filtered)
+    }
+
+    @Test
+    fun `all filtered out returns empty`() {
+        val gate = PolicyGate(PolicyConfig(minimumConfidence = 0.9f))
+        val filtered = gate.filter(listOf(sampleSignalLow, sampleSignalMid, sampleSignalHigh))
+        assertEquals(emptyList<ThreatSignal>(), filtered)
+    }
+
+    @Test
+    fun `all pass through`() {
+        val gate = PolicyGate(PolicyConfig(minimumConfidence = 0.1f))
+        val filtered = gate.filter(listOf(sampleSignalLow, sampleSignalMid, sampleSignalHigh))
+        assertEquals(listOf(sampleSignalLow, sampleSignalMid, sampleSignalHigh), filtered)
+    }
+}


### PR DESCRIPTION
## Summary
- add PolicyGate and HeuristicEngine to coordinate and filter heuristic signals
- add WifiScanResult.toScanInput() mapping extension used by the service wiring
- wire heuristic execution + policy filtering into WatchdogService scan callback
- add unit tests for PolicyGate and HeuristicEngine
- update WscanDatabase to allbackToDestructiveMigration(dropAllTables = true)

## Testing
- cd android && ./gradlew :core:ktlintFormat :app:ktlintFormat :core:test :core:ktlintCheck :app:ktlintCheck

## Plan Reference
- docs/superpowers/plans/2026-03-19-phase2-local-threat-intelligence.md Task 9

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Refs #110