### PR TITLE
deps: Gradle wrapper 9.4.0 → 9.4.1

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=60ea723356d81263e8002fec0fcf9e2b0eee0c0850c7a3d7ab0a63f2ccc601f3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
Bumps Gradle wrapper to latest stable release.

| Component | From | To |
|-----------|------|----|
| Gradle wrapper | 9.4.0 | 9.4.1 |

SHA-256 pin updated to match the new distribution zip.

Closes #213

## Checklist
- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#213)
- [x] One dependency-only PR
- [x] < 200 LOC changed (tests excluded)
- [x] No new features mixed in
- [x] `gradlew clean :core:test :app:assembleDebug` — BUILD SUCCESSFUL (67 tasks)
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets committed
- [x] Merged via Squash and merge only