### PR TITLE
fix(android): SQLCipher factory in ScanMapActivity + CTI quota on outbound attempt

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -13,7 +13,10 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.maps.android.heatmaps.HeatmapTileProvider
 import com.google.maps.android.heatmaps.WeightedLatLng
+import com.wscanplus.app.db.DbPassphraseProvider
 import com.wscanplus.core.db.WscanDatabase
+import net.sqlcipher.database.SQLiteDatabase
+import net.sqlcipher.database.SupportFactory
 import java.util.concurrent.Executors
 
 /**
@@ -57,7 +60,18 @@ class ScanMapActivity :
     }
 
     private fun loadAndRender(map: GoogleMap) {
-        val db = WscanDatabase.getInstance(applicationContext)
+        val passphrase = DbPassphraseProvider(applicationContext).getOrCreate()
+        if (passphrase == null) {
+            Log.e(TAG, "Encrypted database unavailable — cannot load map data")
+            if (!isDestroyed) {
+                runOnUiThread {
+                    Toast.makeText(this, "Encrypted database unavailable.", Toast.LENGTH_LONG).show()
+                }
+            }
+            return
+        }
+        SQLiteDatabase.loadLibs(applicationContext)
+        val db = WscanDatabase.getInstance(applicationContext, SupportFactory(passphrase))
         val scanResults = db.scanResultDao().getGpsTagged(limit = 500)
         if (scanResults.isEmpty()) {
             if (!isDestroyed) {

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CtiCacheRepository.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CtiCacheRepository.kt
@@ -43,9 +43,11 @@ class CtiCacheRepository(
                 }
             }
 
+            // Record the outbound attempt before the call so failed requests
+            // are counted against the quota guardrail, not just successful ones.
+            quotaTracker.recordRequest()
             val result = client.lookupSmoke(ip)
             if (result != null) {
-                quotaTracker.recordRequest()
                 dao.upsert(
                     CtiCacheEntity(
                         cacheKey = key,


### PR DESCRIPTION
Closes #203

## Changes

### P1 — ScanMapActivity SQLCipher factory fix
`ScanMapActivity.loadAndRender()` was calling `WscanDatabase.getInstance(applicationContext)` without a `SupportFactory`, poisoning the Room singleton with an unencrypted helper. Every other DB caller passes `SupportFactory(passphrase)`. Fixed to match.

### P2 — CtiCacheRepository quota accounting fix
`quotaTracker.recordRequest()` was called only on successful network responses. Failed outbound requests were not counted, allowing quota exhaustion to be bypassed on flaky networks. Moved the record call before `client.lookupSmoke(ip)` so all outbound attempts count.

## Test plan
- [ ] ScanMapActivity: open map view on fresh install — should load without crash; DB should remain encrypted
- [ ] CtiCacheRepository: unit tests pass (`./gradlew :app:test`)
- [ ] ktlint: `./gradlew :app:ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)