### PR TITLE
feat(desktop): companion shell + Android session artifact import

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
@@ -79,7 +79,7 @@ class ScanDataExporter(
                 obj.put("signalCount", n.signalCount)
                 obj.put("modelName", n.modelName)
                 sessionNarrativesArray.put(obj)
-                narrativesArray.put(JSONObject(obj.toString()))
+                narrativesArray.put(obj)
             }
 
             val sessionObj = JSONObject()

--- a/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
@@ -115,9 +115,10 @@ class ScanDataExporter(
     companion object {
         private const val TAG = "ScanDataExporter"
         private const val EXPORT_SESSION_LIMIT = 20
-        private val ISO_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).also {
-            it.timeZone = java.util.TimeZone.getTimeZone("UTC")
-        }
+        private val ISO_FORMAT =
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).also {
+                it.timeZone = java.util.TimeZone.getTimeZone("UTC")
+            }
         private val FILE_TIMESTAMP_FORMAT = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
     }
 }

--- a/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
@@ -32,10 +32,12 @@ class ScanDataExporter(
         val sessions = db.scanSessionDao().getRecent(EXPORT_SESSION_LIMIT)
 
         val sessionsArray = JSONArray()
+        val narrativesArray = JSONArray()
         for (session in sessions) {
             val results = db.scanResultDao().getBySession(session.id)
             val signals = db.threatSignalDao().getBySession(session.id)
             val narratives = db.geminiNarrativeDao().getBySession(session.id)
+            val latestNarrative = narratives.firstOrNull()
 
             val resultsArray = JSONArray()
             for (r in results) {
@@ -67,15 +69,17 @@ class ScanDataExporter(
                 signalsArray.put(obj)
             }
 
-            val narrativesArray = JSONArray()
+            val sessionNarrativesArray = JSONArray()
             for (n in narratives) {
                 val obj = JSONObject()
                 obj.put("id", n.id)
+                obj.put("sessionId", n.sessionId)
                 obj.put("narrative", n.narrative)
                 obj.put("generatedAt", n.generatedAt)
                 obj.put("signalCount", n.signalCount)
                 obj.put("modelName", n.modelName)
-                narrativesArray.put(obj)
+                sessionNarrativesArray.put(obj)
+                narrativesArray.put(JSONObject(obj.toString()))
             }
 
             val sessionObj = JSONObject()
@@ -84,9 +88,12 @@ class ScanDataExporter(
             sessionObj.put("endedAt", session.endedAt)
             sessionObj.put("environmentType", session.environmentType.name)
             sessionObj.put("deviceSerial", session.deviceSerial)
+            sessionObj.put("signalCount", latestNarrative?.signalCount ?: signals.size)
+            sessionObj.put("modelName", latestNarrative?.modelName ?: JSONObject.NULL)
+            sessionObj.put("narrative", latestNarrative?.narrative ?: JSONObject.NULL)
             sessionObj.put("scanResults", resultsArray)
             sessionObj.put("threatSignals", signalsArray)
-            sessionObj.put("geminiNarratives", narrativesArray)
+            sessionObj.put("geminiNarratives", sessionNarrativesArray)
             sessionsArray.put(sessionObj)
         }
 
@@ -94,6 +101,7 @@ class ScanDataExporter(
         root.put("exportedAt", ISO_FORMAT.format(Date()))
         root.put("sessionCount", sessions.size)
         root.put("sessions", sessionsArray)
+        root.put("narratives", narrativesArray)
 
         val exportsDir = File(context.cacheDir, "exports")
         exportsDir.mkdirs()

--- a/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/export/ScanDataExporter.kt
@@ -115,7 +115,9 @@ class ScanDataExporter(
     companion object {
         private const val TAG = "ScanDataExporter"
         private const val EXPORT_SESSION_LIMIT = 20
-        private val ISO_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
+        private val ISO_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).also {
+            it.timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }
         private val FILE_TIMESTAMP_FORMAT = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
     }
 }

--- a/desktop/companion.css
+++ b/desktop/companion.css
@@ -341,6 +341,49 @@ body {
   gap: 10px;
 }
 
+.session-controls,
+.session-summary-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.session-controls {
+  grid-template-columns: minmax(0, 1fr) 180px;
+}
+
+.session-summary-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.summary-pill {
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.summary-pill strong {
+  display: block;
+  font-size: 1.15rem;
+  margin-top: 6px;
+}
+
+.summary-pill[data-tone="high"] {
+  border-color: rgba(255, 123, 128, 0.38);
+}
+
+.summary-pill[data-tone="warn"] {
+  border-color: rgba(255, 196, 107, 0.34);
+}
+
+.summary-pill[data-tone="ok"] {
+  border-color: rgba(107, 227, 159, 0.34);
+}
+
+.session-filter {
+  flex: 0 0 180px;
+}
+
 .session-card {
   width: 100%;
   text-align: left;
@@ -383,6 +426,11 @@ body {
   }
 
   .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .session-controls,
+  .session-summary-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/desktop/companion.css
+++ b/desktop/companion.css
@@ -1,0 +1,388 @@
+:root {
+  color-scheme: dark;
+  --bg: #08101f;
+  --panel: rgba(10, 22, 40, 0.92);
+  --panel-alt: rgba(14, 30, 53, 0.92);
+  --border: rgba(113, 153, 255, 0.22);
+  --text: #e8eefc;
+  --muted: #99a9c8;
+  --accent: #4fc3f7;
+  --accent-strong: #1cb5ff;
+  --ok: #6be39f;
+  --warn: #ffc46b;
+  --error: #ff7b80;
+  --shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+  --radius: 24px;
+  --font-body: "Segoe UI Variable Display", "Segoe UI", sans-serif;
+  --font-mono: "Cascadia Code", "Consolas", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(28, 181, 255, 0.18), transparent 28%),
+    radial-gradient(circle at top right, rgba(91, 225, 175, 0.12), transparent 24%),
+    linear-gradient(180deg, #07101d 0%, #08101f 42%, #050a15 100%);
+  color: var(--text);
+  font-family: var(--font-body);
+}
+
+body {
+  padding: 24px;
+}
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: calc(100vh - 48px);
+}
+
+.hero,
+.panel,
+.surface {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  padding: 22px 24px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
+  gap: 20px;
+}
+
+.eyebrow {
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  margin-bottom: 10px;
+}
+
+.hero h1,
+.panel h2,
+.surface h2 {
+  margin: 0;
+  font-weight: 700;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 0.95;
+}
+
+.subcopy,
+.muted {
+  color: var(--muted);
+}
+
+.hero-actions,
+.mode-toggle,
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chip,
+.button,
+.mode-toggle button {
+  border: 1px solid rgba(113, 153, 255, 0.28);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 10px 14px;
+  font: inherit;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, rgba(28, 181, 255, 0.26), rgba(79, 195, 247, 0.12));
+}
+
+.mode-toggle button[data-active="true"] {
+  border-color: rgba(79, 195, 247, 0.8);
+  background: rgba(79, 195, 247, 0.16);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.stat strong {
+  display: block;
+  font-size: 1.45rem;
+  margin-top: 6px;
+}
+
+.workspace {
+  display: grid;
+  gap: 18px;
+}
+
+.workspace[data-layout="wide"] {
+  grid-template-columns: 1.1fr 1.2fr 0.9fr;
+}
+
+.workspace[data-layout="tablet"] {
+  grid-template-columns: 1fr 1fr;
+}
+
+.workspace[data-layout="portrait"] {
+  grid-template-columns: 1fr;
+}
+
+.panel {
+  padding: 18px;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.status-card,
+.section-card,
+.event-card {
+  padding: 16px;
+  border-radius: 20px;
+  background: var(--panel-alt);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.status-card[data-tone="ok"] {
+  border-color: rgba(107, 227, 159, 0.36);
+}
+
+.status-card[data-tone="warn"] {
+  border-color: rgba(255, 196, 107, 0.32);
+}
+
+.status-card[data-tone="error"] {
+  border-color: rgba(255, 123, 128, 0.4);
+}
+
+.keyline {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.tiny {
+  font-size: 0.84rem;
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.list {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.list li {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.list li::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), #8dc7ff);
+  flex: 0 0 auto;
+}
+
+.timeline {
+  display: grid;
+  gap: 12px;
+}
+
+.event-card time {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.event-card h3 {
+  margin: 6px 0 8px;
+  font-size: 1.02rem;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.82rem;
+}
+
+.surface {
+  padding: 16px 18px;
+}
+
+.text-area {
+  width: 100%;
+  min-height: 140px;
+  resize: vertical;
+  border-radius: 14px;
+  border: 1px solid rgba(113, 153, 255, 0.24);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text);
+  padding: 12px 14px;
+  font: inherit;
+}
+
+.field-label {
+  display: block;
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin-bottom: 8px;
+}
+
+.input-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.text-input {
+  flex: 1 1 240px;
+  min-width: 0;
+  border-radius: 14px;
+  border: 1px solid rgba(113, 153, 255, 0.24);
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text);
+  padding: 12px 14px;
+  font: inherit;
+}
+
+.text-input::placeholder {
+  color: #7f90b0;
+}
+
+.intel-card {
+  border-radius: 20px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--panel-alt);
+}
+
+.intel-card[data-tone="high"] {
+  border-color: rgba(255, 123, 128, 0.46);
+}
+
+.intel-card[data-tone="med"] {
+  border-color: rgba(255, 196, 107, 0.42);
+}
+
+.intel-card[data-tone="low"] {
+  border-color: rgba(79, 195, 247, 0.42);
+}
+
+.intel-card[data-tone="warn"] {
+  border-color: rgba(255, 196, 107, 0.42);
+}
+
+.intel-card[data-tone="muted"] {
+  border-color: rgba(153, 169, 200, 0.16);
+}
+
+.portal-signal-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.portal-signal-list li {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.session-list {
+  display: grid;
+  gap: 10px;
+}
+
+.session-card {
+  width: 100%;
+  text-align: left;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font: inherit;
+}
+
+.session-card[data-active="true"] {
+  border-color: rgba(79, 195, 247, 0.72);
+  background: rgba(79, 195, 247, 0.12);
+}
+
+.session-card[data-source="imported"] {
+  border-left: 4px solid rgba(107, 227, 159, 0.7);
+}
+
+.footer-note {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+@media (max-width: 1080px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 14px;
+  }
+
+  .shell {
+    min-height: calc(100vh - 28px);
+  }
+
+  .stats {
+    grid-template-columns: 1fr;
+  }
+}

--- a/desktop/companion.js
+++ b/desktop/companion.js
@@ -25,6 +25,8 @@ const STORAGE_KEYS = {
   selectedSessionId: 'wscanplus.desktop.selectedSessionId',
 };
 
+let macRenderTimer;
+
 function esc(s) {
   return String(s)
     .replace(/&/g, '&amp;')
@@ -402,7 +404,8 @@ function bindEvents() {
   });
   document.querySelector('#mac-intel')?.addEventListener('input', (event) => {
     state.macInput = event.target.value;
-    render();
+    clearTimeout(macRenderTimer);
+    macRenderTimer = setTimeout(() => render(), 150);
   });
   document.querySelector('#portal-variant')?.addEventListener('change', (event) => {
     state.selectedPortal = event.target.value;

--- a/desktop/companion.js
+++ b/desktop/companion.js
@@ -142,10 +142,13 @@ function persistState() {
 function hydrateState() {
   try {
     state.selectedPortal = window.localStorage.getItem(STORAGE_KEYS.selectedPortal) ?? state.selectedPortal;
-    state.selectedSessionId = Number.parseInt(
-      window.localStorage.getItem(STORAGE_KEYS.selectedSessionId) ?? String(state.selectedSessionId),
+    const parsedSessionId = Number.parseInt(
+      window.localStorage.getItem(STORAGE_KEYS.selectedSessionId) ?? '',
       10
     );
+    if (!Number.isNaN(parsedSessionId)) {
+      state.selectedSessionId = parsedSessionId;
+    }
     const intelHistory = JSON.parse(window.localStorage.getItem(STORAGE_KEYS.intelHistory) ?? '[]');
     const sessionNotes = JSON.parse(window.localStorage.getItem(STORAGE_KEYS.sessionNotes) ?? '{}');
     state.intelHistory = Array.isArray(intelHistory) ? intelHistory : [];

--- a/desktop/companion.js
+++ b/desktop/companion.js
@@ -1,0 +1,491 @@
+import { PANEL_SECTIONS, resolveLayout, summarizeDevices } from './companionModel.js';
+import { describeIntel, getMacIntel } from './ouiIntel.js';
+import { PORTAL_VARIANTS, formatScore } from './portalWorkbench.js';
+import { SAMPLE_SESSIONS, describeSession, narrativeTone, parseSessionArtifact } from './sessionWorkbench.js';
+
+const state = {
+  manualLayout: 'auto',
+  devices: [],
+  error: '',
+  refreshedAt: '',
+  macInput: '',
+  intelHistory: [],
+  sessionNotes: {},
+  selectedPortal: PORTAL_VARIANTS[0].id,
+  selectedSessionId: SAMPLE_SESSIONS[0].id,
+  importedSessions: [],
+  importedArtifactPath: '',
+  importError: '',
+};
+
+const STORAGE_KEYS = {
+  sessionNotes: 'wscanplus.desktop.sessionNotes',
+  intelHistory: 'wscanplus.desktop.intelHistory',
+  selectedPortal: 'wscanplus.desktop.selectedPortal',
+  selectedSessionId: 'wscanplus.desktop.selectedSessionId',
+};
+
+function esc(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const timelineEvents = [
+  {
+    time: 'Now',
+    title: 'Threat results companion',
+    body: 'Desktop mirrors scan narratives, investigator notes, and future export workflows without replacing the Android evidence path.',
+    badges: ['Gemini narratives', 'Session context', 'Read-only first']
+  },
+  {
+    time: 'Next',
+    title: 'Companion transport',
+    body: 'ADB device discovery is live now. Watchdog forwarding and desktop-side session views can build on the same bridge safely.',
+    badges: ['ADB', 'Local only', 'No root']
+  },
+  {
+    time: 'Later',
+    title: 'Operator workspace',
+    body: 'Wireshark, EveBox, CrowdSec, and portal/OUI tools can become sidecars rather than separate one-off windows.',
+    badges: ['Flexible layout', 'Side-by-side review', 'Field workflow']
+  }
+];
+
+function appRoot() {
+  return document.querySelector('#app');
+}
+
+function currentSummary() {
+  return summarizeDevices(state.devices, state.error);
+}
+
+function selectedLayout() {
+  return resolveLayout(window.innerWidth, state.manualLayout);
+}
+
+function renderModes(layout) {
+  return ['auto', 'portrait', 'tablet', 'wide']
+    .map((mode) => `
+      <button type="button" data-mode="${mode}" data-active="${state.manualLayout === mode}">
+        ${mode === 'auto' ? `Auto (${layout})` : mode}
+      </button>
+    `)
+    .join('');
+}
+
+function renderSection(section) {
+  return `
+    <article class="section-card">
+      <div class="eyebrow">${section.eyebrow}</div>
+      <h3>${section.title}</h3>
+      <ul class="list muted">
+        ${section.items.map((item) => `<li><span>${item}</span></li>`).join('')}
+      </ul>
+    </article>
+  `;
+}
+
+function renderTimeline() {
+  return timelineEvents
+    .map(
+      (event) => `
+        <article class="event-card">
+          <time>${event.time}</time>
+          <h3>${event.title}</h3>
+          <p class="muted">${event.body}</p>
+          <div class="badge-row">
+            ${event.badges.map((badge) => `<span class="badge">${badge}</span>`).join('')}
+          </div>
+        </article>
+      `
+    )
+    .join('');
+}
+
+function currentIntel() {
+  return describeIntel(getMacIntel(state.macInput));
+}
+
+function selectedPortalArtifact() {
+  return PORTAL_VARIANTS.find((variant) => variant.id === state.selectedPortal) ?? PORTAL_VARIANTS[0];
+}
+
+function availableSessions() {
+  return state.importedSessions.length ? state.importedSessions : SAMPLE_SESSIONS;
+}
+
+function selectedSession() {
+  const sessions = availableSessions();
+  return sessions.find((session) => session.id === state.selectedSessionId) ?? sessions[0];
+}
+
+function currentSessionNote() {
+  return state.sessionNotes[selectedSession().id] ?? '';
+}
+
+function persistState() {
+  try {
+    window.localStorage.setItem(STORAGE_KEYS.sessionNotes, JSON.stringify(state.sessionNotes));
+    window.localStorage.setItem(STORAGE_KEYS.intelHistory, JSON.stringify(state.intelHistory));
+    window.localStorage.setItem(STORAGE_KEYS.selectedPortal, state.selectedPortal);
+    window.localStorage.setItem(STORAGE_KEYS.selectedSessionId, String(state.selectedSessionId));
+  } catch {
+    // Local persistence is opportunistic in the desktop shell.
+  }
+}
+
+function hydrateState() {
+  try {
+    state.selectedPortal = window.localStorage.getItem(STORAGE_KEYS.selectedPortal) ?? state.selectedPortal;
+    state.selectedSessionId = Number.parseInt(
+      window.localStorage.getItem(STORAGE_KEYS.selectedSessionId) ?? String(state.selectedSessionId),
+      10
+    );
+    const intelHistory = JSON.parse(window.localStorage.getItem(STORAGE_KEYS.intelHistory) ?? '[]');
+    const sessionNotes = JSON.parse(window.localStorage.getItem(STORAGE_KEYS.sessionNotes) ?? '{}');
+    state.intelHistory = Array.isArray(intelHistory) ? intelHistory : [];
+    state.sessionNotes = sessionNotes && typeof sessionNotes === 'object' ? sessionNotes : {};
+  } catch {
+    state.intelHistory = [];
+    state.sessionNotes = {};
+  }
+}
+
+function renderIntelHistory() {
+  if (!state.intelHistory.length) {
+    return '<p class="muted">No recent lookups yet. Use this panel to triage MACs from Wireshark, Kismet, Fing, or Android scan notes.</p>';
+  }
+
+  return state.intelHistory
+    .map(
+      (entry) => `
+        <div class="keyline">
+          <div>
+            <div class="mono">${esc(entry.mac)}</div>
+            <div class="muted tiny">${esc(entry.headline)}</div>
+          </div>
+          <span class="badge">${esc(entry.tone)}</span>
+        </div>
+      `
+    )
+    .join('');
+}
+
+function render() {
+  const layout = selectedLayout();
+  const summary = currentSummary();
+  const intel = currentIntel();
+  const portal = selectedPortalArtifact();
+  const session = selectedSession();
+  const sessionSummary = describeSession(session);
+  const sessions = availableSessions();
+
+  appRoot().innerHTML = `
+    <div class="shell">
+      <section class="hero">
+        <div class="stack">
+          <div class="eyebrow">wscan+ companion desktop</div>
+          <h1>One operator surface for Android evidence, desktop review, and field-side layouts.</h1>
+          <p class="subcopy">
+            This companion shell is built to host the existing Android flow, ADB transport, and WebUI-style
+            analyst tools in one responsive desktop surface. It stays local-first and orientation-aware.
+          </p>
+          <div class="hero-actions">
+            <button class="button primary" id="refresh-devices" type="button">Refresh Android companions</button>
+            <span class="chip">Current layout: <strong>${layout}</strong></span>
+            <span class="chip">Last refresh: <span id="last-refresh">${state.refreshedAt || 'not yet'}</span></span>
+          </div>
+        </div>
+        <div class="stack">
+          <div class="eyebrow">View modes</div>
+          <div class="mode-toggle">${renderModes(layout)}</div>
+          <div class="stats">
+            <div class="stat">
+              <span class="muted tiny">Android companions</span>
+              <strong>${state.devices.length}</strong>
+              <span class="muted tiny">${summary.headline}</span>
+            </div>
+            <div class="stat">
+              <span class="muted tiny">Primary role</span>
+              <strong>Companion</strong>
+              <span class="muted tiny">Desktop augments Android, not replaces it.</span>
+            </div>
+            <div class="stat">
+              <span class="muted tiny">Flexible surfaces</span>
+              <strong>3</strong>
+              <span class="muted tiny">Portrait, tablet, and wide operator modes.</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <main class="workspace" data-layout="${layout}">
+        <section class="panel stack">
+          <div class="keyline">
+            <div>
+              <div class="eyebrow">Android bridge</div>
+              <h2>Companion status</h2>
+            </div>
+            <span class="chip mono">adb → tcp:9000 next</span>
+          </div>
+          <article class="status-card" data-tone="${summary.tone}">
+            <div class="keyline">
+              <strong>${esc(summary.headline)}</strong>
+              <span class="badge">${summary.tone}</span>
+            </div>
+            <p class="muted">${esc(summary.detail)}</p>
+          </article>
+          <div class="surface">
+            <div class="eyebrow">Active devices</div>
+            <div id="device-list" class="stack">
+              ${
+                state.devices.length
+                  ? state.devices
+                      .map(
+                        (serial) => `
+                          <div class="keyline">
+                            <span class="mono">${esc(serial)}</span>
+                            <span class="badge">Ready</span>
+                          </div>
+                        `
+                      )
+                      .join('')
+                  : '<p class="muted">No companion device yet. Connect a handset, emulator, or leave this shell in desktop-only review mode.</p>'
+              }
+            </div>
+          </div>
+          <div class="surface">
+            <div class="eyebrow">Integration route</div>
+            <ul class="list muted">
+              <li><span>Reuse Android session and narrative data instead of reimplementing analysis logic.</span></li>
+              <li><span>Host WebUI-style OUI, portal, and field-note tools as desktop companion panels.</span></li>
+              <li><span>Keep transport local and explicit through ADB forwarding or exported session artifacts.</span></li>
+            </ul>
+          </div>
+          <div class="surface stack">
+            <div class="keyline">
+              <div class="eyebrow">Data source</div>
+              <button class="button primary" id="import-artifact" type="button">Import session artifact</button>
+            </div>
+            <p class="muted">${state.importedArtifactPath ? `Imported from ${esc(state.importedArtifactPath)}` : 'Using built-in sample sessions until an exported JSON artifact is imported.'}</p>
+            ${state.importError ? `<p class="muted" style="color: var(--error);">${esc(state.importError)}</p>` : ''}
+          </div>
+          <div class="surface stack">
+            <div class="eyebrow">Recent sessions</div>
+            <div class="session-list">
+              ${sessions.map((entry) => {
+                const info = describeSession(entry);
+                return `
+                  <button class="session-card" data-session-id="${esc(entry.id)}" data-source="${state.importedSessions.length ? 'imported' : 'sample'}" data-active="${entry.id === session.id}">
+                    <div class="keyline">
+                      <strong>${esc(info.title)}</strong>
+                      <span class="badge">${esc(entry.status)}</span>
+                    </div>
+                    <div class="muted tiny">${esc(info.subtitle)}</div>
+                    <div class="muted tiny">${esc(info.detail)}</div>
+                  </button>
+                `;
+              }).join('')}
+            </div>
+          </div>
+        </section>
+
+        <section class="panel stack">
+          <div class="keyline">
+            <div>
+              <div class="eyebrow">Companion panels</div>
+              <h2>Flexible workspace</h2>
+            </div>
+            <span class="chip">Field-ready</span>
+          </div>
+          ${PANEL_SECTIONS.map(renderSection).join('')}
+        </section>
+
+        <section class="panel stack">
+          <div class="keyline">
+            <div>
+              <div class="eyebrow">Desktop intel</div>
+              <h2>Local MAC / OUI desk</h2>
+            </div>
+            <span class="chip">Companion-side triage</span>
+          </div>
+          <div class="surface">
+            <label class="field-label" for="mac-intel">MAC or BSSID</label>
+            <div class="input-row">
+              <input class="text-input mono" id="mac-intel" type="text" value="${esc(state.macInput)}" placeholder="24:0A:C4:11:22:33" />
+              <button class="button primary" id="save-intel" type="button">Save lookup</button>
+            </div>
+          </div>
+          <article class="intel-card" data-tone="${intel.tone}">
+            <div class="keyline">
+              <strong>${intel.headline}</strong>
+              <span class="badge">${getMacIntel(state.macInput).macProfile.prefix || 'pending'}</span>
+            </div>
+            <p class="muted">${intel.detail}</p>
+          </article>
+          <div class="surface stack">
+            <div class="eyebrow">Recent lookups</div>
+            ${renderIntelHistory()}
+          </div>
+        </section>
+
+        <section class="panel stack">
+          <div class="keyline">
+            <div>
+              <div class="eyebrow">Operator review</div>
+              <h2>Session narrative + portal</h2>
+            </div>
+            <span class="chip">${formatScore(portal.fakeScore)}</span>
+          </div>
+          <article class="intel-card" data-tone="${narrativeTone(session)}">
+            <div class="keyline">
+              <div>
+                <strong>${esc(sessionSummary.title)}</strong>
+                <div class="muted tiny">${esc(sessionSummary.subtitle)}</div>
+              </div>
+              <span class="badge">${esc(sessionSummary.detail)}</span>
+            </div>
+            <p class="muted">${esc(session.narrative)}</p>
+            <div class="quick-actions">
+              <span class="chip">Started ${esc(session.startedAt)}</span>
+              <span class="chip">Ended ${esc(session.endedAt ?? 'in progress')}</span>
+            </div>
+          </article>
+          <div class="surface stack">
+            <label class="field-label" for="portal-variant">Portal artifact</label>
+            <select class="text-input" id="portal-variant">
+              ${PORTAL_VARIANTS.map((variant) => `<option value="${variant.id}" ${variant.id === portal.id ? 'selected' : ''}>${variant.title}</option>`).join('')}
+            </select>
+            <div class="intel-card" data-tone="warn">
+              <div class="keyline">
+                <strong>${portal.title}</strong>
+                <span class="badge mono">${portal.artifactId}</span>
+              </div>
+              <p class="muted">${portal.summary}</p>
+            </div>
+            <ul class="portal-signal-list">
+              ${portal.signals.map((signal) => `<li class="muted">${signal}</li>`).join('')}
+            </ul>
+          </div>
+          <div class="surface stack">
+            <label class="field-label" for="session-notes">Notes for ${esc(sessionSummary.title)}</label>
+            <textarea class="text-area" id="session-notes" placeholder="Capture analyst notes, suspected rooms, portal observations, follow-up actions...">${esc(currentSessionNote())}</textarea>
+            <div class="quick-actions">
+              <span class="chip">Local persistence</span>
+              <span class="chip">Bound to session ${session.id}</span>
+              <span class="chip">Desktop companion context</span>
+            </div>
+          </div>
+          <div class="timeline">${renderTimeline()}</div>
+        </section>
+      </main>
+
+      <p class="footer-note">Desktop companion shell is local-first and intended to grow around the Android evidence path, not fork it.</p>
+    </div>
+  `;
+
+  bindEvents();
+}
+
+function bindEvents() {
+  document.querySelector('#refresh-devices')?.addEventListener('click', refreshDevices);
+  document.querySelector('#import-artifact')?.addEventListener('click', importArtifact);
+  document.querySelectorAll('[data-session-id]').forEach((button) => {
+    button.addEventListener('click', () => {
+      state.selectedSessionId = Number.parseInt(button.dataset.sessionId ?? String(availableSessions()[0].id), 10);
+      persistState();
+      render();
+    });
+  });
+  document.querySelector('#mac-intel')?.addEventListener('input', (event) => {
+    state.macInput = event.target.value;
+    render();
+  });
+  document.querySelector('#portal-variant')?.addEventListener('change', (event) => {
+    state.selectedPortal = event.target.value;
+    persistState();
+    render();
+  });
+  document.querySelector('#session-notes')?.addEventListener('input', (event) => {
+    state.sessionNotes = {
+      ...state.sessionNotes,
+      [selectedSession().id]: event.target.value,
+    };
+    persistState();
+  });
+  document.querySelector('#save-intel')?.addEventListener('click', () => {
+    const result = getMacIntel(state.macInput);
+    if (result.status === 'incomplete') {
+      return;
+    }
+
+    const intel = describeIntel(result);
+    state.intelHistory = [
+      {
+        mac: state.macInput.trim(),
+        tone: intel.tone,
+        headline: intel.headline,
+      },
+      ...state.intelHistory.filter((entry) => entry.mac !== state.macInput.trim()),
+    ].slice(0, 6);
+    persistState();
+    render();
+  });
+  document.querySelectorAll('[data-mode]').forEach((button) => {
+    button.addEventListener('click', () => {
+      state.manualLayout = button.dataset.mode ?? 'auto';
+      render();
+    });
+  });
+}
+
+async function refreshDevices() {
+  try {
+    const devices = await window.wscanDesktop.listAdbDevices();
+    state.devices = devices;
+    state.error = '';
+  } catch (error) {
+    state.devices = [];
+    state.error = error instanceof Error ? error.message : String(error);
+  }
+
+  state.refreshedAt = new Date().toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+
+  render();
+}
+
+async function importArtifact() {
+  try {
+    const payload = await window.wscanDesktop.importSessionArtifact();
+    if (!payload) {
+      return;
+    }
+
+    const sessions = parseSessionArtifact(payload.raw);
+    state.importedSessions = sessions;
+    state.importedArtifactPath = payload.filePath;
+    state.importError = '';
+    state.selectedSessionId = sessions[0].id;
+    persistState();
+  } catch (error) {
+    state.importError = error instanceof Error ? error.message : String(error);
+  }
+
+  render();
+}
+
+window.addEventListener('resize', () => {
+  if (state.manualLayout === 'auto') {
+    render();
+  }
+});
+
+hydrateState();
+render();
+refreshDevices();

--- a/desktop/companion.js
+++ b/desktop/companion.js
@@ -424,13 +424,13 @@ function render() {
             </select>
             <div class="intel-card" data-tone="warn">
               <div class="keyline">
-                <strong>${portal.title}</strong>
-                <span class="badge mono">${portal.artifactId}</span>
+                <strong>${esc(portal.title)}</strong>
+                <span class="badge mono">${esc(portal.artifactId)}</span>
               </div>
-              <p class="muted">${portal.summary}</p>
+              <p class="muted">${esc(portal.summary)}</p>
             </div>
             <ul class="portal-signal-list">
-              ${portal.signals.map((signal) => `<li class="muted">${signal}</li>`).join('')}
+              ${portal.signals.map((signal) => `<li class="muted">${esc(signal)}</li>`).join('')}
             </ul>
           </div>
           <div class="surface stack">

--- a/desktop/companion.js
+++ b/desktop/companion.js
@@ -1,7 +1,14 @@
 import { PANEL_SECTIONS, resolveLayout, summarizeDevices } from './companionModel.js';
 import { describeIntel, getMacIntel } from './ouiIntel.js';
 import { PORTAL_VARIANTS, formatScore } from './portalWorkbench.js';
-import { SAMPLE_SESSIONS, describeSession, narrativeTone, parseSessionArtifact } from './sessionWorkbench.js';
+import {
+  SAMPLE_SESSIONS,
+  describeSession,
+  narrativeTone,
+  parseSessionArtifact,
+  summarizeSessions,
+  matchesSessionQuery,
+} from './sessionWorkbench.js';
 
 const state = {
   manualLayout: 'auto',
@@ -16,6 +23,8 @@ const state = {
   importedSessions: [],
   importedArtifactPath: '',
   importError: '',
+  sessionQuery: '',
+  sessionStatusFilter: 'all',
 };
 
 const STORAGE_KEYS = {
@@ -124,6 +133,18 @@ function selectedSession() {
   return sessions.find((session) => session.id === state.selectedSessionId) ?? sessions[0];
 }
 
+function visibleSessions() {
+  const sessions = availableSessions().filter((session) =>
+    matchesSessionQuery(session, state.sessionQuery, state.sessionStatusFilter)
+  );
+
+  if (sessions.length) {
+    return sessions;
+  }
+
+  return availableSessions();
+}
+
 function currentSessionNote() {
   return state.sessionNotes[selectedSession().id] ?? '';
 }
@@ -186,7 +207,8 @@ function render() {
   const portal = selectedPortalArtifact();
   const session = selectedSession();
   const sessionSummary = describeSession(session);
-  const sessions = availableSessions();
+  const sessions = visibleSessions();
+  const sessionStats = summarizeSessions(availableSessions());
 
   appRoot().innerHTML = `
     <div class="shell">
@@ -280,6 +302,42 @@ function render() {
           </div>
           <div class="surface stack">
             <div class="eyebrow">Recent sessions</div>
+            <div class="session-summary-grid">
+              <div class="summary-pill">
+                <span class="muted tiny">Total</span>
+                <strong>${sessionStats.total}</strong>
+              </div>
+              <div class="summary-pill" data-tone="high">
+                <span class="muted tiny">Suspect</span>
+                <strong>${sessionStats.suspect}</strong>
+              </div>
+              <div class="summary-pill" data-tone="warn">
+                <span class="muted tiny">Review</span>
+                <strong>${sessionStats.review}</strong>
+              </div>
+              <div class="summary-pill" data-tone="ok">
+                <span class="muted tiny">Signals</span>
+                <strong>${sessionStats.signals}</strong>
+              </div>
+            </div>
+            <div class="session-controls">
+              <input
+                class="text-input"
+                id="session-query"
+                type="text"
+                value="${esc(state.sessionQuery)}"
+                placeholder="Search by environment, serial, narrative, or id"
+              />
+              <select class="text-input session-filter" id="session-status-filter">
+                <option value="all" ${state.sessionStatusFilter === 'all' ? 'selected' : ''}>All statuses</option>
+                <option value="suspect" ${state.sessionStatusFilter === 'suspect' ? 'selected' : ''}>Suspect</option>
+                <option value="review" ${state.sessionStatusFilter === 'review' ? 'selected' : ''}>Review</option>
+                <option value="clear" ${state.sessionStatusFilter === 'clear' ? 'selected' : ''}>Clear</option>
+              </select>
+            </div>
+            <div class="muted tiny">
+              Showing ${sessions.length} of ${availableSessions().length} sessions
+            </div>
             <div class="session-list">
               ${sessions.map((entry) => {
                 const info = describeSession(entry);
@@ -413,6 +471,14 @@ function bindEvents() {
   document.querySelector('#portal-variant')?.addEventListener('change', (event) => {
     state.selectedPortal = event.target.value;
     persistState();
+    render();
+  });
+  document.querySelector('#session-query')?.addEventListener('input', (event) => {
+    state.sessionQuery = event.target.value;
+    render();
+  });
+  document.querySelector('#session-status-filter')?.addEventListener('change', (event) => {
+    state.sessionStatusFilter = event.target.value;
     render();
   });
   document.querySelector('#session-notes')?.addEventListener('input', (event) => {

--- a/desktop/companionModel.js
+++ b/desktop/companionModel.js
@@ -1,0 +1,72 @@
+export const PANEL_SECTIONS = [
+  {
+    id: 'companion',
+    title: 'Phone Companion',
+    eyebrow: 'Android sync',
+    items: [
+      'Mirror recent scan sessions and Gemini narratives.',
+      'Launch session detail, threat results, and consent state checks.',
+      'Prepare the desktop for ADB transport on demand.'
+    ]
+  },
+  {
+    id: 'analysis',
+    title: 'Analyst Console',
+    eyebrow: 'Desktop workflow',
+    items: [
+      'Pin threat narratives, RF notes, and OUI vendor context side by side.',
+      'Keep Wireshark, EveBox, CrowdSec, and field notes in one operator view.',
+      'Surface fast summaries before the deeper Android evidence trail.'
+    ]
+  },
+  {
+    id: 'field',
+    title: 'Field Layouts',
+    eyebrow: 'Orientation aware',
+    items: [
+      'Portrait for tablet-on-desk and phone-emulation views.',
+      'Tablet for split-pane review while tethered or traveling.',
+      'Wide for full operator console and evidence comparison.'
+    ]
+  }
+];
+
+export function resolveLayout(width, selectedMode = 'auto') {
+  if (selectedMode !== 'auto') {
+    return selectedMode;
+  }
+
+  if (width < 760) {
+    return 'portrait';
+  }
+
+  if (width < 1180) {
+    return 'tablet';
+  }
+
+  return 'wide';
+}
+
+export function summarizeDevices(devices = [], error = '') {
+  if (error) {
+    return {
+      tone: 'error',
+      headline: 'ADB unavailable',
+      detail: error
+    };
+  }
+
+  if (!devices.length) {
+    return {
+      tone: 'warn',
+      headline: 'No Android devices connected',
+      detail: 'Attach a phone or emulator, then refresh the companion link.'
+    };
+  }
+
+  return {
+    tone: 'ok',
+    headline: `${devices.length} Android companion${devices.length === 1 ? '' : 's'} ready`,
+    detail: devices.join(', ')
+  };
+}

--- a/desktop/companionModel.test.js
+++ b/desktop/companionModel.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveLayout, summarizeDevices } from './companionModel.js';
+
+test('resolveLayout maps narrow widths to portrait in auto mode', () => {
+  assert.equal(resolveLayout(640, 'auto'), 'portrait');
+});
+
+test('resolveLayout maps medium widths to tablet in auto mode', () => {
+  assert.equal(resolveLayout(900, 'auto'), 'tablet');
+});
+
+test('resolveLayout maps wide widths to wide in auto mode', () => {
+  assert.equal(resolveLayout(1440, 'auto'), 'wide');
+});
+
+test('resolveLayout respects manual layout override', () => {
+  assert.equal(resolveLayout(640, 'wide'), 'wide');
+});
+
+test('summarizeDevices returns warning summary when no devices are connected', () => {
+  assert.deepEqual(summarizeDevices([]), {
+    tone: 'warn',
+    headline: 'No Android devices connected',
+    detail: 'Attach a phone or emulator, then refresh the companion link.'
+  });
+});
+
+test('summarizeDevices returns ok summary when devices are connected', () => {
+  assert.deepEqual(summarizeDevices(['R58M123ABC']), {
+    tone: 'ok',
+    headline: '1 Android companion ready',
+    detail: 'R58M123ABC'
+  });
+});
+
+test('summarizeDevices surfaces adb errors explicitly', () => {
+  assert.deepEqual(summarizeDevices([], 'adb server not running'), {
+    tone: 'error',
+    headline: 'ADB unavailable',
+    detail: 'adb server not running'
+  });
+});

--- a/desktop/eslint.config.mjs
+++ b/desktop/eslint.config.mjs
@@ -26,6 +26,16 @@ export default [
     rules: {},
   },
   {
+    files: ["companion.js", "preload.js"],
+    languageOptions: {
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        localStorage: "readonly",
+      },
+    },
+  },
+  {
     ignores: ["node_modules/", "dist/"],
   },
 ];

--- a/desktop/eslint.config.mjs
+++ b/desktop/eslint.config.mjs
@@ -20,6 +20,7 @@ export default [
         jest: "readonly",
         Buffer: "readonly",
         setTimeout: "readonly",
+        clearTimeout: "readonly",
         ReadableStream: "readonly",
       },
     },

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -19,9 +19,7 @@
     </style>
   </head>
   <body>
-    <div class="wrapper">
-      <h1>wscan+ Desktop</h1>
-      <p>Placeholder UI — replace with renderer app.</p>
-    </div>
+    <div id="app"></div>
+    <script type="module" src="companion.js"></script>
   </body>
 </html>

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,19 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>wscan+ Desktop</title>
-    <style>
-      body {
-        margin: 0;
-        font-family: Arial, sans-serif;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 100vh;
-      }
-      .wrapper {
-        text-align: center;
-      }
-    </style>
+    <link rel="stylesheet" href="companion.css" />
   </head>
   <body>
     <div id="app"></div>

--- a/desktop/jest.config.mjs
+++ b/desktop/jest.config.mjs
@@ -1,4 +1,5 @@
 export default {
   testEnvironment: "node",
   transform: {},
+  testMatch: ["**/adb/**/*.test.js"],
 };

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -46,7 +46,8 @@ function createWindow() {
     height: 600,
     webPreferences: {
       contextIsolation: true,
-      nodeIntegration: false
+      nodeIntegration: false,
+      preload: join(__dirname, 'preload.js'),
     }
   });
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,6 +1,7 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import { AdbTransport } from './adb/AdbTransport.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -57,6 +58,22 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  ipcMain.handle('adb:listDevices', async () => {
+    if (!adbTransport) return [];
+    return adbTransport.listDevices();
+  });
+
+  ipcMain.handle('sessions:importArtifact', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+    });
+    if (canceled || filePaths.length === 0) return null;
+    const filePath = filePaths[0];
+    const raw = readFileSync(filePath, 'utf8');
+    return { raw, filePath };
+  });
+
   createWindow();
   void initAdbTransport();
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog } from 'electron';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { AdbTransport } from './adb/AdbTransport.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -70,7 +70,7 @@ app.whenReady().then(() => {
     });
     if (canceled || filePaths.length === 0) return null;
     const filePath = filePaths[0];
-    const raw = readFileSync(filePath, 'utf8');
+    const raw = await readFile(filePath, 'utf8');
     return { raw, filePath };
   });
 

--- a/desktop/ouiIntel.js
+++ b/desktop/ouiIntel.js
@@ -1,0 +1,98 @@
+const OUI_DB = {
+  '600194': { vendor: 'Espressif Deauther', type: 'Attack Tool', threat: 'HIGH' },
+  '2462AB': { vendor: 'Espressif Deauther', type: 'Attack Tool', threat: 'HIGH' },
+  '240AC4': { vendor: 'Espressif Systems', type: 'Spy Cam Chip', threat: 'HIGH' },
+  '30AEA4': { vendor: 'Espressif Systems', type: 'Spy Cam Chip', threat: 'HIGH' },
+  '3CEF8C': { vendor: 'Dahua Technology', type: 'CCTV Brand', threat: 'HIGH' },
+  'C056E3': { vendor: 'Hikvision', type: 'CCTV Brand', threat: 'HIGH' },
+  '40CBC0': { vendor: 'Apple AirTag', type: 'BLE Tracker', threat: 'HIGH' },
+  '087CBE': { vendor: 'Tile Inc', type: 'BLE Tracker', threat: 'HIGH' },
+  '94A3DA': { vendor: 'Samsung SmartTag', type: 'BLE Tracker', threat: 'HIGH' },
+  'EC71DB': { vendor: 'Reolink', type: 'IP Camera', threat: 'MED' },
+  '001DB5': { vendor: 'Axis Comm', type: 'IP Camera', threat: 'MED' },
+  '00E04C': { vendor: 'Realtek', type: 'WiFi Chip', threat: 'MED' },
+  '1802F3': { vendor: 'Tuya Smart', type: 'IoT Device', threat: 'MED' },
+  'DCA632': { vendor: 'Raspberry Pi', type: 'Dev Board', threat: 'LOW' },
+  '50C7BF': { vendor: 'TP-Link', type: 'Router', threat: 'LOW' },
+  '18D6C7': { vendor: 'Apple', type: 'Router/AP', threat: 'LOW' },
+  '40B4CD': { vendor: 'Google Pixel', type: 'Mobile', threat: 'LOW' },
+  'F8A9D0': { vendor: 'Samsung', type: 'Mobile', threat: 'LOW' },
+};
+
+export function normalizeMac(mac = '') {
+  return mac.replace(/[^A-Fa-f0-9]/g, '').toUpperCase();
+}
+
+export function getMacProfile(mac = '') {
+  const normalized = normalizeMac(mac);
+  if (normalized.length < 2) {
+    return { normalized, prefix: normalized.slice(0, 6), isLocallyAdministered: false };
+  }
+
+  const firstOctet = Number.parseInt(normalized.slice(0, 2), 16);
+  return {
+    normalized,
+    prefix: normalized.slice(0, 6),
+    isLocallyAdministered: !Number.isNaN(firstOctet) && (firstOctet & 0x02) === 0x02,
+  };
+}
+
+export function lookupOui(mac = '') {
+  const prefix = normalizeMac(mac).slice(0, 6);
+  if (prefix.length < 6) {
+    return null;
+  }
+
+  return OUI_DB[prefix] ?? null;
+}
+
+export function getMacIntel(mac = '') {
+  const macProfile = getMacProfile(mac);
+  const oui = lookupOui(mac);
+
+  if (oui) {
+    return { status: 'known', oui, macProfile };
+  }
+
+  if (macProfile.normalized.length < 6) {
+    return { status: 'incomplete', oui: null, macProfile };
+  }
+
+  if (macProfile.isLocallyAdministered) {
+    return { status: 'private', oui: null, macProfile };
+  }
+
+  return { status: 'unknown', oui: null, macProfile };
+}
+
+export function describeIntel(result) {
+  if (result.status === 'known') {
+    return {
+      tone: result.oui.threat.toLowerCase(),
+      headline: result.oui.vendor,
+      detail: `${result.oui.type} · ${result.oui.threat} confidence bucket`,
+    };
+  }
+
+  if (result.status === 'private') {
+    return {
+      tone: 'warn',
+      headline: 'Private / randomized MAC',
+      detail: 'Likely client privacy rotation rather than a missing public OUI.',
+    };
+  }
+
+  if (result.status === 'unknown') {
+    return {
+      tone: 'muted',
+      headline: 'Unknown vendor',
+      detail: 'No curated OUI match in the local reference set.',
+    };
+  }
+
+  return {
+    tone: 'muted',
+    headline: 'Enter at least 6 hex characters',
+    detail: 'A full OUI prefix is needed before local classification is meaningful.',
+  };
+}

--- a/desktop/ouiIntel.test.js
+++ b/desktop/ouiIntel.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { describeIntel, getMacIntel, lookupOui, normalizeMac } from './ouiIntel.js';
+
+test('normalizeMac strips separators and uppercases the value', () => {
+  assert.equal(normalizeMac('24:0a:c4-aa.bb'), '240AC4AABB');
+});
+
+test('lookupOui returns curated vendor data for known prefixes', () => {
+  assert.deepEqual(lookupOui('24:0A:C4:11:22:33'), {
+    vendor: 'Espressif Systems',
+    type: 'Spy Cam Chip',
+    threat: 'HIGH',
+  });
+});
+
+test('getMacIntel classifies locally administered addresses as private', () => {
+  const intel = getMacIntel('DA:11:22:33:44:55');
+  assert.equal(intel.status, 'private');
+  assert.equal(intel.macProfile.isLocallyAdministered, true);
+});
+
+test('describeIntel returns analyst-facing copy for known OUIs', () => {
+  assert.deepEqual(describeIntel(getMacIntel('40:CB:C0:11:22:33')), {
+    tone: 'high',
+    headline: 'Apple AirTag',
+    detail: 'BLE Tracker · HIGH confidence bucket',
+  });
+});

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -539,6 +539,40 @@
         "global-agent": "^3.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -1214,6 +1248,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1327,6 +1374,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1599,6 +1657,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1613,6 +1674,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1627,6 +1691,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1641,6 +1708,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1655,6 +1725,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1669,6 +1742,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1683,6 +1759,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,6 +1776,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5516,6 +5598,14 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -194,23 +194,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -537,40 +537,6 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1248,19 +1214,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1324,9 +1277,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1354,9 +1307,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.0.tgz",
+      "integrity": "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1374,17 +1327,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2109,9 +2051,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2131,9 +2073,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2142,9 +2084,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2162,11 +2104,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2252,9 +2194,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001779",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
-      "integrity": "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==",
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
       "dev": true,
       "funding": [
         {
@@ -2629,9 +2571,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.313",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3229,9 +3171,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5574,14 +5516,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "start": "electron .",
     "lint": "eslint . --max-warnings=0",
-    "format": "prettier --write .",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --passWithNoTests"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --passWithNoTests && node --test companionModel.test.js ouiIntel.test.js portalWorkbench.test.js sessionWorkbench.test.js"
   },
   "dependencies": {
     "@yume-chan/adb": "2.5.1",

--- a/desktop/portalWorkbench.js
+++ b/desktop/portalWorkbench.js
@@ -1,0 +1,34 @@
+export const PORTAL_VARIANTS = [
+  {
+    id: 'operator-generic',
+    title: 'Operator-class captive portal',
+    artifactId: 'wscanplus-portal-test-001',
+    fakeScore: 0.96,
+    summary: 'Generic ISP-style portal artifact used to validate fake-versus-real portal analysis without copying a real provider brand.',
+    signals: [
+      'data-wscanplus-artifact present on <html>',
+      'POSTs credentials or guest acceptance to /capture',
+      'Password field uses type=text instead of type=password',
+      'No CSRF token or server session token in the form',
+      'No redirect_uri or MAC hint fields',
+      'Expected local-IP serving context instead of an operator domain',
+      'Generic terms without operator identity or support details',
+    ],
+  },
+  {
+    id: 'future-apartment',
+    title: 'Future apartment / library variants',
+    artifactId: 'pending-variant-family',
+    fakeScore: 0.96,
+    summary: 'Follow the same detection contract: preserve wscanplus fingerprint markers while shifting only the visual class.',
+    signals: [
+      'Keep fingerprint JSON and data-wscanplus attributes intact',
+      'Keep /capture endpoint and device analytics payload',
+      'Only change visual class, not truth-model semantics',
+    ],
+  },
+];
+
+export function formatScore(score) {
+  return `${Math.round(score * 100)}% fake confidence`;
+}

--- a/desktop/portalWorkbench.test.js
+++ b/desktop/portalWorkbench.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { PORTAL_VARIANTS, formatScore } from './portalWorkbench.js';
+
+test('portal variants expose at least one operator-class artifact', () => {
+  assert.equal(PORTAL_VARIANTS[0].id, 'operator-generic');
+  assert.equal(PORTAL_VARIANTS[0].artifactId, 'wscanplus-portal-test-001');
+  assert.ok(PORTAL_VARIANTS[0].signals.length > 3);
+});
+
+test('formatScore returns a percent string', () => {
+  assert.equal(formatScore(0.96), '96% fake confidence');
+});

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,6 +1,19 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('wscanDesktop', {
-  listAdbDevices: () => ipcRenderer.invoke('adb:listDevices'),
-  importSessionArtifact: () => ipcRenderer.invoke('sessions:importArtifact'),
+  // NOTE: These functions currently do not call into ipcMain because no
+  // corresponding ipcMain.handle handlers are registered in the main process.
+  // They return rejected Promises to avoid invoking non-existent channels.
+  listAdbDevices: () =>
+    Promise.reject(
+      new Error(
+        'ADB device listing is not available: no ipcMain handler is registered for "adb:listDevices".',
+      ),
+    ),
+  importSessionArtifact: () =>
+    Promise.reject(
+      new Error(
+        'Session artifact import is not available: no ipcMain handler is registered for "sessions:importArtifact".',
+      ),
+    ),
 });

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,19 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('wscanDesktop', {
-  // NOTE: These functions currently do not call into ipcMain because no
-  // corresponding ipcMain.handle handlers are registered in the main process.
-  // They return rejected Promises to avoid invoking non-existent channels.
-  listAdbDevices: () =>
-    Promise.reject(
-      new Error(
-        'ADB device listing is not available: no ipcMain handler is registered for "adb:listDevices".',
-      ),
-    ),
-  importSessionArtifact: () =>
-    Promise.reject(
-      new Error(
-        'Session artifact import is not available: no ipcMain handler is registered for "sessions:importArtifact".',
-      ),
-    ),
+  listAdbDevices: () => ipcRenderer.invoke('adb:listDevices'),
+  importSessionArtifact: () => ipcRenderer.invoke('sessions:importArtifact'),
 });

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('wscanDesktop', {
+  listAdbDevices: () => ipcRenderer.invoke('adb:listDevices'),
+  importSessionArtifact: () => ipcRenderer.invoke('sessions:importArtifact'),
+});

--- a/desktop/sessionWorkbench.js
+++ b/desktop/sessionWorkbench.js
@@ -135,3 +135,46 @@ export function narrativeTone(session) {
 
   return 'ok';
 }
+
+export function summarizeSessions(sessions = []) {
+  return sessions.reduce(
+    (summary, session) => {
+      summary.total += 1;
+      summary.signals += session.signalCount ?? 0;
+      if (session.status === 'suspect') {
+        summary.suspect += 1;
+      } else if (session.status === 'review') {
+        summary.review += 1;
+      } else {
+        summary.clear += 1;
+      }
+      return summary;
+    },
+    { total: 0, suspect: 0, review: 0, clear: 0, signals: 0 }
+  );
+}
+
+export function matchesSessionQuery(session, query = '', status = 'all') {
+  if (status !== 'all' && session.status !== status) {
+    return false;
+  }
+
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return true;
+  }
+
+  const haystack = [
+    session.id,
+    session.environmentType,
+    session.deviceSerial,
+    session.modelName,
+    session.narrative,
+    session.startedAt,
+    session.endedAt ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  return haystack.includes(trimmed);
+}

--- a/desktop/sessionWorkbench.js
+++ b/desktop/sessionWorkbench.js
@@ -85,18 +85,16 @@ export function parseSessionArtifact(raw) {
     throw new Error('Artifact must contain a sessions array.');
   }
 
-  const narrativeBySession = new Map(
-    narratives
-      .filter((item) => typeof item?.sessionId === 'number')
-      .map((item) => [
-        item.sessionId,
-        {
-          narrative: item.narrative,
-          modelName: item.modelName,
-          signalCount: item.signalCount,
-        },
-      ])
-  );
+  const narrativeBySession = new Map();
+  for (const item of narratives) {
+    if (typeof item?.sessionId === 'number' && !narrativeBySession.has(item.sessionId)) {
+      narrativeBySession.set(item.sessionId, {
+        narrative: item.narrative,
+        modelName: item.modelName,
+        signalCount: item.signalCount,
+      });
+    }
+  }
 
   const normalized = sessions
     .filter(

--- a/desktop/sessionWorkbench.js
+++ b/desktop/sessionWorkbench.js
@@ -1,0 +1,137 @@
+export const SAMPLE_SESSIONS = [
+  {
+    id: 104,
+    startedAt: '2026-04-01 09:18',
+    endedAt: '2026-04-01 09:26',
+    environmentType: 'MULTI_UNIT_HOUSING',
+    deviceSerial: 'android-lab-01',
+    signalCount: 4,
+    modelName: 'gemini-2.5-flash',
+    narrative:
+      'Likely surveillance pressure near the entry corridor. Repeated ESPressif-class identifiers and one tracker-like BLE pattern justify a room-by-room physical follow-up.',
+    status: 'suspect',
+  },
+  {
+    id: 103,
+    startedAt: '2026-04-01 08:41',
+    endedAt: '2026-04-01 08:47',
+    environmentType: 'COFFEE_SHOP',
+    deviceSerial: 'android-lab-01',
+    signalCount: 0,
+    modelName: 'gemini-2.5-flash',
+    narrative:
+      'No persistent threat pattern stood out. The strongest signals resembled ordinary client rotation and shared hotspot churn rather than targeted surveillance behavior.',
+    status: 'clear',
+  },
+  {
+    id: 102,
+    startedAt: '2026-03-31 22:06',
+    endedAt: '2026-03-31 22:15',
+    environmentType: 'HOTEL',
+    deviceSerial: 'android-lab-02',
+    signalCount: 2,
+    modelName: 'gemini-2.5-flash',
+    narrative:
+      'Portal and RF conditions were mixed. The session should be paired with portal artifact review before escalation because the confidence is moderate rather than decisive.',
+    status: 'review',
+  },
+];
+
+function deriveStatus(signalCount) {
+  if (signalCount >= 3) {
+    return 'suspect';
+  }
+
+  if (signalCount > 0) {
+    return 'review';
+  }
+
+  return 'clear';
+}
+
+function normalizeImportedSession(session, narrativeBySession) {
+  const narrative = narrativeBySession.get(session.id) ?? {};
+  return {
+    id: session.id,
+    startedAt: formatTimestamp(session.startedAt),
+    endedAt: formatTimestamp(session.endedAt),
+    environmentType: session.environmentType,
+    deviceSerial: session.deviceSerial,
+    signalCount: narrative.signalCount ?? session.signalCount ?? 0,
+    modelName: narrative.modelName ?? session.modelName ?? 'gemini-2.5-flash',
+    narrative: narrative.narrative ?? session.narrative ?? 'No Gemini narrative stored for this session yet.',
+    status: session.status ?? deriveStatus(narrative.signalCount ?? session.signalCount ?? 0),
+  };
+}
+
+export function formatTimestamp(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return new Date(value).toISOString().slice(0, 16).replace('T', ' ');
+  }
+
+  return String(value);
+}
+
+export function parseSessionArtifact(raw) {
+  const parsed = JSON.parse(raw);
+  const sessions = Array.isArray(parsed) ? parsed : parsed.sessions;
+  const narratives = Array.isArray(parsed?.narratives) ? parsed.narratives : [];
+
+  if (!Array.isArray(sessions)) {
+    throw new Error('Artifact must contain a sessions array.');
+  }
+
+  const narrativeBySession = new Map(
+    narratives
+      .filter((item) => typeof item?.sessionId === 'number')
+      .map((item) => [
+        item.sessionId,
+        {
+          narrative: item.narrative,
+          modelName: item.modelName,
+          signalCount: item.signalCount,
+        },
+      ])
+  );
+
+  const normalized = sessions
+    .filter(
+      (session) =>
+        typeof session?.id === 'number' &&
+        typeof session?.startedAt !== 'undefined' &&
+        typeof session?.environmentType === 'string' &&
+        typeof session?.deviceSerial === 'string'
+    )
+    .map((session) => normalizeImportedSession(session, narrativeBySession))
+    .sort((a, b) => String(b.startedAt).localeCompare(String(a.startedAt)));
+
+  if (!normalized.length) {
+    throw new Error('Artifact did not contain any valid scan sessions.');
+  }
+
+  return normalized;
+}
+
+export function describeSession(session) {
+  return {
+    title: `Session ${session.id}`,
+    subtitle: `${session.environmentType} · ${session.deviceSerial}`,
+    detail: `${session.signalCount} signal${session.signalCount === 1 ? '' : 's'} · ${session.modelName}`,
+  };
+}
+
+export function narrativeTone(session) {
+  if (session.status === 'suspect') {
+    return 'high';
+  }
+
+  if (session.status === 'review') {
+    return 'warn';
+  }
+
+  return 'ok';
+}

--- a/desktop/sessionWorkbench.test.js
+++ b/desktop/sessionWorkbench.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { SAMPLE_SESSIONS, describeSession, narrativeTone, parseSessionArtifact } from './sessionWorkbench.js';
+
+test('sample sessions reflect scan session ids and narrative fields', () => {
+  assert.equal(typeof SAMPLE_SESSIONS[0].id, 'number');
+  assert.equal(typeof SAMPLE_SESSIONS[0].narrative, 'string');
+  assert.equal(typeof SAMPLE_SESSIONS[0].signalCount, 'number');
+});
+
+test('describeSession returns an operator-facing summary', () => {
+  assert.deepEqual(describeSession(SAMPLE_SESSIONS[0]), {
+    title: 'Session 104',
+    subtitle: 'MULTI_UNIT_HOUSING · android-lab-01',
+    detail: '4 signals · gemini-2.5-flash',
+  });
+});
+
+test('narrativeTone maps session status to display tone', () => {
+  assert.equal(narrativeTone(SAMPLE_SESSIONS[0]), 'high');
+  assert.equal(narrativeTone(SAMPLE_SESSIONS[1]), 'ok');
+  assert.equal(narrativeTone(SAMPLE_SESSIONS[2]), 'warn');
+});
+
+test('parseSessionArtifact normalizes sessions plus narratives from exported JSON', () => {
+  const sessions = parseSessionArtifact(
+    JSON.stringify({
+      sessions: [
+        {
+          id: 7,
+          startedAt: 1775047560000,
+          endedAt: 1775047860000,
+          environmentType: 'HOTEL',
+          deviceSerial: 'android-lab-03',
+        },
+      ],
+      narratives: [
+        {
+          sessionId: 7,
+          narrative: 'Review front-desk portal conditions.',
+          generatedAt: 1775047900000,
+          signalCount: 2,
+          modelName: 'gemini-2.5-flash',
+        },
+      ],
+    })
+  );
+
+  assert.deepEqual(sessions[0], {
+    id: 7,
+    startedAt: '2026-04-01 12:46',
+    endedAt: '2026-04-01 12:51',
+    environmentType: 'HOTEL',
+    deviceSerial: 'android-lab-03',
+    signalCount: 2,
+    modelName: 'gemini-2.5-flash',
+    narrative: 'Review front-desk portal conditions.',
+    status: 'review',
+  });
+});
+
+test('parseSessionArtifact rejects invalid artifact shapes', () => {
+  assert.throws(() => parseSessionArtifact(JSON.stringify({ nope: [] })), /sessions array/);
+});

--- a/desktop/sessionWorkbench.test.js
+++ b/desktop/sessionWorkbench.test.js
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { SAMPLE_SESSIONS, describeSession, narrativeTone, parseSessionArtifact } from './sessionWorkbench.js';
+import {
+  SAMPLE_SESSIONS,
+  describeSession,
+  narrativeTone,
+  parseSessionArtifact,
+  summarizeSessions,
+  matchesSessionQuery,
+} from './sessionWorkbench.js';
 
 test('sample sessions reflect scan session ids and narrative fields', () => {
   assert.equal(typeof SAMPLE_SESSIONS[0].id, 'number');
@@ -61,4 +68,21 @@ test('parseSessionArtifact normalizes sessions plus narratives from exported JSO
 
 test('parseSessionArtifact rejects invalid artifact shapes', () => {
   assert.throws(() => parseSessionArtifact(JSON.stringify({ nope: [] })), /sessions array/);
+});
+
+test('summarizeSessions totals session statuses and signal counts', () => {
+  assert.deepEqual(summarizeSessions(SAMPLE_SESSIONS), {
+    total: 3,
+    suspect: 1,
+    review: 1,
+    clear: 1,
+    signals: 6,
+  });
+});
+
+test('matchesSessionQuery filters by query and status', () => {
+  assert.equal(matchesSessionQuery(SAMPLE_SESSIONS[0], 'corridor', 'all'), true);
+  assert.equal(matchesSessionQuery(SAMPLE_SESSIONS[1], 'corridor', 'all'), false);
+  assert.equal(matchesSessionQuery(SAMPLE_SESSIONS[2], '', 'review'), true);
+  assert.equal(matchesSessionQuery(SAMPLE_SESSIONS[2], '', 'suspect'), false);
 });


### PR DESCRIPTION
## Summary
- Wire `preload.js` into `BrowserWindow` so `window.wscanDesktop` is exposed and the companion shell actually boots
- Replace placeholder `index.html` with `#app` mount + `companion.js` module entry point
- Add full companion renderer: ADB status, session list, MAC/OUI desk, narrative + portal workbench, operator notes, layout modes
- Add `esc()` on all external interpolations in `companion.js` (imported artifact fields, ADB serials, file paths, user input) — fixes P1 innerHTML injection finding
- Add `preload.js`, `companionModel.js`, `ouiIntel.js`, `portalWorkbench.js`, `sessionWorkbench.js`, `companion.css` and their test files (18 tests)
- Android: `ScanDataExporter.kt` — serializes 20 most recent sessions (scan results, threat signals, Gemini narratives) to encrypted-DB-sourced JSON in app cache dir
- Remove dead `jest` dep (runner is `node:test`), remove unused `format` script, fix `brace-expansion` moderate CVE

## Test plan
- [ ] `npm test` in `desktop/` — 18/18 pass
- [ ] `npm run lint` in `desktop/` — 0 warnings
- [ ] `./gradlew :core:test` in `android/` — passes
- [ ] `./gradlew :app:compileDebugKotlin` in `android/` — passes
- [ ] Electron window loads companion shell (not placeholder) after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)