### PR TITLE
fix(p2): log StandardScanner teardown failures (#143)

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/scanner/StandardScanner.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/scanner/StandardScanner.kt
@@ -138,7 +138,7 @@ class StandardScanner(
             try {
                 appContext.unregisterReceiver(it)
             } catch (e: IllegalArgumentException) {
-                // Receiver was not registered — log in future when logging is available
+                Log.w(TAG, "Receiver teardown skipped because it was not registered", e)
             }
             receiver = null
         }
@@ -150,7 +150,7 @@ class StandardScanner(
                     fun unregister() = wifiManager.unregisterScanResultsCallback(callback)
                     unregister()
                 } catch (e: Exception) {
-                    // Callback not registered or already unregistered — log in future when logging is available
+                    Log.w(TAG, "Scan callback teardown did not complete cleanly", e)
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR logs defensive teardown failures in StandardScanner.stop() instead of swallowing them silently.

## Why
Repo guardrails require caught exceptions to be logged. The current catch paths hide receiver/callback teardown problems that matter for on-device scanner lifecycle debugging.

## What changed
- add Log.w(...) for receiver unregister failures
- add Log.w(...) for scan callback unregister failures
- no scanner behavior changes beyond observability

## Verification
- cmd /c gradlew.bat :core:test
- cmd /c gradlew.bat :core:ktlintCheck :app:ktlintCheck
- git ls-files .env android/local.properties

## Traceability
- Made by: Copilot / Codex
- References exactly one GitHub Issue: #143
- Rules followed: one bugfix PR, no mixed dependency work, no behavior refactor, required Android checks passed

## Checklist
- [x] Made by: Copilot / Codex
- [x] References exactly one GitHub Issue
- [x] CI is green before marking Ready for Review (draft PR open first)
- [x] One feature OR one bugfix (not both)
- [x] < 200 LOC changed (tests excluded)
- [x] No new dependencies mixed in
- [x] Meaningful tests included/updated not required for this logging-only fix
- [x] Errors are logged, not silently swallowed
- [x] Documentation updated or doc issue filed
- [x] .env / local.properties NOT committed
- [x] No secrets of any kind committed
- [x] Required platform checks passed
- [x] Gemini/Vertex integration untouched
