### PR TITLE
docs(p1): record Pixel matrix and desktop adb handoff

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,8 +7,11 @@
 ## Device Testing
 - docs/testing/README.md — testing layout, rules, and per-device organization
 - docs/testing/shared/38_operational_checklist.md — repeatable adb/device validation checklist
+- docs/testing/shared/50_desktop_adb_handoff.md — host-side adb commands and state checks for future desktop integration
 - docs/testing/devices/motorola-g4-play-2024/README.md — archived prior-device testing context
 - docs/testing/devices/revvl-tab-2/README.md — current Android 15 device prep and test entry point
+- docs/testing/devices/pixel-10-pro-xl/README.md — strict-environment Pixel target and install baseline
+- docs/testing/devices/pixel-10-pro-xl/2026-03-20-full-adb-matrix.md — full Pixel permission/background/keyguard matrix result
 
 ## Roadmap
 - docs/ROADMAP.md — phases and priorities

--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -131,8 +131,8 @@ This section is the fast re-entry point for the next Claude/Copilot session.
 - Current active Android target is `Revvl Tab 2` (Android 15)
 - Previous archived device-testing baseline is `moto g play - 2024`
 - Latest strict-environment target is `Pixel 10 Pro XL` on the current beta track
-- First Revvl baseline result is documented in `docs/testing/devices/revvl-tab-2/2026-03-20-baseline-smoke-test.md`
-- Pixel beta / Advanced Protection install baseline is documented in `docs/testing/devices/pixel-10-pro-xl/README.md`
+  - First Revvl baseline result is documented in `docs/testing/devices/revvl-tab-2/2026-03-20-baseline-smoke-test.md`
+  - Pixel beta / Advanced Protection install baseline is documented in `docs/testing/devices/pixel-10-pro-xl/README.md`
 - Runtime discrepancy from that baseline is tracked in issue `#122` (missing visible app-side adb logs on Revvl Android 15)
 - Android 15 permission strategy note is documented in `docs/research/android_wifi_location_strategy.md`
 - Current technical stance:
@@ -144,11 +144,14 @@ This section is the fast re-entry point for the next Claude/Copilot session.
   - `#125` - backgrounded / keyguard-visible app loses effective `getScanResults()` access while shell scans still work
 - Cross-device validation status:
   - baseline: Revvl Tab 2 / Android 15 and moto g play - 2024 / Android 14 both reproduced the background / keyguard scan-access failure
-  - fix validation in progress on issue `#126`: `ACCESS_BACKGROUND_LOCATION` + `foregroundServiceType="location|dataSync"`
+  - issue `#126` fix is now merged: `ACCESS_BACKGROUND_LOCATION` + `foregroundServiceType="location|dataSync"`
   - moto g play - 2024 / Android 14 now regains locked-screen scan access with the current fix when device location mode is enabled
   - Revvl Tab 2 / Android 15 no longer emits the prior app-UID location-permission violation under keyguard
   - Pixel 10 Pro XL beta-track baseline: trusted-host `adb install -r` (install/update) succeeded with Advanced Protection still enabled, including a repeat install with the lockscreen showing
-  - next validation target should be the full shared matrix on Pixel 10 Pro XL under its current beta / Advanced Protection posture
+  - Pixel 10 Pro XL full matrix is now documented in `docs/testing/devices/pixel-10-pro-xl/2026-03-20-full-adb-matrix.md`
+  - Pixel 10 Pro XL now passes foreground, true background, secure keyguard, and post-unlock recovery on the current fix
+  - coarse-only remains degraded/incomplete on the Pixel path and should be treated as an explicit product decision area
+  - future desktop implementation should reuse the host-side adb checks captured in `docs/testing/shared/50_desktop_adb_handoff.md`
 
 ### Local workspace caution
 
@@ -165,10 +168,11 @@ This section is the fast re-entry point for the next Claude/Copilot session.
    - WatchdogService Android 15 six-hour restart hardening
    - settings deep link refinement
    - first additional unit tests
-4. Finish issue `#126` validation and then move to the Pixel 10 Pro XL / Android 17 device:
-   - confirm post-unlock recovery on Revvl and Motorola with the current fix
-   - run `shared/49_background_keyguard_scan_matrix.md` on Pixel 10 Pro XL
-   - assess whether the app should enforce "Allow all the time" in its operator flow or keep it mode-specific
+4. Turn the remaining permission-model questions into tracked work:
+   - decide whether coarse-only should remain a degraded path or redirect into explicit fine-location escalation
+   - decide whether the app should enforce "Allow all the time" in its operator flow or keep it mode-specific
+   - validate first-trust Pixel / Advanced Protection onboarding separately from already-trusted-host behavior
+5. Carry the documented adb install / permission / state checks into the later desktop companion implementation
 
 ---
 

--- a/docs/research/android_wifi_location_strategy.md
+++ b/docs/research/android_wifi_location_strategy.md
@@ -23,7 +23,7 @@ For apps targeting Android 10+:
 - `ACCESS_COARSE_LOCATION` alone is not sufficient for the current scan-results path.
 - `NEARBY_WIFI_DEVICES` does not replace `ACCESS_FINE_LOCATION` for `getScanResults()`.
 
-This matches the current Revvl Tab 2 evidence:
+This matches the current Revvl Tab 2 and Pixel evidence:
 
 - coarse-only permission allows the app to launch and start the service
 - actual scan retrieval still fails on the current path
@@ -78,6 +78,8 @@ Post-fix validation on 2026-03-20:
 - `WatchdogService` now runs as `foregroundServiceType="location|dataSync"`
 - moto g play - 2024 / Android 14 regained locked-screen scan access once device location mode was enabled
 - Revvl Tab 2 / Android 15 no longer emits the prior app-UID location-permission violation while backgrounded/keyguard-visible
+- Pixel 10 Pro XL on the current beta track now passes foreground, true background, secure keyguard, and post-unlock recovery with fresh scan callbacks and threat output
+- Pixel coarse-only remains degraded: the app starts and logs the state, but did not produce usable scan-result callbacks during the clean matrix run
 
 The current evidence supports keeping background location in scope for wscan+'s discreet / long-running field mode.
 
@@ -119,10 +121,10 @@ Near-term stance for wscan+:
 
 Now that `ACCESS_BACKGROUND_LOCATION` is implemented, validate the remaining edge cases on current hardware:
 
-1. Re-run the shared background/keyguard matrix on the Pixel 10 Pro XL / Android 17 strict-security device.
-2. Compare service survival, scan callbacks, and artifact generation with and without the activity visible.
-3. Measure practical battery cost during a fixed interval capture run.
-4. Decide whether the app should hard-require "Allow all the time" or expose a narrower foreground-only mode.
+1. Measure practical battery cost during a fixed interval capture run on at least one Android 14+ phone and the Revvl tablet.
+2. Decide whether the app should hard-require "Allow all the time" or expose a narrower foreground-only mode.
+3. Decide whether coarse-only should remain an allowed degraded state or redirect operators into an explicit fine-location upgrade path.
+4. Validate first-trust host behavior separately from already-trusted-host behavior on the Pixel / Advanced Protection path.
 
 ## Sources
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -6,6 +6,7 @@ This area separates repeatable test procedures from device-specific evidence.
 
 - `shared/` - reusable checklists and operator guidance that apply across devices
 - `shared/49_background_keyguard_scan_matrix.md` - repeatable unlocked / HOME / secure-keyguard / post-unlock matrix for scan continuity
+- `shared/50_desktop_adb_handoff.md` - host-side adb commands and data points the future desktop companion will need
 - `devices/motorola-g4-play-2024/` - archived findings from the previous Android test device
 - `devices/revvl-tab-2/` - active prep and session notes for the current Android 15 tablet target
 - `devices/pixel-10-pro-xl/` - latest beta-track Pixel target with Advanced Protection enabled

--- a/docs/testing/devices/pixel-10-pro-xl/2026-03-20-full-adb-matrix.md
+++ b/docs/testing/devices/pixel-10-pro-xl/2026-03-20-full-adb-matrix.md
@@ -1,0 +1,193 @@
+# Pixel 10 Pro XL Full ADB Matrix
+
+**Date**: 2026-03-20  
+**Build under test**: `com.wscanplus.app` `versionName=0.1.0`, `versionCode=2`  
+**Platform values reported by adb**:
+
+- `ro.build.version.release=16`
+- `ro.build.version.sdk=36`
+- `ro.build.version.codename=CinnamonBun`
+
+## Scope
+
+Run the full permission and runtime matrix on the current Pixel beta device with:
+
+- Advanced Protection enabled
+- developer options enabled
+- Wi-Fi scan throttling disabled
+- current background/keyguard fix on `main`
+
+This pass intentionally re-ran the matrix sequentially after an earlier parallel permission test
+produced contaminated results.
+
+## Preconditions used for the clean pass
+
+- Wi-Fi enabled
+- trusted-host adb session already authorized
+- device location mode explicitly checked before each conclusion
+- app logs filtered by:
+  - `MainActivity`
+  - `WatchdogService`
+  - `StandardScanner`
+  - `ScannerChain`
+  - `WifiService`
+
+## Results
+
+### 1. No-permission launch
+
+Observed behavior:
+
+- the app landed in the Android location permission controller
+- the first prompt offered:
+  - precise vs approximate
+  - while-using vs one-time vs deny
+
+Conclusion:
+
+- current operator flow correctly surfaces the system permission gate instead of failing silently
+
+### 2. Coarse-only launch
+
+Granted state:
+
+- `ACCESS_COARSE_LOCATION`
+- `NEARBY_WIFI_DEVICES`
+- `ACCESS_FINE_LOCATION` revoked
+- `ACCESS_BACKGROUND_LOCATION` revoked
+
+Observed behavior:
+
+- `MainActivity` logged `Permissions granted: FINE=false, COARSE=true`
+- `WatchdogService` started
+- `StandardScanner` started
+- the UI remained on `Starting scanner...`
+- shell `cmd wifi list-scan-results` remained populated
+- the app did not produce fresh `Received ... scan results` callbacks during the coarse-only sample
+
+Conclusion:
+
+- coarse-only is still a degraded state on the current Pixel path
+- it no longer dead-ends startup, but it is not a reliable scan-capable mode
+
+### 3. Full-permission foreground
+
+Granted state:
+
+- `ACCESS_FINE_LOCATION`
+- `ACCESS_COARSE_LOCATION`
+- `ACCESS_BACKGROUND_LOCATION`
+- `NEARBY_WIFI_DEVICES`
+
+Observed behavior:
+
+- `MainActivity` resumed
+- `WifiService` logged `getScanResults uid=...`
+- `StandardScanner` received `49` fresh results on the first clean foreground control
+- `StandardScanner` later received `52` fresh results on the final unlocked foreground control
+- `WatchdogService` produced threat output in both foreground samples
+
+Conclusion:
+
+- full foreground scan path is working on the current Pixel build
+
+### 4. True background sample
+
+Method:
+
+- launch Android Settings to move `MainActivity` out of top-resumed state
+
+Observed behavior:
+
+- `topResumedActivity=com.android.settings/.Settings`
+- `WatchdogService` remained foreground
+- `WifiService` logged `getScanResults uid=...`
+- `StandardScanner` received `47` fresh results
+- `WatchdogService` produced threat output
+
+Conclusion:
+
+- the current background-location + location-typed foreground-service fix is holding in true background state on this Pixel
+
+### 5. Secure keyguard continuity
+
+Observed behavior:
+
+- `showing=true`
+- `screenState=SCREEN_STATE_ON`
+- top surface was a non-app keyguard/dream activity
+- `WatchdogService` remained foreground
+- `WifiService` logged `getScanResults uid=...`
+- `StandardScanner` received `52` fresh results
+- `WatchdogService` produced threat output
+
+Conclusion:
+
+- locked-screen scan continuity is working on the current Pixel setup
+
+### 6. Post-unlock recovery
+
+Observed behavior:
+
+- unlocked-background recovery succeeded while Settings stayed top-resumed
+- unlocked-foreground recovery succeeded after bringing `MainActivity` back to the front
+- final unlocked foreground control produced `52` fresh results and threat output
+
+Conclusion:
+
+- post-unlock recovery is normal on this device after the current fix
+
+### 7. Location-off failure control
+
+Method:
+
+- set `location_mode=0`
+
+Observed behavior:
+
+- `WifiService` logged:
+  - `Permission violation - getScanResults not allowed ... reason=Location mode is disabled for the device`
+- `StandardScanner` received `0` scan results
+- `WatchdogService` produced `0 of 0` signals
+- location mode was restored immediately after the control
+
+Conclusion:
+
+- the app still reflects the expected platform denial when device location is off
+- the background/keyguard fix did not mask that underlying requirement
+
+## Advanced Protection result
+
+Observed earlier on the same device/session:
+
+- trusted-host `adb install -r` succeeded while Advanced Protection was enabled
+- a repeat `adb install -r` also succeeded with the lockscreen showing
+
+Interpretation:
+
+- in the current trusted-host setup, Advanced Protection is not blocking test-app install/update
+- future desktop onboarding should still distinguish:
+  - first-trust vs already-trusted host
+  - install/update vs shell access
+  - unlocked vs locked device state
+
+## Desktop handoff relevance
+
+This run confirms the future desktop companion needs host-side checks for:
+
+- app version currently installed
+- runtime permission state
+- `location_mode`
+- whether the app is foregrounded, backgrounded, or behind keyguard
+- whether `WatchdogService` remains foreground
+- whether `WifiService` is returning app-UID scan access or a permission-violation reason
+
+See `docs/testing/shared/50_desktop_adb_handoff.md`.
+
+## Post-session device state
+
+At the end of this session:
+
+- device location was set back to off (`location_mode=0`)
+- the test app was removed from the device
+

--- a/docs/testing/devices/pixel-10-pro-xl/README.md
+++ b/docs/testing/devices/pixel-10-pro-xl/README.md
@@ -42,6 +42,11 @@ Interpretation:
 
 ## Next validation
 
-- run `shared/49_background_keyguard_scan_matrix.md`
-- verify whether app-side log visibility on Pixel is closer to Motorola or Revvl behavior
-- evaluate whether Advanced Protection changes any install/update or runtime permission prompts compared with prior devices
+- Full matrix result is now documented in `2026-03-20-full-adb-matrix.md`.
+- Current conclusions:
+  - full-permission foreground, true background, secure keyguard, and post-unlock recovery all pass on the current Pixel setup
+  - coarse-only still behaves as degraded/incomplete rather than fully scan-capable
+  - `location_mode` must still be checked before drawing scan conclusions
+- Post-session state after the full matrix:
+  - device location returned to off
+  - test app removed from the device

--- a/docs/testing/shared/49_background_keyguard_scan_matrix.md
+++ b/docs/testing/shared/49_background_keyguard_scan_matrix.md
@@ -102,5 +102,10 @@ As of 2026-03-20:
 - post-fix validation with `ACCESS_BACKGROUND_LOCATION` + `foregroundServiceType="location|dataSync"`:
   - moto g play - 2024 (Android 14): secure keyguard now allows `getScanResults()` and `StandardScanner` receives fresh results again
   - Revvl Tab 2 (Android 15): the previous `Permission violation - getScanResults not allowed ... has no location permission` signature no longer appears under keyguard, and the app UID reaches `getScanResults()`
+  - Pixel 10 Pro XL beta-track device: unlocked foreground, true background, secure keyguard, and post-unlock recovery all pass with fresh scan results and threat output
+
+Related limitation that remains outside the background/keyguard fix:
+
+- coarse-only permission on the Pixel still launches the app and service, but did not produce usable scan-result callbacks during the full matrix run
 
 This remains a cross-device issue area, but the current fix path now has positive evidence on both test devices.

--- a/docs/testing/shared/50_desktop_adb_handoff.md
+++ b/docs/testing/shared/50_desktop_adb_handoff.md
@@ -1,0 +1,125 @@
+# Desktop ADB Handoff Data
+
+**Updated**: 2026-03-20
+
+## Purpose
+
+Record the minimum adb checks and runtime data points that the future desktop companion will need
+to collect or explain when it starts orchestrating Android installs, permissions, and scan-state
+verification.
+
+This note is repo-local on purpose so Android and desktop sessions stay aligned even before the
+desktop implementation begins.
+
+## Host-side checks that proved useful
+
+### Install / version state
+
+```powershell
+adb shell dumpsys package com.wscanplus.app | Select-String -Pattern 'versionName=|versionCode='
+adb install -r path\to\app-debug.apk
+adb uninstall com.wscanplus.app
+```
+
+Use for:
+
+- confirming which build is on-device
+- updating the test app from a trusted host
+- cleaning up test installs after a session
+
+### Permission state
+
+```powershell
+adb shell dumpsys package com.wscanplus.app | Select-String -Pattern 'ACCESS_FINE_LOCATION|ACCESS_COARSE_LOCATION|ACCESS_BACKGROUND_LOCATION|NEARBY_WIFI_DEVICES'
+adb shell cmd appops get com.wscanplus.app
+adb shell pm grant com.wscanplus.app android.permission.ACCESS_FINE_LOCATION
+adb shell pm grant com.wscanplus.app android.permission.ACCESS_COARSE_LOCATION
+adb shell pm grant com.wscanplus.app android.permission.ACCESS_BACKGROUND_LOCATION
+adb shell pm grant com.wscanplus.app android.permission.NEARBY_WIFI_DEVICES
+adb shell pm revoke com.wscanplus.app android.permission.ACCESS_FINE_LOCATION
+adb shell pm revoke com.wscanplus.app android.permission.ACCESS_COARSE_LOCATION
+adb shell pm revoke com.wscanplus.app android.permission.ACCESS_BACKGROUND_LOCATION
+adb shell pm revoke com.wscanplus.app android.permission.NEARBY_WIFI_DEVICES
+```
+
+Use for:
+
+- proving whether the app has the intended runtime state
+- separating no-permission, coarse-only, and full-permission behavior
+
+### Location / Wi-Fi environment state
+
+```powershell
+adb shell settings get secure location_mode
+adb shell settings put secure location_mode 0
+adb shell settings put secure location_mode 3
+adb shell cmd wifi status
+adb shell cmd wifi start-scan
+adb shell cmd wifi list-scan-results
+```
+
+Interpretation:
+
+- `location_mode=0` means device location is off and will produce platform scan denial even when
+  the app has permissions
+- shell scan results can still be populated while app-UID scan access fails, so shell data alone
+  is not proof that the app itself is working
+
+### Activity / lock / service state
+
+```powershell
+adb shell dumpsys activity activities | Select-String -Pattern 'topResumedActivity=|com.wscanplus.app/.MainActivity'
+adb shell dumpsys window policy | Select-String -Pattern 'showing=|screenState='
+adb shell dumpsys activity services com.wscanplus.app | Select-String -Pattern 'WatchdogService|foreground=true'
+adb shell am start -a android.settings.SETTINGS
+adb shell am start -n com.wscanplus.app/.MainActivity
+adb shell input keyevent 26
+```
+
+Use for:
+
+- distinguishing unlocked foreground vs true background vs keyguard samples
+- proving whether `WatchdogService` stayed alive during the transition
+
+### App/runtime logs
+
+```powershell
+adb logcat -c
+adb logcat -d -v brief MainActivity:D WatchdogService:D StandardScanner:D ScannerChain:D WifiService:D *:S
+```
+
+High-value signals:
+
+- `Permissions granted: FINE=..., COARSE=...`
+- `Using Standard scanner`
+- `Scanner started (API ...)`
+- `Received ... scan results (... after stale filter)`
+- `Threats: ... signals passed policy gate`
+- `Permission violation - getScanResults not allowed ...`
+
+## Data the desktop app should eventually surface
+
+- installed app version
+- runtime permission summary
+- current `location_mode`
+- Wi-Fi enabled / scan-always state
+- whether the app activity is foregrounded or not
+- whether `WatchdogService` is running foreground
+- last scan-result count
+- last platform denial reason, if any
+
+## Cross-device lessons now established
+
+- Pixel and Motorola default to tethering on connection in this lab setup; Revvl does not
+- Revvl is currently the constrained tablet baseline; Pixel and Motorola are the cleaner install /
+  tether test targets
+- background/keyguard scan continuity must be validated separately from simple foreground success
+- coarse-only must be treated as degraded, not equivalent to full scan capability
+
+## OPSEC
+
+- do not place device serials or other persistent device identifiers in tracked docs, issues, PR
+  text, or commit messages
+- use redacted placeholders in docs and examples
+- raw identifiers belong only in local git-ignored artifacts when operationally necessary
+


### PR DESCRIPTION
## Summary\n- Made by: Copilot / Codex\n- References exactly one GitHub Issue: #130\n- Document the completed Pixel 10 Pro XL full ADB matrix\n- Capture the host-side adb commands and runtime data needed for later desktop companion implementation\n- Update shared/session docs with the resulting cross-device conclusions and post-test device state\n\n## Why\n- The Pixel run completed the modern Android foreground/background/keyguard matrix on the current fix\n- The resulting adb checks and interpretation rules are now stable enough to preserve for later desktop integration\n- Coarse-only remains degraded on the Pixel path and should stay visible as a tracked product decision area\n\n## Rules followed\n- One PR only, tied to one issue\n- Docs-only scope; no drive-by refactors\n- OPSEC hard rule preserved: no device serials or persistent identifiers in tracked docs\n- Local-only .vscode/extensions.json left untouched\n\n## Verification\n- Docs-only change; no code/tests were changed or required\n- Confirmed test app removed from Pixel and Moto after the session\n- Confirmed Pixel location returned to off after the session\n\n## Checklist\n- [x] Made by: Copilot\n- [x] References exactly one GitHub Issue\n- [x] One feature OR one bugfix (docs-only)\n- [x] No new dependencies mixed in\n- [x] Documentation updated\n- [x] .env / local.properties NOT committed\n- [x] No secrets of any kind committed\n- [x] Gemini/Vertex integration untouched