### PR TITLE
feat(android): CapabilityProbe runtime capability detection layer

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,6 +48,12 @@
     <!-- Required for ServerSocket(9000) ADB communication (Phase 3) -->
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Required for CameraIrSelfTest (user-triggered capability self-test only) -->
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <!-- Required for AcousticSelfTest (user-triggered capability self-test only) -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
     <!-- Required API 33+ to post notifications (e.g. permission-revoked alert from WatchdogService) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/AcousticSelfTest.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/AcousticSelfTest.kt
@@ -1,0 +1,188 @@
+package com.wscanplus.app.capabilities
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.AudioTrack
+import android.media.MediaRecorder
+import android.os.SystemClock
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.sin
+
+object AcousticSelfTest {
+    const val TEST_FREQUENCY_HZ = 19_000
+    const val SAMPLE_RATE = 44_100
+    const val DETECTION_THRESHOLD = 0.3f
+
+    private const val TONE_DURATION_MS = 200
+    private const val CAPTURE_DURATION_MS = 500
+    private const val LEAD_IN_MS = 50L
+
+    suspend fun runTest(context: Context): AcousticStatus =
+        withContext(Dispatchers.IO) {
+            if (!hasRecordAudioPermission(context)) {
+                return@withContext AcousticStatus.UNTESTED
+            }
+
+            val recordBufferSize =
+                AudioRecord.getMinBufferSize(
+                    SAMPLE_RATE,
+                    AudioFormat.CHANNEL_IN_MONO,
+                    AudioFormat.ENCODING_PCM_16BIT,
+                )
+            if (recordBufferSize <= 0) {
+                return@withContext AcousticStatus.UNTESTED
+            }
+
+            val playbackSamples = generateTone()
+            val recordedSamples = ShortArray((SAMPLE_RATE * CAPTURE_DURATION_MS) / 1000)
+            val playbackBufferSize = playbackSamples.size * Short.SIZE_BYTES
+            val captureBufferSize = max(recordBufferSize, recordedSamples.size * Short.SIZE_BYTES)
+
+            val audioRecord =
+                AudioRecord
+                    .Builder()
+                    .setAudioSource(MediaRecorder.AudioSource.MIC)
+                    .setAudioFormat(
+                        AudioFormat
+                            .Builder()
+                            .setSampleRate(SAMPLE_RATE)
+                            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                            .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+                            .build(),
+                    ).setBufferSizeInBytes(captureBufferSize)
+                    .build()
+            val audioTrack =
+                AudioTrack
+                    .Builder()
+                    .setAudioAttributes(
+                        AudioAttributes
+                            .Builder()
+                            .setLegacyStreamType(AudioManager.STREAM_MUSIC)
+                            .build(),
+                    ).setAudioFormat(
+                        AudioFormat
+                            .Builder()
+                            .setSampleRate(SAMPLE_RATE)
+                            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                            .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                            .build(),
+                    ).setTransferMode(AudioTrack.MODE_STATIC)
+                    .setBufferSizeInBytes(playbackBufferSize)
+                    .build()
+
+            if (audioRecord.state != AudioRecord.STATE_INITIALIZED ||
+                audioTrack.state != AudioTrack.STATE_INITIALIZED
+            ) {
+                audioRecord.release()
+                audioTrack.release()
+                return@withContext AcousticStatus.UNTESTED
+            }
+
+            try {
+                val written =
+                    audioTrack.write(
+                        playbackSamples,
+                        0,
+                        playbackSamples.size,
+                        AudioTrack.WRITE_BLOCKING,
+                    )
+                if (written <= 0) {
+                    return@withContext AcousticStatus.UNTESTED
+                }
+
+                audioRecord.startRecording()
+                SystemClock.sleep(LEAD_IN_MS)
+                audioTrack.play()
+                val read =
+                    audioRecord.read(
+                        recordedSamples,
+                        0,
+                        recordedSamples.size,
+                        AudioRecord.READ_BLOCKING,
+                    )
+                audioTrack.stop()
+                audioRecord.stop()
+
+                if (read <= 0) {
+                    return@withContext AcousticStatus.UNTESTED
+                }
+
+                val ratio = computeEnergyRatio(recordedSamples, read)
+                if (ratio >= DETECTION_THRESHOLD) {
+                    AcousticStatus.CAPABLE
+                } else {
+                    AcousticStatus.NOT_CAPABLE
+                }
+            } finally {
+                audioTrack.release()
+                audioRecord.release()
+            }
+        }
+
+    private fun hasRecordAudioPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun generateTone(): ShortArray {
+        val sampleCount = (SAMPLE_RATE * TONE_DURATION_MS) / 1000
+        val samples = ShortArray(sampleCount)
+        for (index in 0 until sampleCount) {
+            val phase = (2.0 * PI * TEST_FREQUENCY_HZ * index) / SAMPLE_RATE
+            samples[index] = (sin(phase) * Short.MAX_VALUE * 0.5).toInt().toShort()
+        }
+        return samples
+    }
+
+    private fun computeEnergyRatio(
+        samples: ShortArray,
+        count: Int,
+    ): Float {
+        if (count <= 0) {
+            return 0f
+        }
+
+        var totalEnergy = 0.0
+        for (index in 0 until count) {
+            val sample = samples[index].toDouble() / Short.MAX_VALUE
+            totalEnergy += sample * sample
+        }
+        if (totalEnergy <= 0.0) {
+            return 0f
+        }
+
+        val targetEnergy = goertzel(samples, count, TEST_FREQUENCY_HZ.toDouble())
+        return (targetEnergy / totalEnergy).toFloat()
+    }
+
+    private fun goertzel(
+        samples: ShortArray,
+        count: Int,
+        frequencyHz: Double,
+    ): Double {
+        val normalizedFrequency = frequencyHz / SAMPLE_RATE
+        val coefficient = 2.0 * cos(2.0 * PI * normalizedFrequency)
+
+        var q0: Double
+        var q1 = 0.0
+        var q2 = 0.0
+
+        for (index in 0 until count) {
+            val sample = samples[index].toDouble() / Short.MAX_VALUE
+            q0 = coefficient * q1 - q2 + sample
+            q2 = q1
+            q1 = q0
+        }
+
+        return q1 * q1 + q2 * q2 - coefficient * q1 * q2
+    }
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/AcousticSelfTest.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/AcousticSelfTest.kt
@@ -89,40 +89,44 @@ object AcousticSelfTest {
             }
 
             try {
-                val written =
-                    audioTrack.write(
-                        playbackSamples,
-                        0,
-                        playbackSamples.size,
-                        AudioTrack.WRITE_BLOCKING,
-                    )
-                if (written <= 0) {
-                    return@withContext AcousticStatus.UNTESTED
-                }
+                val result =
+                    runCatching {
+                        val written =
+                            audioTrack.write(
+                                playbackSamples,
+                                0,
+                                playbackSamples.size,
+                                AudioTrack.WRITE_BLOCKING,
+                            )
+                        if (written <= 0) {
+                            return@runCatching AcousticStatus.UNTESTED
+                        }
 
-                audioRecord.startRecording()
-                SystemClock.sleep(LEAD_IN_MS)
-                audioTrack.play()
-                val read =
-                    audioRecord.read(
-                        recordedSamples,
-                        0,
-                        recordedSamples.size,
-                        AudioRecord.READ_BLOCKING,
-                    )
-                audioTrack.stop()
-                audioRecord.stop()
+                        audioRecord.startRecording()
+                        SystemClock.sleep(LEAD_IN_MS)
+                        audioTrack.play()
+                        val read =
+                            audioRecord.read(
+                                recordedSamples,
+                                0,
+                                recordedSamples.size,
+                                AudioRecord.READ_BLOCKING,
+                            )
+                        audioTrack.stop()
+                        audioRecord.stop()
 
-                if (read <= 0) {
-                    return@withContext AcousticStatus.UNTESTED
-                }
+                        if (read <= 0) {
+                            return@runCatching AcousticStatus.UNTESTED
+                        }
 
-                val ratio = computeEnergyRatio(recordedSamples, read)
-                if (ratio >= DETECTION_THRESHOLD) {
-                    AcousticStatus.CAPABLE
-                } else {
-                    AcousticStatus.NOT_CAPABLE
-                }
+                        val ratio = computeEnergyRatio(recordedSamples, read)
+                        if (ratio >= DETECTION_THRESHOLD) {
+                            AcousticStatus.CAPABLE
+                        } else {
+                            AcousticStatus.NOT_CAPABLE
+                        }
+                    }
+                result.getOrDefault(AcousticStatus.UNTESTED)
             } finally {
                 audioTrack.release()
                 audioRecord.release()

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CameraIrSelfTest.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CameraIrSelfTest.kt
@@ -49,15 +49,17 @@ object CameraIrSelfTest {
                 if (!completed.compareAndSet(false, true)) {
                     return
                 }
-                runCatching {
-                    providerRef
-                        ?.javaClass
-                        ?.getMethod("unbindAll")
-                        ?.invoke(providerRef)
-                }
                 analyzerExecutor.shutdownNow()
-                if (continuation.isActive) {
-                    continuation.resume(status)
+                ContextCompat.getMainExecutor(context).execute {
+                    runCatching {
+                        providerRef
+                            ?.javaClass
+                            ?.getMethod("unbindAll")
+                            ?.invoke(providerRef)
+                    }
+                    if (continuation.isActive) {
+                        continuation.resume(status)
+                    }
                 }
             }
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CameraIrSelfTest.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CameraIrSelfTest.kt
@@ -1,0 +1,293 @@
+package com.wscanplus.app.capabilities
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.lang.reflect.Proxy
+import java.nio.ByteBuffer
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.resume
+
+object CameraIrSelfTest {
+    const val IR_BRIGHTNESS_THRESHOLD = 245
+    const val IR_MIN_BRIGHT_FRAMES = 3
+    const val MAX_FRAMES = 150
+
+    suspend fun runTest(
+        context: Context,
+        lifecycleOwner: LifecycleOwner,
+    ): CameraIrStatus =
+        suspendCancellableCoroutine { continuation ->
+            if (!hasCameraPermission(context)) {
+                continuation.resume(CameraIrStatus.UNTESTED)
+                return@suspendCancellableCoroutine
+            }
+            if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) {
+                continuation.resume(CameraIrStatus.NOT_CAPABLE)
+                return@suspendCancellableCoroutine
+            }
+
+            val classes = loadCameraXClasses()
+            if (classes == null) {
+                continuation.resume(CameraIrStatus.UNTESTED)
+                return@suspendCancellableCoroutine
+            }
+
+            val analyzerExecutor = Executors.newSingleThreadExecutor()
+            val completed = AtomicBoolean(false)
+            var providerRef: Any? = null
+
+            fun finish(status: CameraIrStatus) {
+                if (!completed.compareAndSet(false, true)) {
+                    return
+                }
+                runCatching {
+                    providerRef
+                        ?.javaClass
+                        ?.getMethod("unbindAll")
+                        ?.invoke(providerRef)
+                }
+                analyzerExecutor.shutdownNow()
+                if (continuation.isActive) {
+                    continuation.resume(status)
+                }
+            }
+
+            continuation.invokeOnCancellation {
+                finish(CameraIrStatus.UNTESTED)
+            }
+
+            try {
+                val providerFuture =
+                    classes.processCameraProvider
+                        .getMethod("getInstance", Context::class.java)
+                        .invoke(null, context)
+                providerFuture
+                    .javaClass
+                    .getMethod("addListener", Runnable::class.java, Executor::class.java)
+                    .invoke(
+                        providerFuture,
+                        Runnable {
+                            try {
+                                providerRef =
+                                    providerFuture
+                                        .javaClass
+                                        .getMethod("get")
+                                        .invoke(providerFuture)
+
+                                val imageAnalysis = buildImageAnalysis(classes)
+                                val analyzer =
+                                    createAnalyzer(
+                                        classes = classes,
+                                        executor = analyzerExecutor,
+                                        finish = ::finish,
+                                    )
+                                imageAnalysis
+                                    .javaClass
+                                    .getMethod(
+                                        "setAnalyzer",
+                                        Executor::class.java,
+                                        classes.analyzer,
+                                    ).invoke(imageAnalysis, analyzerExecutor, analyzer)
+
+                                val selector =
+                                    createCameraSelector(
+                                        selectorBuilderClass = classes.cameraSelectorBuilder,
+                                        context = context,
+                                    )
+                                val useCaseArray =
+                                    java.lang.reflect.Array.newInstance(classes.useCase, 1).also { array ->
+                                        java.lang.reflect.Array
+                                            .set(array, 0, imageAnalysis)
+                                    }
+
+                                providerRef
+                                    ?.javaClass
+                                    ?.getMethod(
+                                        "bindToLifecycle",
+                                        LifecycleOwner::class.java,
+                                        classes.cameraSelector,
+                                        useCaseArray.javaClass,
+                                    )?.invoke(providerRef, lifecycleOwner, selector, useCaseArray)
+                            } catch (_: Throwable) {
+                                finish(CameraIrStatus.UNTESTED)
+                            }
+                        },
+                        ContextCompat.getMainExecutor(context),
+                    )
+            } catch (_: Throwable) {
+                finish(CameraIrStatus.UNTESTED)
+            }
+        }
+
+    private fun buildImageAnalysis(classes: CameraXClasses): Any {
+        val builder =
+            classes.imageAnalysisBuilder
+                .getDeclaredConstructor()
+                .newInstance()
+        runCatching {
+            val keepLatest =
+                classes.imageAnalysis
+                    .getField("STRATEGY_KEEP_ONLY_LATEST")
+                    .getInt(null)
+            builder
+                .javaClass
+                .getMethod("setBackpressureStrategy", Int::class.javaPrimitiveType)
+                .invoke(builder, keepLatest)
+        }
+        return builder
+            .javaClass
+            .getMethod("build")
+            .invoke(builder) as Any
+    }
+
+    private fun createAnalyzer(
+        classes: CameraXClasses,
+        executor: ExecutorService,
+        finish: (CameraIrStatus) -> Unit,
+    ): Any {
+        val frameState = FrameState()
+        return Proxy.newProxyInstance(
+            classes.analyzer.classLoader,
+            arrayOf(classes.analyzer),
+        ) { _, method, args ->
+            if (method.name != "analyze") {
+                return@newProxyInstance null
+            }
+            val imageProxy = args?.firstOrNull() ?: return@newProxyInstance null
+            try {
+                frameState.totalFrames += 1
+                if (isBrightFrame(imageProxy)) {
+                    frameState.brightFrames += 1
+                }
+                if (frameState.brightFrames >= IR_MIN_BRIGHT_FRAMES) {
+                    finish(CameraIrStatus.CAPABLE)
+                } else if (frameState.totalFrames >= MAX_FRAMES) {
+                    finish(CameraIrStatus.NOT_CAPABLE)
+                }
+            } finally {
+                imageProxy
+                    .javaClass
+                    .getMethod("close")
+                    .invoke(imageProxy)
+                if (frameState.totalFrames >= MAX_FRAMES) {
+                    executor.shutdown()
+                }
+            }
+            null
+        }
+    }
+
+    private fun hasCameraPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun isBrightFrame(imageProxy: Any): Boolean {
+        val planes =
+            imageProxy
+                .javaClass
+                .getMethod("getPlanes")
+                .invoke(imageProxy) as Array<*>
+        val yPlane = planes.firstOrNull() ?: return false
+        val buffer =
+            yPlane
+                .javaClass
+                .getMethod("getBuffer")
+                .invoke(yPlane) as ByteBuffer
+        val duplicate = buffer.duplicate()
+
+        var brightest = 0
+        while (duplicate.hasRemaining()) {
+            val luminance = duplicate.get().toInt() and 0xFF
+            if (luminance > brightest) {
+                brightest = luminance
+            }
+            if (brightest >= IR_BRIGHTNESS_THRESHOLD) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun createCameraSelector(
+        selectorBuilderClass: Class<*>,
+        context: Context,
+    ): Any {
+        val builder =
+            selectorBuilderClass
+                .getDeclaredConstructor()
+                .newInstance()
+        builder
+            .javaClass
+            .getMethod("requireLensFacing", Int::class.javaPrimitiveType)
+            .invoke(builder, preferredLensFacing(context))
+        return builder
+            .javaClass
+            .getMethod("build")
+            .invoke(builder) as Any
+    }
+
+    private fun preferredLensFacing(context: Context): Int {
+        val cameraManager = context.getSystemService(CameraManager::class.java)
+        val backFacing = CameraCharacteristics.LENS_FACING_BACK
+        val frontFacing = CameraCharacteristics.LENS_FACING_FRONT
+
+        cameraManager
+            ?.cameraIdList
+            ?.forEach { cameraId: String ->
+                val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+                if (characteristics.get(CameraCharacteristics.LENS_FACING) == backFacing) {
+                    return backFacing
+                }
+            }
+
+        cameraManager
+            ?.cameraIdList
+            ?.forEach { cameraId: String ->
+                val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+                if (characteristics.get(CameraCharacteristics.LENS_FACING) == frontFacing) {
+                    return frontFacing
+                }
+            }
+
+        return backFacing
+    }
+
+    private fun loadCameraXClasses(): CameraXClasses? =
+        try {
+            CameraXClasses(
+                processCameraProvider = Class.forName("androidx.camera.lifecycle.ProcessCameraProvider"),
+                imageAnalysis = Class.forName("androidx.camera.core.ImageAnalysis"),
+                imageAnalysisBuilder = Class.forName("androidx.camera.core.ImageAnalysis\$Builder"),
+                analyzer = Class.forName("androidx.camera.core.ImageAnalysis\$Analyzer"),
+                cameraSelector = Class.forName("androidx.camera.core.CameraSelector"),
+                cameraSelectorBuilder = Class.forName("androidx.camera.core.CameraSelector\$Builder"),
+                useCase = Class.forName("androidx.camera.core.UseCase"),
+            )
+        } catch (_: Throwable) {
+            null
+        }
+
+    private data class CameraXClasses(
+        val processCameraProvider: Class<*>,
+        val imageAnalysis: Class<*>,
+        val imageAnalysisBuilder: Class<*>,
+        val analyzer: Class<*>,
+        val cameraSelector: Class<*>,
+        val cameraSelectorBuilder: Class<*>,
+        val useCase: Class<*>,
+    )
+
+    private data class FrameState(
+        var totalFrames: Int = 0,
+        var brightFrames: Int = 0,
+    )
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -19,17 +19,26 @@ object CapabilityProbe {
             packageManager.hasSystemFeature(
                 PackageManager.FEATURE_WIFI,
             )
+        val locationGranted = hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
         val wifiPermissionsGranted =
             hasPermission(context, Manifest.permission.CHANGE_WIFI_STATE) &&
-                hasPermission(context, Manifest.permission.ACCESS_WIFI_STATE)
+                hasPermission(context, Manifest.permission.ACCESS_WIFI_STATE) &&
+                locationGranted
         val wifiRttFeature =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
                 packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_RTT)
         val wifiRttAvailableNow =
-            if (wifiRttFeature && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (wifiRttFeature && locationGranted) {
                 context
                     .getSystemService(WifiRttManager::class.java)
                     ?.isAvailable == true
+            } else {
+                false
+            }
+        val uwb =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                @Suppress("InlinedApi")
+                packageManager.hasSystemFeature(PackageManager.FEATURE_UWB)
             } else {
                 false
             }
@@ -37,13 +46,13 @@ object CapabilityProbe {
         return DeviceCapabilityManifest(
             deviceModel = Build.MODEL,
             wifiScan = wifiFeature && wifiPermissionsGranted,
-            wifiRtt = wifiRttFeature,
+            wifiRtt = wifiRttFeature && locationGranted,
             wifiAware =
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                     packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE),
-            uwb = packageManager.hasSystemFeature("android.hardware.uwb"),
+            uwb = uwb,
             barometer = hasSensor(sensorManager, Sensor.TYPE_PRESSURE),
-            nsd = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN,
+            nsd = true,
             bluetoothLe =
                 packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE) &&
                     context
@@ -62,7 +71,9 @@ object CapabilityProbe {
     private fun hasPermission(
         context: Context,
         permission: String,
-    ): Boolean = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    ): Boolean =
+        ContextCompat
+            .checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 
     private fun hasSensor(
         sensorManager: SensorManager?,

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -1,0 +1,71 @@
+package com.wscanplus.app.capabilities
+
+import android.Manifest
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.net.wifi.rtt.WifiRttManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+object CapabilityProbe {
+    suspend fun probe(context: Context): DeviceCapabilityManifest {
+        val packageManager = context.packageManager
+        val sensorManager = context.getSystemService(SensorManager::class.java)
+
+        val wifiFeature =
+            packageManager.hasSystemFeature(
+                PackageManager.FEATURE_WIFI,
+            )
+        val wifiPermissionsGranted =
+            hasPermission(context, Manifest.permission.CHANGE_WIFI_STATE) &&
+                hasPermission(context, Manifest.permission.ACCESS_WIFI_STATE)
+        val wifiRttFeature =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
+                packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_RTT)
+        val wifiRttAvailableNow =
+            if (wifiRttFeature && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                context
+                    .getSystemService(WifiRttManager::class.java)
+                    ?.isAvailable == true
+            } else {
+                false
+            }
+
+        return DeviceCapabilityManifest(
+            deviceModel = Build.MODEL,
+            wifiScan = wifiFeature && wifiPermissionsGranted,
+            wifiRtt = wifiRttFeature,
+            wifiAware =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                    packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE),
+            uwb = packageManager.hasSystemFeature("android.hardware.uwb"),
+            barometer = hasSensor(sensorManager, Sensor.TYPE_PRESSURE),
+            nsd = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN,
+            bluetoothLe =
+                packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE) &&
+                    context
+                        .getSystemService(BluetoothManager::class.java)
+                        ?.adapter != null,
+            proximity = hasSensor(sensorManager, Sensor.TYPE_PROXIMITY),
+            magnetometer = hasSensor(sensorManager, Sensor.TYPE_MAGNETIC_FIELD),
+            accelerometer = hasSensor(sensorManager, Sensor.TYPE_ACCELEROMETER),
+            gyroscope = hasSensor(sensorManager, Sensor.TYPE_GYROSCOPE),
+            wifiRttAvailableNow = wifiRttAvailableNow,
+            cameraIrCapable = CameraIrStatus.UNTESTED,
+            acousticSonarCapable = AcousticStatus.UNTESTED,
+        )
+    }
+
+    private fun hasPermission(
+        context: Context,
+        permission: String,
+    ): Boolean = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+    private fun hasSensor(
+        sensorManager: SensorManager?,
+        sensorType: Int,
+    ): Boolean = sensorManager?.getDefaultSensor(sensorType) != null
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DetectorGate.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DetectorGate.kt
@@ -1,0 +1,36 @@
+package com.wscanplus.app.capabilities
+
+object DetectorGate {
+    enum class DetectorRequirement {
+        WIFI_SCAN,
+        WIFI_RTT,
+        UWB_RANGING,
+        FLOOR_INFERENCE,
+        CAMERA_IR_SWEEP,
+        GLINT_SWEEP,
+        ACOUSTIC_PRESENCE,
+        BLE_SCAN,
+        NSD_DISCOVERY,
+    }
+
+    fun canRun(
+        manifest: DeviceCapabilityManifest,
+        requirement: DetectorRequirement,
+    ): Boolean =
+        when (requirement) {
+            DetectorRequirement.WIFI_SCAN -> manifest.wifiScan
+            DetectorRequirement.WIFI_RTT -> manifest.wifiRtt && manifest.wifiRttAvailableNow
+            DetectorRequirement.UWB_RANGING -> manifest.uwb
+            DetectorRequirement.FLOOR_INFERENCE -> manifest.barometer
+            DetectorRequirement.CAMERA_IR_SWEEP ->
+                manifest.cameraIrCapable == CameraIrStatus.CAPABLE ||
+                    manifest.cameraIrCapable == CameraIrStatus.PARTIAL
+            DetectorRequirement.GLINT_SWEEP ->
+                manifest.cameraIrCapable == CameraIrStatus.CAPABLE ||
+                    manifest.cameraIrCapable == CameraIrStatus.PARTIAL
+            DetectorRequirement.ACOUSTIC_PRESENCE ->
+                manifest.acousticSonarCapable == AcousticStatus.CAPABLE
+            DetectorRequirement.BLE_SCAN -> manifest.bluetoothLe
+            DetectorRequirement.NSD_DISCOVERY -> manifest.nsd
+        }
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DeviceCapabilityManifest.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DeviceCapabilityManifest.kt
@@ -1,0 +1,33 @@
+package com.wscanplus.app.capabilities
+
+data class DeviceCapabilityManifest(
+    val deviceModel: String,
+    val wifiScan: Boolean,
+    val wifiRtt: Boolean,
+    val wifiAware: Boolean,
+    val uwb: Boolean,
+    val barometer: Boolean,
+    val nsd: Boolean,
+    val bluetoothLe: Boolean,
+    val proximity: Boolean,
+    val magnetometer: Boolean,
+    val accelerometer: Boolean,
+    val gyroscope: Boolean,
+    val wifiRttAvailableNow: Boolean,
+    val cameraIrCapable: CameraIrStatus,
+    val acousticSonarCapable: AcousticStatus,
+)
+
+enum class CameraIrStatus {
+    UNTESTED,
+    CAPABLE,
+    NOT_CAPABLE,
+    PARTIAL,
+}
+
+enum class AcousticStatus {
+    UNTESTED,
+    CAPABLE,
+    NOT_CAPABLE,
+    DEVICE_VARIABLE,
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/DetectorGateTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/DetectorGateTest.kt
@@ -1,0 +1,99 @@
+package com.wscanplus.app.capabilities
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DetectorGateTest {
+    private fun manifest(
+        wifiScan: Boolean = false,
+        wifiRtt: Boolean = false,
+        wifiRttAvailableNow: Boolean = false,
+        uwb: Boolean = false,
+        barometer: Boolean = false,
+        cameraIr: CameraIrStatus = CameraIrStatus.UNTESTED,
+        acoustic: AcousticStatus = AcousticStatus.UNTESTED,
+        bluetoothLe: Boolean = false,
+        nsd: Boolean = false,
+    ) = DeviceCapabilityManifest(
+        deviceModel = "Test",
+        wifiScan = wifiScan,
+        wifiRtt = wifiRtt,
+        wifiAware = false,
+        uwb = uwb,
+        barometer = barometer,
+        nsd = nsd,
+        bluetoothLe = bluetoothLe,
+        proximity = false,
+        magnetometer = false,
+        accelerometer = false,
+        gyroscope = false,
+        wifiRttAvailableNow = wifiRttAvailableNow,
+        cameraIrCapable = cameraIr,
+        acousticSonarCapable = acoustic,
+    )
+
+    @Test
+    fun wifiScan_requires_wifiScan_true() {
+        assertFalse(DetectorGate.canRun(manifest(wifiScan = false), DetectorGate.DetectorRequirement.WIFI_SCAN))
+        assertTrue(DetectorGate.canRun(manifest(wifiScan = true), DetectorGate.DetectorRequirement.WIFI_SCAN))
+    }
+
+    @Test
+    fun wifiRtt_requires_both_rtt_flags() {
+        assertFalse(DetectorGate.canRun(manifest(wifiRtt = true, wifiRttAvailableNow = false), DetectorGate.DetectorRequirement.WIFI_RTT))
+        assertFalse(DetectorGate.canRun(manifest(wifiRtt = false, wifiRttAvailableNow = true), DetectorGate.DetectorRequirement.WIFI_RTT))
+        assertTrue(DetectorGate.canRun(manifest(wifiRtt = true, wifiRttAvailableNow = true), DetectorGate.DetectorRequirement.WIFI_RTT))
+    }
+
+    @Test
+    fun uwbRanging_requires_uwb() {
+        assertFalse(DetectorGate.canRun(manifest(uwb = false), DetectorGate.DetectorRequirement.UWB_RANGING))
+        assertTrue(DetectorGate.canRun(manifest(uwb = true), DetectorGate.DetectorRequirement.UWB_RANGING))
+    }
+
+    @Test
+    fun floorInference_requires_barometer() {
+        assertFalse(DetectorGate.canRun(manifest(barometer = false), DetectorGate.DetectorRequirement.FLOOR_INFERENCE))
+        assertTrue(DetectorGate.canRun(manifest(barometer = true), DetectorGate.DetectorRequirement.FLOOR_INFERENCE))
+    }
+
+    @Test
+    fun cameraIrSweep_capable_and_partial_allowed() {
+        assertFalse(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.UNTESTED), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
+        assertFalse(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.NOT_CAPABLE), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
+        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.CAPABLE), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
+        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.PARTIAL), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
+    }
+
+    @Test
+    fun glintSweep_same_as_cameraIr() {
+        assertFalse(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.UNTESTED), DetectorGate.DetectorRequirement.GLINT_SWEEP))
+        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.CAPABLE), DetectorGate.DetectorRequirement.GLINT_SWEEP))
+        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.PARTIAL), DetectorGate.DetectorRequirement.GLINT_SWEEP))
+    }
+
+    @Test
+    fun acousticPresence_requires_capable_only() {
+        assertFalse(DetectorGate.canRun(manifest(acoustic = AcousticStatus.UNTESTED), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE))
+        assertFalse(
+            DetectorGate.canRun(manifest(acoustic = AcousticStatus.NOT_CAPABLE), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE),
+        )
+        assertFalse(
+            DetectorGate.canRun(manifest(acoustic = AcousticStatus.DEVICE_VARIABLE), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE),
+        )
+        assertTrue(DetectorGate.canRun(manifest(acoustic = AcousticStatus.CAPABLE), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE))
+    }
+
+    @Test
+    fun bleScan_requires_bluetoothLe() {
+        assertFalse(DetectorGate.canRun(manifest(bluetoothLe = false), DetectorGate.DetectorRequirement.BLE_SCAN))
+        assertTrue(DetectorGate.canRun(manifest(bluetoothLe = true), DetectorGate.DetectorRequirement.BLE_SCAN))
+    }
+
+    @Test
+    fun nsdDiscovery_requires_nsd() {
+        assertFalse(DetectorGate.canRun(manifest(nsd = false), DetectorGate.DetectorRequirement.NSD_DISCOVERY))
+        assertTrue(DetectorGate.canRun(manifest(nsd = true), DetectorGate.DetectorRequirement.NSD_DISCOVERY))
+    }
+}


### PR DESCRIPTION
Closes #197

## Summary

- `DeviceCapabilityManifest` — immutable data class capturing WiFi, RTT, WiFi Aware, UWB, barometer, proximity, magnetometer, accelerometer, gyroscope, BLE, NSD, camera IR status, acoustic sonar status
- `CapabilityProbe` — suspend probe function, checks already-granted permissions and system features only (never requests permissions)
- `DetectorGate` — maps 9 `DetectorRequirement` values to manifest fields, all detector modules check this before activating
- `CameraIrSelfTest` — user-triggered, reflective CameraX binding with graceful `UNTESTED` fallback if CameraX absent at runtime
- `AcousticSelfTest` — user-triggered Goertzel algorithm at 19kHz, emits chirp + records + computes energy ratio

No existing files modified. No new dependencies added.

## Test plan

- [ ] ktlint passes (verified locally)
- [ ] CI green
- [ ] Copilot review