### PR TITLE
docs: refresh SESSION_STATE + ROADMAP to reflect post-#200 repo state

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,51 +69,45 @@ These are real remaining tasks, but they are no longer reasons to treat Phase 2 
 - `ACCESS_COARSE_LOCATION` remains supported only as degraded onboarding / limited mode, not normal scan-capable operation.
 - `ACCESS_BACKGROUND_LOCATION` is required for the intended field / long-running detection mode because foreground-only access is not sufficient for reliable background and keyguard continuity.
 
-## Phase 3 — Privacy + CTI Integration (Android)
+## Phase 3 — Privacy + CTI Integration (Android) ✅ Complete
 
-External API calls require consent framework first. GDPR/CCPA compliance before any third-party data sharing.
+- [x] Consent framework (opt-in, GDPR/CCPA compliant) (PR #173)
+- [x] CrowdSec CTI client (OkHttp, `/v2/smoke/{ip}`) (PR #174)
+- [x] Firebase setup (BOM 34.11.0) (PR #175)
+- [x] CTI cache + quota guardrails + degraded-mode handler (PRs #177, #180)
+- [x] Google Maps threat heatmap + GPS-tagged scan history (PR #178)
+- [x] SQLCipher AES-256 DB encryption + 30-day retention purge (PR #181)
 
-- [ ] Consent framework (opt-in, GDPR/CCPA compliant) — BEFORE any API calls
-- [ ] CrowdSec CTI client (OkHttp, `/v2/smoke/{ip}`)
-- [ ] CTI cache (Room, smoke 48h / fire 6h TTL)
-- [ ] Quota guardrails (30 req/week free tier)
-- [ ] Degraded-mode handler (cache-only when CTI unavailable)
+PRs: #173–#182
 
-~8-10 PRs
+## Phase 4 — AI Layer + Reporting (Android) ✅ Complete
 
-## Phase 4 — AI Layer + Reporting (Android)
+- [x] GeminiThreatAnalyzer (firebase-ai, consent-gated, 5-min cooldown) (PR #183)
+- [x] GeminiNarrativeEntity + DAO + DB v4 (PR #184)
+- [x] ThreatResultsActivity + bug fixes (PR #186)
+- [x] Scan history export (JSON) (PR #187)
+- [x] Scan history timeline activity (PR #190)
+- [x] ADB transport — device list + WatchdogService port forward tcp:9000 (PRs #192–#193)
+- [x] Companion shell + Android session artifact import (PRs #194–#195)
 
-Gemini integration for natural language threat assessment + user-facing results.
-
-Current sequencing note:
-
-- The active `#10` work establishes Android-side fused location sampling, GPS-tagged scan persistence, and Kismet `web GPS` upload first.
-- The Google Maps feature in `#9` should build on that stored GPS data rather than introducing a second location pipeline.
-
-- [ ] Gemini/firebase-ai runtime integration (prompt builder consuming ThreatSignal list)
-- [ ] Incident Narrative generator (Gemini converts events to plain English)
-- [ ] Baseline vs. Now visual (normal network count vs. incident density)
-- [ ] Threat results UI (list, detail, color-coded badges)
-- [ ] Scan history timeline (Room-backed)
-- [ ] Google Maps heatmap (GPS-tagged scans, cluster markers)
-- [ ] JSON export (scan session + ThreatSignals + audit log)
-- [ ] Plain-language incident summary export (shareable)
-- [ ] Thermal/power correlation logging (battery drain alongside scan events)
-
-~10-14 PRs
+PRs: #183–#195
 
 ## Phase 5 — Desktop Hub + Companion Sync
 
 Desktop receives and aggregates data from Android companion(s).
 
-- [ ] Desktop `src/` structure + IPC bridge
-- [ ] ADB library evaluation (Tango ADB for ESM compatibility)
-- [ ] Android ServerSocket(9000) implementation
-- [ ] Desktop scan aggregation + sqlite cache
+- [x] Desktop flat layout + IPC bridge (PR #200)
+- [x] ADB transport — `@yume-chan/adb`, WatchdogService tcp:9000 (PRs #192–#195)
+- [x] Android ServerSocket(9000) implementation (PR #193)
+- [x] CompanionServer (WebSocket, token auth, rate limiting) (PR #200)
+- [x] Scanner + detector + store wired into Electron main (PR #200)
+- [x] CapabilityProbe layer — DeviceCapabilityManifest + DetectorGate + self-tests (PR #198)
+- [ ] Transport hello — include DeviceCapabilityManifest JSON in WatchdogService hello
+- [ ] Spatial WiFi floor tracking — barometer-based relative floor detection
 - [ ] Desktop CTI client (fetch-based)
 - [ ] Unified timeline + map overlay
 
-~12-16 PRs
+~6-8 PRs remaining
 
 ## Phase 6 — Packaging + Release
 

--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -74,15 +74,25 @@ wscanplus/
 │   ├── app/           # Application module
 │   ├── core/          # Library module
 │   └── gradle/        # Wrapper + daemon config
-├── desktop/           # Electron app (Linux-first, ESM)
-│   ├── src/
-│   │   ├── main/      # Electron main process
-│   │   └── renderer/  # UI — terminal/advanced + accessible modes
+├── desktop/           # Electron app (Linux-first, ESM) — flat layout post-#200
+│   ├── main.js        # Electron main process
+│   ├── preload.js     # Context bridge (window.wscan + window.wscanDesktop)
+│   ├── renderer.mjs   # Renderer UI
+│   ├── scanner.mjs    # iw-based WiFi scan loop
+│   ├── detector.mjs   # Threat scoring
+│   ├── store.mjs      # EventEmitter state store
+│   ├── companionServer.mjs  # WebSocket companion server (token auth)
+│   ├── adbPreflight.mjs     # ADB device readiness checks
+│   ├── adb/           # AdbTransport (WatchdogService tcp:9000)
+│   ├── companion.js   # Companion UI shell
+│   ├── sessionWorkbench.js  # Session artifact import
 │   └── package.json   # "type": "module"
 ├── docs/              # All documentation
 └── .github/
     └── workflows/     # CI only — no deploy/merge/trigger jobs
 ```
+
+> Note: `dvntone/wscanplus_desktop` was a separate companion repo that has been consolidated into `desktop/` via PR #200 and archived. It is no longer a live dependency.
 
 ---
 
@@ -100,41 +110,39 @@ See [docs/ROADMAP.md](/docs/ROADMAP.md) for the full phased plan.
 
 ---
 
-## 2026-03-23 Handoff Snapshot
+## 2026-04-04 Handoff Snapshot
 
 This section is the fast re-entry point for the next session.
 
-### Remote repo state (2026-03-23)
+### Remote repo state (2026-04-04)
 
-- `main` is current — latest merge: PR `#158` (docs: Copilot review followup)
+- `main` is current — latest merge: PR `#200` (desktop consolidation)
 - No open PRs
-- Open issues: `#9`, `#121`, `#122`, `#124`, `#125`, `#156`
-- P1 bugs `#122`, `#124`, `#125` block new feature work
+- No open blocking issues
+- `dvntone/wscanplus_desktop` archived — desktop runtime now lives in `desktop/` of this monorepo
+- `dvntone/wscanplus-deprecrated-` archived
+- `dvntone/flipp3d` archived
 
-### Immediate action needed (before next session)
+### Completed phases (as of 2026-04-04)
 
-**`gh auth refresh -s workflow`** — run this once to add workflow scope to gh CLI token.
-Required to push fixes to `.github/workflows/` files on desktop and webui repos.
-See memory file `project_codeql_fixes_pending.md` for exact steps.
+- **Phase 0–2**: Complete (Android scanner, heuristics, Room DB, OUI)
+- **Phase 3**: Complete (consent framework, CrowdSec CTI, Firebase, CTI cache, quota guardrails, SQLCipher, scan history)
+- **Phase 4**: Complete (GeminiThreatAnalyzer, scan history timeline, ADB transport, companion shell, JSON export, ESM preload bridge)
+- **Phase 5 (partial)**: CapabilityProbe layer merged (PR #198). Desktop consolidated (PR #200).
 
-### Copilot quota
+### Phase 5 remaining work
 
-Copilot at 110%+ usage. Resets the 9th. Merge on green CI only until then.
+1. **Transport hello update** — include `DeviceCapabilityManifest` JSON in WatchdogService hello message to desktop
+2. **Spatial WiFi floor tracking** — barometer-based relative floor detection (handoff spec in `/mnt/c/Users/Devia/AppData/Local/Temp/wscan_pull/handoff.md`)
+3. **darklotusLABS web UI** — Sentinel Prism theme, NYX assistant, Vite build for app.darklotuslabs.com
 
-### Desktop and webui repo status
+### Active repos
 
-- `wscanplus_desktop`: CodeQL workflow broken (actions not pinned to SHAs). Fix documented in memory.
-- `wscanplus_webui`: CodeQL workflow broken (no JS source yet). Fix documented in memory.
-- Both fixes blocked by missing `workflow` scope on gh CLI token.
-
-### Phase 3 scope (when P1 bugs resolved)
-
-1. File 5 code bugs from Codex findings as issues
-2. Timestamp µs→ms fix in WifiScanResult.toScanInput()
-3. OuiAssetLoader integration in WatchdogService
-4. CTI client (CrowdSec API) + Room cache layer
-5. Scan history accumulation + baseline population
-6. Gemini firebase-ai threat narrative layer
+| Repo | Status |
+|------|--------|
+| `dvntone/wscanplus` | Active — canonical monorepo |
+| `dvntone/wscanplus_webui` | Active — darklotuslabs.com placeholder (sweep-tool-v2.jsx) |
+| `dvntone/MetaRadar-Clone` | Reference only |
 
 ---
 
@@ -175,9 +183,8 @@ This section is the fast re-entry point for the next Claude/Copilot session.
 
 ### Cross-repo dependency
 
-- Companion desktop repo `dvntone/wscanplus_desktop` was audited and hardened on 2026-03-20
-- Result: no open PRs, no open issues, CI includes `npm test` + `npm run lint`, and `npm audit` is clean after `electron-builder` upgrade
-- Treat the desktop repo as aligned with current Android handoff assumptions
+- `dvntone/wscanplus_desktop` was consolidated into `desktop/` of this monorepo via PR #200 on 2026-04-04 and is now archived.
+- All desktop development happens in `desktop/` of this repo only.
 
 ### Device-testing docs standard
 


### PR DESCRIPTION
Closes #201

## Summary

- `SESSION_STATE.md` — updated desktop folder structure to flat layout, replaced stale 2026-03-23 handoff with current 2026-04-04 state, removed `wscanplus_desktop` as live dependency, updated cross-repo section
- `ROADMAP.md` — marked Phase 3 + Phase 4 complete with PR references, updated Phase 5 to show completed items and remaining work

## No implementation changes — docs only