### PR TITLE
docs: add March 20 handoff session state

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 ## Current State
 - docs/SESSION_STATE.md — architecture decisions, locked choices, current phase + next steps
-- `docs/SESSION_STATE.md#2026-03-20-handoff-snapshot` — fastest re-entry point for the next AI session
+- [docs/SESSION_STATE.md#2026-03-20-handoff-snapshot](docs/SESSION_STATE.md#2026-03-20-handoff-snapshot) — fastest re-entry point for the next AI session
 
 ## Roadmap
 - docs/ROADMAP.md — phases and priorities
@@ -26,6 +26,5 @@
 ## Safety / Process
 - AGENTS.md — AI agent guardrails (quick reference)
 - docs/AGENTS.md — full universal guardrails for all agents
-- KNOWN_ISSUES.md — incident history, repo configuration changes, known limitations
-- KNOWN_ISSUES.md — also records Phase 2 completion status as of 2026-03-20
+- KNOWN_ISSUES.md — incident history, repo configuration changes, known limitations; also records Phase 2 completion status as of 2026-03-20
 - .github/copilot-instructions.md — Copilot-specific behavior rules

--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -99,7 +99,7 @@ This section is the fast re-entry point for the next Claude/Copilot session.
 ### Remote repo state
 
 - `main` is current and there are **no open PRs** in `dvntone/wscanplus`
-- The Phase 2 completion note is now recorded in `KNOWN_ISSUES.md`
+- `KNOWN_ISSUES.md` records the Phase 2 completion snapshot added on 2026-03-20
 - Issue `#116` (app-side logging) was closed after merge
 - The only open tracked work at repo level is:
   - `#9` — Google Maps threat heatmap + scan history map


### PR DESCRIPTION
References #119

Made by: Copilot / Codex

What changed and why:
- Added a March 20 handoff snapshot to `docs/SESSION_STATE.md` so the next Claude/Copilot session can recover current repo status quickly.
- Updated `docs/INDEX.md` to point directly at the handoff entry.
- Documented current remote state, verification status, local-worktree cautions, and recommended next work.

Verification:
- `cmd /c "set JAVA_HOME=& gradlew.bat --no-daemon :core:ktlintCheck :app:ktlintCheck"`
