### PR TITLE
docs: refresh session handoff after issue 10 merge

### DIFF
--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -178,7 +178,7 @@ This section is the fast re-entry point for the next Claude/Copilot session.
 
 ### Recommended next work
 
-1. Issue `#9` — add Google Maps threat heatmap and GPS-tagged scan history map on top of the stored GPS fields from merged issue `#10`
+1. Issue `#9` — add Google Maps threat heatmap and GPS-tagged scan history map on top of the stored GPS fields implemented in PR `#148` (which closed issue `#10`)
 2. Resolve the remaining Android runtime issues already tracked:
    - `#125` re-test secure-lockscreen / stronger background cases on Revvl Android 15, because non-secure HOME and screen-off did not reproduce the earlier failure on current `main`
    - `#124` align issue/docs state with current behavior: coarse-only is now blocked before service startup on current `main`


### PR DESCRIPTION
## Summary
- refresh the Android session handoff after the merged `#10` GPS/Kismet work
- remove the stale note that PR `#148` is still under review and record the merged/closed state instead
- re-order the next-work guidance so follow-on sessions pick up `#9` and the remaining runtime triage from the right baseline

## Why
- refs #121
- this keeps repo memory aligned with what actually landed on `main` and avoids future agent confusion during re-entry

## Agent Traceability
- agent: Codex/Copilot
- rules followed: one issue per PR, one open PR at a time, docs-only scope, no unrelated local files staged

## Verification
- docs-only change
- verified that the issue/PR state now recorded in the handoff matches the merged GitHub state for `#148` / `#10`