### PR TITLE
fix(desktop): clear companion sessions on token rotation + IPC iface validation

### DIFF
--- a/desktop/companionServer.mjs
+++ b/desktop/companionServer.mjs
@@ -37,6 +37,9 @@ export class CompanionServer {
 
   generateToken() {
     this.#token = randomBytes(16).toString('hex');
+    // Clear per-device sequence state so reconnects after token rotation
+    // are not permanently rejected by the monotonic-sequence check.
+    this.#sessions.clear();
     return this.#token;
   }
 
@@ -65,6 +68,7 @@ export class CompanionServer {
         resolve();
         return;
       }
+      this.#sessions.clear();
       this.#wss?.close();
       this.#httpServer.close(() => {
         this.#httpServer = null;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -322,7 +322,12 @@ ipcMain.handle('adb:preflight', async () => {
   }
 });
 
+const IFACE_RE = /^[a-zA-Z0-9_-]{1,32}$/;
+
 ipcMain.handle('scan:start', async (_event, iface) => {
+  if (iface !== undefined && iface !== null && !IFACE_RE.test(iface)) {
+    return { ok: false, error: 'Invalid interface name' };
+  }
   try {
     await startScanning(iface || undefined);
     return { ok: true, started: true, interface: store.state.interface };


### PR DESCRIPTION
Closes #205
Closes #206

## Changes

### Fix 1 — CompanionServer session clear on token rotation (TM-003, high)

`generateToken()` and `stop()` now call `this.#sessions.clear()`.

Previously, per-device monotonic sequence state survived token rotation. A device reconnecting after re-pairing would start its sequence from 0 and get permanently rejected — companion ingest broken until full desktop restart.

### Fix 2 — Interface name allowlist in `scan:start` IPC handler (JS-ELECTRON-002, medium)

Added `IFACE_RE = /^[a-zA-Z0-9_-]{1,32}$/` check before the renderer-supplied interface name reaches `spawn`. Returns `{ ok: false }` on invalid input rather than throwing. Valid Linux interface names fit this pattern; no legitimate scan target is rejected.

## Test plan
- [ ] Token rotation: pair device, rotate token via UI, re-pair — subsequent scan payloads should be accepted (not rejected as non-monotonic)
- [ ] Restart cycle: stop/start companion server — reconnecting device should not have stale sequence state
- [ ] IPC fuzz: send `scan:start` with `iface = "../../etc/passwd"` → returns `{ ok: false, error: 'Invalid interface name' }`
- [ ] IPC normal: send `scan:start` with `iface = "wlan0"` → starts scan normally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)