### PR TITLE
fix(p1): align permission flow with field mode policy

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -42,7 +42,7 @@ class MainActivity : Activity() {
         rootLayout.addView(actionButton)
         setContentView(rootLayout)
 
-        if (hasAllPermissions()) {
+        if (hasEntryPermissions()) {
             maybeStartWatchdog()
         } else {
             requestPermissions(requiredPermissions(), REQUEST_CODE)
@@ -52,11 +52,7 @@ class MainActivity : Activity() {
     override fun onResume() {
         super.onResume()
         // Re-check permissions when returning from Settings
-        if (hasAllPermissions()) {
-            maybeStartWatchdog()
-        } else {
-            showPermissionDenied()
-        }
+        refreshScannerState()
     }
 
     override fun onRequestPermissionsResult(
@@ -71,16 +67,18 @@ class MainActivity : Activity() {
         val hasFine = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         val hasCoarse = hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
         Log.d(TAG, "Permissions granted: FINE=$hasFine, COARSE=$hasCoarse")
-        if (hasAllPermissions()) {
-            maybeStartWatchdog()
-        } else {
-            showPermissionDenied()
-        }
+        refreshScannerState()
     }
 
     private fun showPermissionDenied() {
         statusView.text =
             "Scanning disabled. Grant Wi-Fi and location permissions in Settings to start."
+        configureActionButton("Open App Settings") { openAppSettings() }
+    }
+
+    private fun showPreciseLocationRequired() {
+        statusView.text =
+            "Approximate-only location is degraded. Enable precise location in App Settings to start scanning."
         configureActionButton("Open App Settings") { openAppSettings() }
     }
 
@@ -104,11 +102,13 @@ class MainActivity : Activity() {
         return base.toTypedArray()
     }
 
-    private fun hasAllPermissions(): Boolean = hasRequiredLocationPermission() && hasNonLocationPermissions()
+    private fun hasEntryPermissions(): Boolean = hasAnyLocationPermission() && hasNonLocationPermissions()
 
-    private fun hasRequiredLocationPermission(): Boolean =
-        hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) ||
-            hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
+    private fun hasAnyLocationPermission(): Boolean = hasFineLocationPermission() || hasCoarseLocationPermission()
+
+    private fun hasFineLocationPermission(): Boolean = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+
+    private fun hasCoarseLocationPermission(): Boolean = hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
 
     private fun hasNonLocationPermissions(): Boolean =
         requiredPermissions()
@@ -124,8 +124,24 @@ class MainActivity : Activity() {
 
     private var scannerStarted = false
 
+    private fun refreshScannerState() {
+        if (hasFineLocationPermission().not() && hasCoarseLocationPermission() && hasNonLocationPermissions()) {
+            showPreciseLocationRequired()
+            return
+        }
+        if (hasEntryPermissions()) {
+            maybeStartWatchdog()
+        } else {
+            showPermissionDenied()
+        }
+    }
+
     private fun maybeStartWatchdog() {
         if (scannerStarted) return
+        if (hasFineLocationPermission().not()) {
+            showPreciseLocationRequired()
+            return
+        }
         if (isDeviceLocationEnabled().not()) {
             showLocationServicesRequired()
             return
@@ -144,7 +160,7 @@ class MainActivity : Activity() {
 
     private fun showBackgroundLocationRequired() {
         statusView.text =
-            "Scanning cannot start until you grant 'Allow all the time' location access in Settings."
+            "Field mode needs 'Allow all the time' location access. Without it, locked-screen and background scanning is unreliable."
         configureActionButton("Open App Settings") { openAppSettings() }
     }
 


### PR DESCRIPTION
## Summary
- agent: Copilot / Codex
- closes #141
- stop treating coarse-only location as scan-capable in `MainActivity`
- make the field-mode background-location requirement explicit in the recovery UI

## Why
- current repo docs lock `ACCESS_FINE_LOCATION` as the scan-capable path, `ACCESS_COARSE_LOCATION` as degraded-only, and `ACCESS_BACKGROUND_LOCATION` as required for intended field mode
- the app UI still implied coarse-only could proceed normally, which no longer matched the validated device behavior
- this PR keeps the change limited to the permission-state flow without broad UI refactoring

## Verification
- `cmd /c "set JAVA_HOME=& cd android && gradlew.bat --no-daemon :core:test :app:assembleDebug :core:ktlintCheck :app:ktlintCheck"`
- confirmed `.env` and `local.properties` remain untracked
