### PR TITLE
feat(android): WatchdogService ServerSocket hello transport + CapabilityManifest

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jlleitschuh.gradle.ktlint")
 }
 
@@ -80,6 +81,7 @@ dependencies {
     // Kotlin coroutines — required by CrowdSecCtiClient (withContext) and other async flows
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 
     // CrowdSec CTI client — /v2/smoke IP reputation lookups (Phase 3)
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -16,6 +16,8 @@ import android.provider.Settings
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
+import com.wscanplus.app.capabilities.CapabilityProbe
+import com.wscanplus.app.capabilities.DeviceCapabilityManifest
 import com.wscanplus.app.cti.BuildConfigCrowdSecCtiKeyProvider
 import com.wscanplus.app.cti.CrowdSecCtiClient
 import com.wscanplus.app.cti.CtiCacheRepository
@@ -54,11 +56,19 @@ import com.wscanplus.core.threat.SsidFloodingHeuristic
 import com.wscanplus.core.threat.WepOpenHeuristic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import net.sqlcipher.database.SQLiteDatabase
 import net.sqlcipher.database.SupportFactory
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -87,6 +97,11 @@ import java.util.concurrent.atomic.AtomicReference
 class WatchdogService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val ouiLookupRef = AtomicReference<OuiLookup?>(null)
+    private val watchdogJson =
+        Json {
+            encodeDefaults = true
+            explicitNulls = false
+        }
     private var scannerChain: ScannerChain? = null
     private var scannerExecutor: ExecutorService? = null
     private var startFuture: Future<*>? = null
@@ -101,6 +116,10 @@ class WatchdogService : Service() {
     private lateinit var ctiCacheRepository: CtiCacheRepository
     private lateinit var retentionManager: RetentionManager
     private lateinit var geminiThreatAnalyzer: GeminiThreatAnalyzer
+    private var capabilityManifest: DeviceCapabilityManifest? = null
+    private var helloServerSocket: ServerSocket? = null
+    private var helloClientSocket: Socket? = null
+    private var helloServerJob: Job? = null
     private var lastGeminiAnalysisAtMs: Long = 0L
     private val geminiAnalysisInFlight = AtomicBoolean(false)
     private val engine =
@@ -171,6 +190,7 @@ class WatchdogService : Service() {
         )
         if (scannerChain == null) {
             startTimeMillis = SystemClock.elapsedRealtime()
+            startHelloServerIfNeeded()
             val executor =
                 Executors.newSingleThreadExecutor { runnable ->
                     Thread(runnable, "wscanplus-watchdog")
@@ -352,6 +372,9 @@ class WatchdogService : Service() {
         super.onDestroy()
         serviceScope.cancel()
         Log.i(TAG, "Service destroyed")
+        helloServerJob?.cancel()
+        helloServerJob = null
+        closeHelloSockets()
         // Cancel any queued start task before submitting stop, so a pending start cannot
         // race with or follow the stop on the executor queue.
         startFuture?.cancel(true)
@@ -373,8 +396,130 @@ class WatchdogService : Service() {
             }
         }
         executor?.shutdown()
-        // TODO (Phase 3): close ServerSocket
     }
+
+    private fun startHelloServerIfNeeded() {
+        if (helloServerJob != null) {
+            return
+        }
+
+        helloServerJob =
+            serviceScope.launch(Dispatchers.IO) {
+                if (capabilityManifest == null) {
+                    capabilityManifest =
+                        try {
+                            CapabilityProbe
+                                .probe(applicationContext)
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Capability probe failed; hello payload will omit capabilities", e)
+                            null
+                        }
+                }
+
+                runHelloServerLoop()
+            }
+    }
+
+    private fun runHelloServerLoop() {
+        try {
+            val loopbackAddress =
+                InetAddress
+                    .getByName(HELLO_BIND_HOST)
+            val serverSocket =
+                ServerSocket(
+                    HELLO_PORT,
+                    1,
+                    loopbackAddress,
+                )
+            helloServerSocket = serverSocket
+            Log.i(TAG, "Watchdog hello transport listening on $HELLO_BIND_HOST:$HELLO_PORT")
+
+            while (!serverSocket.isClosed) {
+                val clientSocket =
+                    try {
+                        serverSocket.accept()
+                    } catch (e: SocketException) {
+                        if (serverSocket.isClosed) {
+                            break
+                        }
+                        throw e
+                    }
+
+                handleHelloConnection(clientSocket)
+            }
+        } catch (e: Exception) {
+            if (!isExpectedHelloShutdown(e)) {
+                Log.e(TAG, "Watchdog hello transport failed", e)
+            }
+        } finally {
+            closeHelloSockets()
+        }
+    }
+
+    private fun handleHelloConnection(clientSocket: Socket) {
+        helloClientSocket = clientSocket
+
+        try {
+            val helloMessage =
+                buildWatchdogHelloJson(
+                    deviceId = buildHelloDeviceId(),
+                    capabilityManifest = capabilityManifest,
+                    json = watchdogJson,
+                )
+
+            clientSocket
+                .getOutputStream()
+                .writer(Charsets.UTF_8)
+                .apply {
+                    write(helloMessage)
+                    write("\n")
+                    flush()
+                }
+
+            val inputStream = clientSocket.getInputStream()
+            while (inputStream.read() != -1) {
+                // Keep the connection open until the desktop side disconnects.
+            }
+        } catch (e: Exception) {
+            if (!isExpectedHelloShutdown(e)) {
+                Log.w(TAG, "Watchdog hello client connection failed", e)
+            }
+        } finally {
+            try {
+                clientSocket.close()
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to close hello client socket", e)
+            }
+            if (helloClientSocket === clientSocket) {
+                helloClientSocket = null
+            }
+        }
+    }
+
+    private fun closeHelloSockets() {
+        val clientSocket = helloClientSocket
+        helloClientSocket = null
+        try {
+            clientSocket?.close()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to close hello client socket", e)
+        }
+
+        val serverSocket = helloServerSocket
+        helloServerSocket = null
+        try {
+            serverSocket?.close()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to close hello server socket", e)
+        }
+    }
+
+    private fun isExpectedHelloShutdown(error: Exception): Boolean =
+        error is SocketException &&
+            (
+                error.message?.contains("Socket closed", ignoreCase = true) == true ||
+                    error.message?.contains("closed", ignoreCase = true) == true
+            )
 
     private fun createSession(): Long =
         database.scanSessionDao().insert(
@@ -387,6 +532,16 @@ class WatchdogService : Service() {
         )
 
     private fun buildDeviceIdentifier(): String = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID) ?: "unknown-device"
+
+    @Suppress("DEPRECATION")
+    private fun buildHelloDeviceId(): String {
+        val buildSerial = Build.SERIAL
+        return if (buildSerial.isNullOrBlank() || buildSerial == Build.UNKNOWN) {
+            buildDeviceIdentifier()
+        } else {
+            buildSerial
+        }
+    }
 
     private fun persistResults(
         results: List<WifiScanResult>,
@@ -509,6 +664,8 @@ class WatchdogService : Service() {
         private const val CHANNEL_ID_ALERT = "wscanplus_alerts"
         private const val NOTIFICATION_ID = 1
         private const val NOTIFICATION_ID_REVOKED = 2
+        private const val HELLO_BIND_HOST = "127.0.0.1"
+        private const val HELLO_PORT = 9000
         private const val KISMET_SEND_INTERVAL_MS = 10_000L
         private const val GEMINI_COOLDOWN_MS = 5 * 60 * 1000L
 
@@ -519,3 +676,27 @@ class WatchdogService : Service() {
         const val EXTRA_DEGRADED = "extra_degraded"
     }
 }
+
+@Serializable
+internal data class WatchdogHelloPayload(
+    val type: String,
+    val deviceId: String,
+    val capabilities: DeviceCapabilityManifest? = null,
+)
+
+internal fun buildWatchdogHelloJson(
+    deviceId: String,
+    capabilityManifest: DeviceCapabilityManifest?,
+    json: Json =
+        Json {
+            encodeDefaults = true
+            explicitNulls = false
+        },
+): String =
+    json.encodeToString(
+        WatchdogHelloPayload(
+            type = "hello",
+            deviceId = deviceId,
+            capabilities = capabilityManifest,
+        ),
+    )

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DeviceCapabilityManifest.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DeviceCapabilityManifest.kt
@@ -1,5 +1,8 @@
 package com.wscanplus.app.capabilities
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class DeviceCapabilityManifest(
     val deviceModel: String,
     val wifiScan: Boolean,
@@ -18,6 +21,7 @@ data class DeviceCapabilityManifest(
     val acousticSonarCapable: AcousticStatus,
 )
 
+@Serializable
 enum class CameraIrStatus {
     UNTESTED,
     CAPABLE,
@@ -25,6 +29,7 @@ enum class CameraIrStatus {
     PARTIAL,
 }
 
+@Serializable
 enum class AcousticStatus {
     UNTESTED,
     CAPABLE,

--- a/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
@@ -1,0 +1,59 @@
+package com.wscanplus.app
+
+import com.wscanplus.app.capabilities.AcousticStatus
+import com.wscanplus.app.capabilities.CameraIrStatus
+import com.wscanplus.app.capabilities.DeviceCapabilityManifest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WatchdogServiceHelloPayloadTest {
+    @Test
+    fun `hello message contains capabilities when manifest is present`() {
+        val manifest =
+            DeviceCapabilityManifest(
+                deviceModel = "Pixel Test",
+                wifiScan = true,
+                wifiRtt = true,
+                wifiAware = false,
+                uwb = false,
+                barometer = true,
+                nsd = true,
+                bluetoothLe = true,
+                proximity = true,
+                magnetometer = true,
+                accelerometer = true,
+                gyroscope = true,
+                wifiRttAvailableNow = true,
+                cameraIrCapable = CameraIrStatus.UNTESTED,
+                acousticSonarCapable = AcousticStatus.UNTESTED,
+            )
+
+        val payload =
+            buildWatchdogHelloJson(
+                deviceId = "serial-123",
+                capabilityManifest = manifest,
+            )
+
+        val root =
+            Json
+                .parseToJsonElement(payload)
+                .jsonObject
+
+        assertEquals("hello", root.getValue("type").jsonPrimitive.content)
+        assertEquals("serial-123", root.getValue("deviceId").jsonPrimitive.content)
+        assertTrue(root.containsKey("capabilities"))
+        assertEquals(
+            "Pixel Test",
+            root
+                .getValue("capabilities")
+                .jsonObject
+                .getValue("deviceModel")
+                .jsonPrimitive
+                .content,
+        )
+    }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application") version "9.1.0" apply false
     id("com.android.library") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.10" apply false
     // google-services — applied in :app; requires google-services.json at android/app/
     id("com.google.gms.google-services") version "4.4.4" apply false
     // secrets-gradle-plugin: injects GOOGLE_MAPS_API_KEY and CROWDSEC_CTI_API_KEY


### PR DESCRIPTION
Closes #208

## Summary
- Made by: Claude / Codex
- Added the missing localhost ServerSocket(9000) hello transport in WatchdogService on a background coroutine and closed it cleanly in onDestroy
- Probed DeviceCapabilityManifest once on Dispatchers.IO, serialized it with kotlinx.serialization, and included it in every hello payload under capabilities
- Added a JVM unit test covering the hello payload shape when the manifest is present
- Added the minimal Kotlin serialization plugin/runtime wiring required because android/ did not already expose it on main

## Why
main still had the Android ADB hello transport marked as TODO. This change implements that missing socket path and carries the runtime capability manifest in the first handshake payload so the desktop side can learn device capabilities immediately.

## Rules Followed
- One feature session only
- Kotlin only
- No main-thread probe or socket operations
- Draft PR opened first
- PR references exactly one GitHub issue
- Exact version pin used for the added serialization runtime

## Validation
- ./gradlew :app:ktlintCheck --console plain
- ./gradlew :app:testDebugUnitTest --console plain
- ./gradlew :core:test --console plain
- git ls-files .env local.properties android/local.properties desktop/.env desktop/local.properties

## Notes
- kotlinx.serialization was not visibly configured in ndroid/ on main, so the app module now applies the serialization plugin and adds kotlinx-serialization-json:1.9.0 explicitly to support manifest encoding.