### PR TITLE
deps(desktop): electron 41.1.1 + @yume-chan/adb-server-node-tcp 2.5.2

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10,11 +10,11 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@yume-chan/adb": "2.5.1",
+        "@yume-chan/adb-server-node-tcp": "2.5.2",
         "ws": "8.20.0"
       },
       "devDependencies": {
-        "@yume-chan/adb-server-node-tcp": "^2.5.2",
-        "electron": "^41.1.1",
+        "electron": "41.1.1",
         "eslint": "9.0.0",
         "jest": "30.3.0"
       },
@@ -1838,7 +1838,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@yume-chan/adb-server-node-tcp/-/adb-server-node-tcp-2.5.2.tgz",
       "integrity": "sha512-ga9icFBRUk1n6lO+ymlj83qE+90kMLV8sQA3w9mZAisfdxxEEIq1cvXitFQJvDgL0NuFQruVI4JoZA/wrgpKOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@yume-chan/adb": "^2.5.1",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10,11 +10,11 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@yume-chan/adb": "2.5.1",
-        "@yume-chan/adb-server-node-tcp": "2.1.0",
         "ws": "8.20.0"
       },
       "devDependencies": {
-        "electron": "41.0.3",
+        "@yume-chan/adb-server-node-tcp": "^2.5.2",
+        "electron": "^41.1.1",
         "eslint": "9.0.0",
         "jest": "30.3.0"
       },
@@ -1835,15 +1835,16 @@
       }
     },
     "node_modules/@yume-chan/adb-server-node-tcp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@yume-chan/adb-server-node-tcp/-/adb-server-node-tcp-2.1.0.tgz",
-      "integrity": "sha512-nMr6MnzzY5ch3YTBH0R2Or06e2/wrL4p+WfxeuDmV1f0S0zcqOEb7IjTOsFIqEyYXItRMfx65eIkhimwiCNB9g==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@yume-chan/adb-server-node-tcp/-/adb-server-node-tcp-2.5.2.tgz",
+      "integrity": "sha512-ga9icFBRUk1n6lO+ymlj83qE+90kMLV8sQA3w9mZAisfdxxEEIq1cvXitFQJvDgL0NuFQruVI4JoZA/wrgpKOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@yume-chan/adb": "^2.1.0",
+        "@yume-chan/adb": "^2.5.1",
         "@yume-chan/async": "^4.1.3",
         "@yume-chan/stream-extra": "^2.1.0",
-        "@yume-chan/struct": "^2.0.1"
+        "@yume-chan/struct": "^2.3.2"
       }
     },
     "node_modules/@yume-chan/async": {
@@ -2611,9 +2612,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "41.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.0.3.tgz",
-      "integrity": "sha512-IDjx8liW1q+r7+MOip5W1Eo1eMwJzVObmYrd9yz2dPCkS7XlgLq3qPVMR80TpiROFp73iY30kTzMdpA6fEVs3A==",
+      "version": "41.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
+      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@yume-chan/adb": "2.5.1",
+    "@yume-chan/adb-server-node-tcp": "2.5.2",
     "ws": "8.20.0"
   },
   "devDependencies": {
-    "@yume-chan/adb-server-node-tcp": "^2.5.2",
-    "electron": "^41.1.1",
+    "electron": "41.1.1",
     "eslint": "9.0.0",
     "jest": "30.3.0"
   },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@yume-chan/adb": "2.5.1",
-    "@yume-chan/adb-server-node-tcp": "2.1.0",
     "ws": "8.20.0"
   },
   "devDependencies": {
-    "electron": "41.0.3",
+    "@yume-chan/adb-server-node-tcp": "^2.5.2",
+    "electron": "^41.1.1",
     "eslint": "9.0.0",
     "jest": "30.3.0"
   },


### PR DESCRIPTION
## Summary
- `electron`: 41.0.3 → 41.1.1 (patch)
- `@yume-chan/adb-server-node-tcp`: 2.1.0 → 2.5.2 (minor)
- `npm audit` reports 0 vulnerabilities post-update (was 1 low)

Closes #212

## Checklist
- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#212)
- [x] One dependency-only PR
- [x] < 200 LOC changed (tests excluded)
- [x] No new features mixed in
- [x] `npm test` — 31/31 pass
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets committed
- [x] Merged via Squash and merge only