### PR TITLE
fix(desktop): add sandbox: false to enable ESM preload bridge

### DIFF
--- a/desktop/companion.js
+++ b/desktop/companion.js
@@ -201,6 +201,10 @@ function renderIntelHistory() {
 }
 
 function render() {
+  const focusedId = document.activeElement?.id || null;
+  const selectionStart = document.activeElement?.selectionStart ?? null;
+  const selectionEnd = document.activeElement?.selectionEnd ?? null;
+
   const layout = selectedLayout();
   const summary = currentSummary();
   const intel = currentIntel();
@@ -451,6 +455,14 @@ function render() {
   `;
 
   bindEvents();
+
+  if (focusedId) {
+    const el = document.getElementById(focusedId);
+    if (el) {
+      el.focus();
+      if (selectionStart !== null) el.setSelectionRange(selectionStart, selectionEnd);
+    }
+  }
 }
 
 function bindEvents() {

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -48,6 +48,7 @@ function createWindow() {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
+      sandbox: false,
       preload: join(__dirname, 'preload.js'),
     }
   });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -53,6 +53,14 @@ function createWindow() {
     }
   });
 
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+  win.webContents.on('will-navigate', (event, url) => {
+    if (url !== win.webContents.getURL()) {
+      event.preventDefault();
+      console.warn('[security] Blocked navigation to', url);
+    }
+  });
+
   win.loadFile(join(__dirname, 'index.html')).catch((err) => {
     console.error('Failed to load index.html', err);
   });


### PR DESCRIPTION
## Summary
- Electron 41 enables sandbox by default; sandboxed preloads cannot use ESM `import`, causing `window.wscanDesktop` to be `undefined` in the renderer
- `sandbox: false` restores Node.js access in the preload context while keeping `contextIsolation: true` for renderer security
- Fixes "Cannot read properties of undefined (reading 'listAdbDevices')" and "importSessionArtifact" runtime errors

## Test plan
- [ ] Launch `npm start` — no `window.wscanDesktop` errors in DevTools console
- [ ] "Refresh Android companions" button calls through without throwing
- [ ] "Import session artifact" opens file dialog

🤖 Generated with [Claude Code](https://claude.ai/claude-code)