### PR TITLE
fix(p1): add location-settings deep link for scan recovery

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.location.LocationManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -53,6 +54,8 @@ class MainActivity : Activity() {
         // Re-check permissions when returning from Settings
         if (hasAllPermissions()) {
             maybeStartWatchdog()
+        } else {
+            showPermissionDenied()
         }
     }
 
@@ -78,7 +81,7 @@ class MainActivity : Activity() {
     private fun showPermissionDenied() {
         statusView.text =
             "Scanning disabled. Grant Wi-Fi and location permissions in Settings to start."
-        configureActionButton("Open Settings") { openAppSettings() }
+        configureActionButton("Open App Settings") { openAppSettings() }
     }
 
     private fun openAppSettings() {
@@ -123,6 +126,10 @@ class MainActivity : Activity() {
 
     private fun maybeStartWatchdog() {
         if (scannerStarted) return
+        if (isDeviceLocationEnabled().not()) {
+            showLocationServicesRequired()
+            return
+        }
         if (requiresBackgroundLocationPrompt()) {
             showBackgroundLocationRequired()
             return
@@ -138,7 +145,32 @@ class MainActivity : Activity() {
     private fun showBackgroundLocationRequired() {
         statusView.text =
             "Scanning cannot start until you grant 'Allow all the time' location access in Settings."
-        configureActionButton("Open Settings") { openAppSettings() }
+        configureActionButton("Open App Settings") { openAppSettings() }
+    }
+
+    private fun showLocationServicesRequired() {
+        statusView.text =
+            "Scanning cannot start until device location services are turned on."
+        configureActionButton("Open Location Settings") { openLocationSettings() }
+    }
+
+    private fun openLocationSettings() {
+        val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+        startActivity(intent)
+    }
+
+    private fun isDeviceLocationEnabled(): Boolean {
+        val locationManager = getSystemService(LocationManager::class.java)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            locationManager.isLocationEnabled
+        } else {
+            @Suppress("DEPRECATION")
+            Settings.Secure.getInt(
+                contentResolver,
+                Settings.Secure.LOCATION_MODE,
+                Settings.Secure.LOCATION_MODE_OFF,
+            ) != Settings.Secure.LOCATION_MODE_OFF
+        }
     }
 
     private fun configureActionButton(


### PR DESCRIPTION
## Summary
- Made by: Copilot / Codex
- References exactly one GitHub Issue: #136
- Add a direct Location Settings deep link when runtime permissions are granted but device location services are turned off

## Why
- The app already deep-linked to App Settings for denied runtime permissions
- Modern Android can still block scan-capable behavior when device location services are off even if runtime permissions are granted
- Operators should be taken to the correct settings surface for the actual failure state instead of being dumped into the wrong menu

## Verification
- Ran Android verification locally:
  - `:core:test`
  - `:app:assembleDebug`
  - `:core:ktlintCheck`
  - `:app:ktlintCheck`
- Pixel sanity check with `location_mode=0` confirmed the app now shows:
  - `Scanning cannot start until device location services are turned on.`
  - `Open Location Settings`

## Rules followed
- One PR only, tied to one issue
- One bugfix only
- No new dependencies
- Local-only `.vscode/extensions.json` left untouched

## Checklist
- [x] Made by: Copilot
- [x] References exactly one GitHub Issue
- [x] One feature OR one bugfix
- [x] No new dependencies mixed in
- [x] Meaningful verification completed
- [x] Errors are logged, not silently swallowed
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets of any kind committed
- [x] Gemini/Vertex integration untouched
