### PR TITLE
feat(android): BarometerSampler + FloorEstimate — relative floor tracking

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/sensor/BarometerSampler.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/sensor/BarometerSampler.kt
@@ -5,7 +5,6 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.util.Log
-import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -20,6 +19,7 @@ import kotlin.math.roundToInt
  * Floor math:
  *   ~1 hPa ≈ 8.5 m altitude change (ISA standard lapse rate, sea-level approximation).
  *   Typical residential floor height ≈ 3 m → ~0.353 hPa per floor.
+ *   deltaHpa = baselineHpa − currentHpa, so positive deltaHpa = lower current pressure = higher altitude.
  *
  * This class has no Android framework dependencies beyond [SensorManager] and [SensorEvent],
  * making the floor calculation logic unit-testable without Robolectric.
@@ -29,29 +29,33 @@ class BarometerSampler(
     private val onEstimate: (FloorEstimate) -> Unit,
 ) : SensorEventListener {
     private var baselineHpa: Float? = null
+    private var started = false
     private val pressureSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE)
 
     /** True when the device has a barometer. */
     val isAvailable: Boolean get() = pressureSensor != null
 
     /**
-     * Register the sensor listener. Safe to call multiple times — subsequent calls are no-ops
-     * if already registered.
+     * Register the sensor listener. No-op if already started or no barometer is present.
      */
     fun start() {
+        if (started) return
         val sensor =
             pressureSensor ?: run {
                 Log.w(TAG, "No barometer sensor available — BarometerSampler inactive")
                 return
             }
         sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+        started = true
         Log.d(TAG, "BarometerSampler started")
     }
 
     /** Unregister the sensor listener and clear the baseline. */
     fun stop() {
+        if (!started) return
         sensorManager.unregisterListener(this)
         baselineHpa = null
+        started = false
         Log.d(TAG, "BarometerSampler stopped")
     }
 
@@ -97,7 +101,8 @@ class BarometerSampler(
 
         /**
          * Meters of altitude change per hPa at sea level (ISA standard).
-         * Positive hPa delta = lower altitude (descended).
+         * With deltaHpa computed as baselineHpa − currentHpa, a positive hPa delta
+         * means lower current pressure and therefore higher altitude (ascended).
          */
         internal const val METERS_PER_HPA = 8.5f
 
@@ -120,12 +125,10 @@ class BarometerSampler(
             val deltaHpa = baselineHpa - currentHpa
             val deltaMeters = deltaHpa * METERS_PER_HPA
             val relativeFloor = (deltaMeters / FLOOR_HEIGHT_METERS).roundToInt()
-            val confidenceFloors = (CONFIDENCE_METERS / FLOOR_HEIGHT_METERS)
-            val confidenceMeters = abs(confidenceFloors * FLOOR_HEIGHT_METERS) + CONFIDENCE_METERS
             return FloorEstimate(
                 relativeFloor = relativeFloor,
                 deltaHpa = deltaHpa,
-                confidenceMeters = confidenceMeters,
+                confidenceMeters = CONFIDENCE_METERS,
             )
         }
     }

--- a/android/app/src/main/kotlin/com/wscanplus/app/sensor/BarometerSampler.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/sensor/BarometerSampler.kt
@@ -1,0 +1,132 @@
+package com.wscanplus.app.sensor
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Samples [Sensor.TYPE_PRESSURE] and emits [FloorEstimate] relative to a calibration baseline.
+ *
+ * Usage:
+ * 1. Call [start] to register the sensor listener.
+ * 2. Call [calibrate] at the reference floor (e.g. "Ground Floor" or building entry).
+ * 3. [onEstimate] is invoked on each new reading while a baseline is set.
+ * 4. Call [stop] to unregister.
+ *
+ * Floor math:
+ *   ~1 hPa ≈ 8.5 m altitude change (ISA standard lapse rate, sea-level approximation).
+ *   Typical residential floor height ≈ 3 m → ~0.353 hPa per floor.
+ *
+ * This class has no Android framework dependencies beyond [SensorManager] and [SensorEvent],
+ * making the floor calculation logic unit-testable without Robolectric.
+ */
+class BarometerSampler(
+    private val sensorManager: SensorManager,
+    private val onEstimate: (FloorEstimate) -> Unit,
+) : SensorEventListener {
+    private var baselineHpa: Float? = null
+    private val pressureSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE)
+
+    /** True when the device has a barometer. */
+    val isAvailable: Boolean get() = pressureSensor != null
+
+    /**
+     * Register the sensor listener. Safe to call multiple times — subsequent calls are no-ops
+     * if already registered.
+     */
+    fun start() {
+        val sensor =
+            pressureSensor ?: run {
+                Log.w(TAG, "No barometer sensor available — BarometerSampler inactive")
+                return
+            }
+        sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+        Log.d(TAG, "BarometerSampler started")
+    }
+
+    /** Unregister the sensor listener and clear the baseline. */
+    fun stop() {
+        sensorManager.unregisterListener(this)
+        baselineHpa = null
+        Log.d(TAG, "BarometerSampler stopped")
+    }
+
+    /**
+     * Set the current pressure reading as the floor-0 baseline.
+     * The next sensor event after calibration will be delivered as floor 0 with deltaHpa ≈ 0.
+     */
+    fun calibrate(baselineHpa: Float) {
+        this.baselineHpa = baselineHpa
+        Log.i(TAG, "Barometer baseline set: $baselineHpa hPa")
+    }
+
+    /** Calibrate using the most recent sensor reading. No-op if no reading has arrived yet. */
+    fun calibrateNow() {
+        val current =
+            lastReadingHpa ?: run {
+                Log.w(TAG, "calibrateNow() called before any sensor reading arrived")
+                return
+            }
+        calibrate(current)
+    }
+
+    private var lastReadingHpa: Float? = null
+
+    override fun onSensorChanged(event: SensorEvent) {
+        if (event.sensor.type != Sensor.TYPE_PRESSURE) return
+        val hpa = event.values[0]
+        lastReadingHpa = hpa
+        val baseline = baselineHpa ?: return
+        val estimate = computeFloorEstimate(hpa, baseline)
+        onEstimate(estimate)
+    }
+
+    override fun onAccuracyChanged(
+        sensor: Sensor,
+        accuracy: Int,
+    ) {
+        // Not used.
+    }
+
+    companion object {
+        private const val TAG = "BarometerSampler"
+
+        /**
+         * Meters of altitude change per hPa at sea level (ISA standard).
+         * Positive hPa delta = lower altitude (descended).
+         */
+        internal const val METERS_PER_HPA = 8.5f
+
+        /** Assumed floor height in meters for residential/office buildings. */
+        internal const val FLOOR_HEIGHT_METERS = 3.0f
+
+        /** Estimated vertical uncertainty for consumer barometers indoors (meters). */
+        internal const val CONFIDENCE_METERS = 1.5f
+
+        /**
+         * Compute a [FloorEstimate] from [currentHpa] relative to [baselineHpa].
+         *
+         * Exposed as a pure static function so unit tests can exercise the math
+         * without constructing a [BarometerSampler].
+         */
+        fun computeFloorEstimate(
+            currentHpa: Float,
+            baselineHpa: Float,
+        ): FloorEstimate {
+            val deltaHpa = baselineHpa - currentHpa
+            val deltaMeters = deltaHpa * METERS_PER_HPA
+            val relativeFloor = (deltaMeters / FLOOR_HEIGHT_METERS).roundToInt()
+            val confidenceFloors = (CONFIDENCE_METERS / FLOOR_HEIGHT_METERS)
+            val confidenceMeters = abs(confidenceFloors * FLOOR_HEIGHT_METERS) + CONFIDENCE_METERS
+            return FloorEstimate(
+                relativeFloor = relativeFloor,
+                deltaHpa = deltaHpa,
+                confidenceMeters = confidenceMeters,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/sensor/FloorEstimate.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/sensor/FloorEstimate.kt
@@ -6,7 +6,7 @@ package com.wscanplus.app.sensor
  * All values are relative to the calibration baseline — there is no absolute MSL.
  *
  * @param relativeFloor Estimated floor offset from baseline (0 = calibration level, +1 = one floor up).
- * @param deltaHpa      Pressure change from baseline in hPa (negative = higher altitude).
+ * @param deltaHpa      Pressure change from baseline in hPa (positive = higher altitude, computed as baselineHpa − currentHpa).
  * @param confidenceMeters Estimated vertical uncertainty in meters (~±1.5 m typical indoors).
  */
 data class FloorEstimate(

--- a/android/app/src/main/kotlin/com/wscanplus/app/sensor/FloorEstimate.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/sensor/FloorEstimate.kt
@@ -1,0 +1,16 @@
+package com.wscanplus.app.sensor
+
+/**
+ * Relative floor estimate derived from barometric pressure change.
+ *
+ * All values are relative to the calibration baseline — there is no absolute MSL.
+ *
+ * @param relativeFloor Estimated floor offset from baseline (0 = calibration level, +1 = one floor up).
+ * @param deltaHpa      Pressure change from baseline in hPa (negative = higher altitude).
+ * @param confidenceMeters Estimated vertical uncertainty in meters (~±1.5 m typical indoors).
+ */
+data class FloorEstimate(
+    val relativeFloor: Int,
+    val deltaHpa: Float,
+    val confidenceMeters: Float,
+)

--- a/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
@@ -1,0 +1,84 @@
+package com.wscanplus.app.sensor
+
+import com.wscanplus.app.sensor.BarometerSampler.Companion.CONFIDENCE_METERS
+import com.wscanplus.app.sensor.BarometerSampler.Companion.FLOOR_HEIGHT_METERS
+import com.wscanplus.app.sensor.BarometerSampler.Companion.METERS_PER_HPA
+import com.wscanplus.app.sensor.BarometerSampler.Companion.computeFloorEstimate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.math.roundToInt
+
+class BarometerSamplerTest {
+    @Test
+    fun `floor 0 when at baseline`() {
+        val estimate = computeFloorEstimate(currentHpa = 1013.25f, baselineHpa = 1013.25f)
+        assertEquals(0, estimate.relativeFloor)
+        assertEquals(0f, estimate.deltaHpa, 0.001f)
+    }
+
+    @Test
+    fun `positive floor when above baseline`() {
+        // One floor up ≈ 3 m ≈ 0.353 hPa drop in current reading
+        val oneFlorHpa = FLOOR_HEIGHT_METERS / METERS_PER_HPA
+        val estimate =
+            computeFloorEstimate(
+                currentHpa = 1013.25f - oneFlorHpa,
+                baselineHpa = 1013.25f,
+            )
+        assertEquals(1, estimate.relativeFloor)
+    }
+
+    @Test
+    fun `negative floor when below baseline`() {
+        val oneFlorHpa = FLOOR_HEIGHT_METERS / METERS_PER_HPA
+        val estimate =
+            computeFloorEstimate(
+                currentHpa = 1013.25f + oneFlorHpa,
+                baselineHpa = 1013.25f,
+            )
+        assertEquals(-1, estimate.relativeFloor)
+    }
+
+    @Test
+    fun `three floors up`() {
+        val threeFloorHpa = (3 * FLOOR_HEIGHT_METERS) / METERS_PER_HPA
+        val estimate =
+            computeFloorEstimate(
+                currentHpa = 1013.25f - threeFloorHpa,
+                baselineHpa = 1013.25f,
+            )
+        assertEquals(3, estimate.relativeFloor)
+    }
+
+    @Test
+    fun `deltaHpa reflects pressure change direction`() {
+        // Current lower than baseline → positive delta (ascended)
+        val estimate = computeFloorEstimate(currentHpa = 1010f, baselineHpa = 1013.25f)
+        assertEquals(1013.25f - 1010f, estimate.deltaHpa, 0.001f)
+    }
+
+    @Test
+    fun `confidenceMeters is positive and non-zero`() {
+        val estimate = computeFloorEstimate(currentHpa = 1013.25f, baselineHpa = 1013.25f)
+        assert(estimate.confidenceMeters > 0f)
+    }
+
+    @Test
+    fun `large pressure drop maps to many floors`() {
+        // 10 hPa drop ≈ 85 m ≈ 28 floors
+        val expectedFloors = ((10f * METERS_PER_HPA) / FLOOR_HEIGHT_METERS).roundToInt()
+        val estimate =
+            computeFloorEstimate(
+                currentHpa = 1013.25f - 10f,
+                baselineHpa = 1013.25f,
+            )
+        assertEquals(expectedFloors, estimate.relativeFloor)
+    }
+
+    @Test
+    fun `constants are physically reasonable`() {
+        assert(METERS_PER_HPA in 7f..10f) { "Expected 7-10 m/hPa, got $METERS_PER_HPA" }
+        assert(FLOOR_HEIGHT_METERS in 2.5f..4f) { "Expected 2.5-4 m/floor, got $FLOOR_HEIGHT_METERS" }
+        assert(CONFIDENCE_METERS in 0.5f..3f) { "Expected 0.5-3 m confidence, got $CONFIDENCE_METERS" }
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
@@ -5,6 +5,7 @@ import com.wscanplus.app.sensor.BarometerSampler.Companion.FLOOR_HEIGHT_METERS
 import com.wscanplus.app.sensor.BarometerSampler.Companion.METERS_PER_HPA
 import com.wscanplus.app.sensor.BarometerSampler.Companion.computeFloorEstimate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.math.roundToInt
 
@@ -19,10 +20,10 @@ class BarometerSamplerTest {
     @Test
     fun `positive floor when above baseline`() {
         // One floor up ≈ 3 m ≈ 0.353 hPa drop in current reading
-        val oneFlorHpa = FLOOR_HEIGHT_METERS / METERS_PER_HPA
+        val oneFloorHpa = FLOOR_HEIGHT_METERS / METERS_PER_HPA
         val estimate =
             computeFloorEstimate(
-                currentHpa = 1013.25f - oneFlorHpa,
+                currentHpa = 1013.25f - oneFloorHpa,
                 baselineHpa = 1013.25f,
             )
         assertEquals(1, estimate.relativeFloor)
@@ -30,10 +31,10 @@ class BarometerSamplerTest {
 
     @Test
     fun `negative floor when below baseline`() {
-        val oneFlorHpa = FLOOR_HEIGHT_METERS / METERS_PER_HPA
+        val oneFloorHpa = FLOOR_HEIGHT_METERS / METERS_PER_HPA
         val estimate =
             computeFloorEstimate(
-                currentHpa = 1013.25f + oneFlorHpa,
+                currentHpa = 1013.25f + oneFloorHpa,
                 baselineHpa = 1013.25f,
             )
         assertEquals(-1, estimate.relativeFloor)
@@ -58,9 +59,9 @@ class BarometerSamplerTest {
     }
 
     @Test
-    fun `confidenceMeters is positive and non-zero`() {
+    fun `confidenceMeters equals CONFIDENCE_METERS constant`() {
         val estimate = computeFloorEstimate(currentHpa = 1013.25f, baselineHpa = 1013.25f)
-        assert(estimate.confidenceMeters > 0f)
+        assertEquals(CONFIDENCE_METERS, estimate.confidenceMeters, 0.001f)
     }
 
     @Test
@@ -77,8 +78,8 @@ class BarometerSamplerTest {
 
     @Test
     fun `constants are physically reasonable`() {
-        assert(METERS_PER_HPA in 7f..10f) { "Expected 7-10 m/hPa, got $METERS_PER_HPA" }
-        assert(FLOOR_HEIGHT_METERS in 2.5f..4f) { "Expected 2.5-4 m/floor, got $FLOOR_HEIGHT_METERS" }
-        assert(CONFIDENCE_METERS in 0.5f..3f) { "Expected 0.5-3 m confidence, got $CONFIDENCE_METERS" }
+        assertTrue("Expected 7-10 m/hPa, got $METERS_PER_HPA", METERS_PER_HPA in 7f..10f)
+        assertTrue("Expected 2.5-4 m/floor, got $FLOOR_HEIGHT_METERS", FLOOR_HEIGHT_METERS in 2.5f..4f)
+        assertTrue("Expected 0.5-3 m confidence, got $CONFIDENCE_METERS", CONFIDENCE_METERS in 0.5f..3f)
     }
 }


### PR DESCRIPTION
## Summary
Pure logic layer for barometric relative floor tracking. No UI, no DB writes, no new dependencies.

- `FloorEstimate` data class: `relativeFloor`, `deltaHpa`, `confidenceMeters`
- `BarometerSampler`: registers `TYPE_PRESSURE`, `calibrate(Float)` / `calibrateNow()`, emits `FloorEstimate` via callback
- `computeFloorEstimate()` exposed as a static pure function — unit-testable without Robolectric
- 1 hPa ≈ 8.5 m; floor height = 3 m → ~0.35 hPa/floor
- `isAvailable` guards against no-barometer devices

Closes #216

This is step 1 of 3 for spatial WiFi floor tracking (Phase 5):
- [x] Step 1 — BarometerSampler (this PR)
- [ ] Step 2 — Wire into WatchdogService (gated on `capabilityManifest.barometer`)
- [ ] Step 3 — Floor badge overlay on ScanMapActivity

## Checklist
- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#216)
- [x] No new dependencies
- [x] 8 unit tests — all pass
- [x] `ktlintCheck` — clean
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets committed
- [x] Merged via Squash and merge only
- [x] Gemini/Vertex integration untouched