### PR TITLE
fix(desktop): tolerate missing capabilities in AdbTransport hello message

### DIFF
--- a/desktop/adb/AdbTransport.js
+++ b/desktop/adb/AdbTransport.js
@@ -18,8 +18,12 @@ const WATCHDOG_PORT = 9000;
 export class AdbTransport extends EventEmitter {
   /** @type {AdbServerClient} */
   #client;
+  /** @type {string} */
+  #bufferedText = '';
   /** @type {ReadableStreamDefaultReader<Uint8Array> | undefined} */
   #reader;
+  /** @type {{ serial: string, deviceId: string | null, capabilities: object | null } | null} */
+  #session = null;
   /** @type {{ readable: ReadableStream<Uint8Array>, writable: WritableStream<Uint8Array>, closed: Promise<undefined>, close: () => Promise<void>, transportId?: bigint } | undefined} */
   #socket;
   /** @type {string | undefined} */
@@ -41,6 +45,16 @@ export class AdbTransport extends EventEmitter {
   }
 
   /**
+   * Returns the last parsed hello session for the connected device.
+   * `capabilities` is `null` when the Android side omits the key.
+   *
+   * @returns {{ serial: string, deviceId: string | null, capabilities: object | null } | null}
+   */
+  get session() {
+    return this.#session;
+  }
+
+  /**
    * Connect to WatchdogService on tcp:9000 for the given device serial.
    * Emits `connect`, then `data` events as Buffers, and `disconnect` when closed.
    *
@@ -53,6 +67,8 @@ export class AdbTransport extends EventEmitter {
     }
 
     await this.disconnect();
+    this.#bufferedText = '';
+    this.#session = null;
 
     try {
       const socket = await this.#client.createDeviceConnection(
@@ -125,7 +141,9 @@ export class AdbTransport extends EventEmitter {
           }
 
           if (value) {
-            this.emit('data', Buffer.from(value));
+            const buffer = Buffer.from(value);
+            this.#handleIncomingBuffer(buffer);
+            this.emit('data', buffer);
           }
         }
       } catch (error) {
@@ -151,5 +169,43 @@ export class AdbTransport extends EventEmitter {
     this.#connectedSerial = undefined;
 
     this.emit('disconnect', { serial });
+  }
+
+  #handleIncomingBuffer(buffer) {
+    this.#bufferedText += buffer.toString('utf8');
+
+    let newlineIndex = this.#bufferedText.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = this.#bufferedText.slice(0, newlineIndex).trim();
+      this.#bufferedText = this.#bufferedText.slice(newlineIndex + 1);
+
+      if (line) {
+        this.#handleJsonLine(line);
+      }
+
+      newlineIndex = this.#bufferedText.indexOf('\n');
+    }
+  }
+
+  #handleJsonLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (message?.type !== 'hello') {
+      return;
+    }
+
+    this.#session = {
+      serial: this.#connectedSerial ?? '',
+      deviceId:
+        typeof message.deviceId === 'string' ? message.deviceId : null,
+      capabilities: message.capabilities ?? null,
+    };
+
+    this.emit('hello', this.#session);
   }
 }

--- a/desktop/adb/AdbTransport.test.js
+++ b/desktop/adb/AdbTransport.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { Buffer } from 'node:buffer';
 
 // --- Mocks must be declared before importing the module under test ---
 
@@ -121,6 +122,40 @@ describe('AdbTransport.connect', () => {
       'tcp:9000',
     );
     expect(events).toEqual(['connect:serial-123', 'data:Hi', 'disconnect:serial-123']);
+  });
+
+  test('accepts hello without capabilities and stores null on session', async () => {
+    const hello = `${JSON.stringify({
+      type: 'hello',
+      deviceId: 'android-123',
+    })}\n`;
+    const socket = createSocket({
+      chunks: [Buffer.from(hello, 'utf8')],
+      autoClose: false,
+    });
+    mockCreateDeviceConnection.mockResolvedValue(socket);
+    mockWaitForDisconnect.mockResolvedValue();
+
+    const transport = new AdbTransport();
+    const helloEvents = [];
+
+    transport.on('hello', (session) => helloEvents.push(session));
+
+    await transport.connect('serial-123');
+    await flushMicrotasks();
+
+    expect(transport.session).toEqual({
+      serial: 'serial-123',
+      deviceId: 'android-123',
+      capabilities: null,
+    });
+    expect(helloEvents).toEqual([
+      {
+        serial: 'serial-123',
+        deviceId: 'android-123',
+        capabilities: null,
+      },
+    ]);
   });
 
   test('disconnect closes the socket and emits disconnect once', async () => {


### PR DESCRIPTION
Closes #210

## Summary
- Made by: Claude / Codex
- Added hello-message parsing to `desktop/adb/AdbTransport.js` so the transport normalizes a missing `capabilities` key to `null` instead of assuming it exists
- Stored the parsed hello session on the transport and emitted a `hello` event without breaking existing raw `data` events
- Added a unit test proving a hello payload without `capabilities` is accepted and results in `capabilities: null`

## Why
After the Android hello transport change, `capabilities` is optional when probing fails. The desktop ADB transport must treat that as an unprobed device and continue normally rather than throwing on missing property access.

## Rules Followed
- One bugfix session only
- ESM only, no new dependencies
- Exact dependency pins unchanged
- Draft PR opened first
- PR references exactly one GitHub issue

## Validation
- `npm test`
- `npm run lint`
- `git ls-files .env local.properties android/local.properties desktop/.env desktop/local.properties`
