### PR TITLE
feat(android+desktop): telemetry evidence — hello freshness + bidirectional ack

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import net.sqlcipher.database.SQLiteDatabase
@@ -76,6 +77,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -94,12 +96,12 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * Threading rule: scanner chain and ServerSocket operations MUST run on background
  * threads. Never call scanners or socket operations on the main thread.
- *
- * TODO (Phase 3): open ServerSocket(9000) on a background thread for ADB comms.
  */
 class WatchdogService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val ouiLookupRef = AtomicReference<OuiLookup?>(null)
+    private val helloSeq = AtomicInteger(0)
+    private val inboundJson = Json { ignoreUnknownKeys = true }
     private val watchdogJson =
         Json {
             encodeDefaults = true
@@ -124,6 +126,9 @@ class WatchdogService : Service() {
 
     @Volatile
     var currentFloorEstimate: FloorEstimate? = null
+        private set
+    @Volatile
+    var lastDesktopAckSeq: Int = -1
         private set
     private var helloServerSocket: ServerSocket? = null
     private var helloClientSocket: Socket? = null
@@ -496,10 +501,14 @@ class WatchdogService : Service() {
         helloClientSocket = clientSocket
 
         try {
+            val seq = helloSeq.getAndIncrement()
             val helloMessage =
                 buildWatchdogHelloJson(
                     deviceId = buildHelloDeviceId(),
+                    seq = seq,
+                    sentAt = System.currentTimeMillis(),
                     capabilityManifest = capabilityManifest,
+                    floorEstimate = currentFloorEstimate,
                     json = watchdogJson,
                 )
 
@@ -512,10 +521,10 @@ class WatchdogService : Service() {
                     flush()
                 }
 
-            val inputStream = clientSocket.getInputStream()
-            while (inputStream.read() != -1) {
-                // Keep the connection open until the desktop side disconnects.
-            }
+            clientSocket
+                .getInputStream()
+                .bufferedReader(Charsets.UTF_8)
+                .forEachLine { line -> parseDesktopMessage(line) }
         } catch (e: Exception) {
             if (!isExpectedHelloShutdown(e)) {
                 Log.w(TAG, "Watchdog hello client connection failed", e)
@@ -529,6 +538,18 @@ class WatchdogService : Service() {
             if (helloClientSocket === clientSocket) {
                 helloClientSocket = null
             }
+        }
+    }
+
+    private fun parseDesktopMessage(line: String) {
+        try {
+            val msg = inboundJson.decodeFromString<DesktopMessageEnvelope>(line)
+            if (msg.type == "ack") {
+                lastDesktopAckSeq = msg.seq
+                Log.d(TAG, "Desktop ack received: seq=${msg.seq}")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse desktop message", e)
         }
     }
 
@@ -717,12 +738,32 @@ class WatchdogService : Service() {
 internal data class WatchdogHelloPayload(
     val type: String,
     val deviceId: String,
+    val seq: Int,
+    val sentAt: Long,
     val capabilities: DeviceCapabilityManifest? = null,
+    val floorEstimate: FloorEstimateSummary? = null,
+)
+
+@Serializable
+internal data class FloorEstimateSummary(
+    val relativeFloor: Int,
+    val deltaHpa: Float,
+    val confidenceMeters: Float,
+    val observedAt: Long,
+)
+
+@Serializable
+internal data class DesktopMessageEnvelope(
+    val type: String,
+    val seq: Int = -1,
 )
 
 internal fun buildWatchdogHelloJson(
     deviceId: String,
+    seq: Int,
+    sentAt: Long,
     capabilityManifest: DeviceCapabilityManifest?,
+    floorEstimate: FloorEstimate? = null,
     json: Json =
         Json {
             encodeDefaults = true
@@ -733,6 +774,16 @@ internal fun buildWatchdogHelloJson(
         WatchdogHelloPayload(
             type = "hello",
             deviceId = deviceId,
+            seq = seq,
+            sentAt = sentAt,
             capabilities = capabilityManifest,
+            floorEstimate = floorEstimate?.let {
+                FloorEstimateSummary(
+                    relativeFloor = it.relativeFloor,
+                    deltaHpa = it.deltaHpa,
+                    confidenceMeters = it.confidenceMeters,
+                    observedAt = it.observedAt,
+                )
+            },
         ),
     )

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -127,6 +127,7 @@ class WatchdogService : Service() {
     @Volatile
     var currentFloorEstimate: FloorEstimate? = null
         private set
+
     @Volatile
     var lastDesktopAckSeq: Int = -1
         private set
@@ -777,13 +778,14 @@ internal fun buildWatchdogHelloJson(
             seq = seq,
             sentAt = sentAt,
             capabilities = capabilityManifest,
-            floorEstimate = floorEstimate?.let {
-                FloorEstimateSummary(
-                    relativeFloor = it.relativeFloor,
-                    deltaHpa = it.deltaHpa,
-                    confidenceMeters = it.confidenceMeters,
-                    observedAt = it.observedAt,
-                )
-            },
+            floorEstimate =
+                floorEstimate?.let {
+                    FloorEstimateSummary(
+                        relativeFloor = it.relativeFloor,
+                        deltaHpa = it.deltaHpa,
+                        confidenceMeters = it.confidenceMeters,
+                        observedAt = it.observedAt,
+                    )
+                },
         ),
     )

--- a/android/app/src/main/kotlin/com/wscanplus/app/sensor/BarometerSampler.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/sensor/BarometerSampler.kt
@@ -130,6 +130,7 @@ class BarometerSampler(
         fun computeFloorEstimate(
             currentHpa: Float,
             baselineHpa: Float,
+            observedAt: Long = System.currentTimeMillis(),
         ): FloorEstimate {
             val deltaHpa = baselineHpa - currentHpa
             val deltaMeters = deltaHpa * METERS_PER_HPA
@@ -138,6 +139,7 @@ class BarometerSampler(
                 relativeFloor = relativeFloor,
                 deltaHpa = deltaHpa,
                 confidenceMeters = CONFIDENCE_METERS,
+                observedAt = observedAt,
             )
         }
     }

--- a/android/app/src/main/kotlin/com/wscanplus/app/sensor/FloorEstimate.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/sensor/FloorEstimate.kt
@@ -8,9 +8,11 @@ package com.wscanplus.app.sensor
  * @param relativeFloor Estimated floor offset from baseline (0 = calibration level, +1 = one floor up).
  * @param deltaHpa      Pressure change from baseline in hPa (positive = higher altitude, computed as baselineHpa − currentHpa).
  * @param confidenceMeters Estimated vertical uncertainty in meters (~±1.5 m typical indoors).
+ * @param observedAt    Epoch milliseconds when the sensor reading that produced this estimate was captured.
  */
 data class FloorEstimate(
     val relativeFloor: Int,
     val deltaHpa: Float,
     val confidenceMeters: Float,
+    val observedAt: Long,
 )

--- a/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
@@ -13,69 +13,88 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class WatchdogServiceHelloPayloadTest {
-
-    private val manifest = DeviceCapabilityManifest(
-        deviceModel = "Pixel Test",
-        wifiScan = true,
-        wifiRtt = true,
-        wifiAware = false,
-        uwb = false,
-        barometer = true,
-        nsd = true,
-        bluetoothLe = true,
-        proximity = true,
-        magnetometer = true,
-        accelerometer = true,
-        gyroscope = true,
-        wifiRttAvailableNow = true,
-        cameraIrCapable = CameraIrStatus.UNTESTED,
-        acousticSonarCapable = AcousticStatus.UNTESTED,
-    )
+    private val manifest =
+        DeviceCapabilityManifest(
+            deviceModel = "Pixel Test",
+            wifiScan = true,
+            wifiRtt = true,
+            wifiAware = false,
+            uwb = false,
+            barometer = true,
+            nsd = true,
+            bluetoothLe = true,
+            proximity = true,
+            magnetometer = true,
+            accelerometer = true,
+            gyroscope = true,
+            wifiRttAvailableNow = true,
+            cameraIrCapable = CameraIrStatus.UNTESTED,
+            acousticSonarCapable = AcousticStatus.UNTESTED,
+        )
 
     @Test
     fun `hello contains type, deviceId, seq, and sentAt`() {
         val sentAt = 1_700_000_000_000L
-        val payload = buildWatchdogHelloJson(
-            deviceId = "serial-123",
-            seq = 3,
-            sentAt = sentAt,
-            capabilityManifest = null,
-        )
+        val payload =
+            buildWatchdogHelloJson(
+                deviceId = "serial-123",
+                seq = 3,
+                sentAt = sentAt,
+                capabilityManifest = null,
+            )
 
         val root = Json.parseToJsonElement(payload).jsonObject
 
         assertEquals("hello", root.getValue("type").jsonPrimitive.content)
         assertEquals("serial-123", root.getValue("deviceId").jsonPrimitive.content)
-        assertEquals(3, root.getValue("seq").jsonPrimitive.content.toInt())
-        assertEquals(sentAt, root.getValue("sentAt").jsonPrimitive.content.toLong())
+        assertEquals(
+            3,
+            root
+                .getValue("seq")
+                .jsonPrimitive.content
+                .toInt(),
+        )
+        assertEquals(
+            sentAt,
+            root
+                .getValue("sentAt")
+                .jsonPrimitive.content
+                .toLong(),
+        )
     }
 
     @Test
     fun `hello contains capabilities when manifest is present`() {
-        val payload = buildWatchdogHelloJson(
-            deviceId = "serial-123",
-            seq = 0,
-            sentAt = 1_700_000_000_000L,
-            capabilityManifest = manifest,
-        )
+        val payload =
+            buildWatchdogHelloJson(
+                deviceId = "serial-123",
+                seq = 0,
+                sentAt = 1_700_000_000_000L,
+                capabilityManifest = manifest,
+            )
 
         val root = Json.parseToJsonElement(payload).jsonObject
 
         assertTrue(root.containsKey("capabilities"))
         assertEquals(
             "Pixel Test",
-            root.getValue("capabilities").jsonObject.getValue("deviceModel").jsonPrimitive.content,
+            root
+                .getValue("capabilities")
+                .jsonObject
+                .getValue("deviceModel")
+                .jsonPrimitive.content,
         )
     }
 
     @Test
     fun `hello omits capabilities when manifest is null`() {
-        val payload = buildWatchdogHelloJson(
-            deviceId = "serial-456",
-            seq = 0,
-            sentAt = 1_700_000_000_000L,
-            capabilityManifest = null,
-        )
+        val payload =
+            buildWatchdogHelloJson(
+                deviceId = "serial-456",
+                seq = 0,
+                sentAt = 1_700_000_000_000L,
+                capabilityManifest = null,
+            )
 
         val root = Json.parseToJsonElement(payload).jsonObject
 
@@ -84,36 +103,51 @@ class WatchdogServiceHelloPayloadTest {
 
     @Test
     fun `hello includes floorEstimate when provided`() {
-        val estimate = FloorEstimate(
-            relativeFloor = 2,
-            deltaHpa = 0.71f,
-            confidenceMeters = 1.5f,
-            observedAt = 1_700_000_001_000L,
-        )
-        val payload = buildWatchdogHelloJson(
-            deviceId = "serial-789",
-            seq = 1,
-            sentAt = 1_700_000_000_000L,
-            capabilityManifest = null,
-            floorEstimate = estimate,
-        )
+        val estimate =
+            FloorEstimate(
+                relativeFloor = 2,
+                deltaHpa = 0.71f,
+                confidenceMeters = 1.5f,
+                observedAt = 1_700_000_001_000L,
+            )
+        val payload =
+            buildWatchdogHelloJson(
+                deviceId = "serial-789",
+                seq = 1,
+                sentAt = 1_700_000_000_000L,
+                capabilityManifest = null,
+                floorEstimate = estimate,
+            )
 
         val root = Json.parseToJsonElement(payload).jsonObject
         assertTrue(root.containsKey("floorEstimate"))
         val fe = root.getValue("floorEstimate").jsonObject
-        assertEquals(2, fe.getValue("relativeFloor").jsonPrimitive.content.toInt())
-        assertEquals(1_700_000_001_000L, fe.getValue("observedAt").jsonPrimitive.content.toLong())
+        assertEquals(
+            2,
+            fe
+                .getValue("relativeFloor")
+                .jsonPrimitive.content
+                .toInt(),
+        )
+        assertEquals(
+            1_700_000_001_000L,
+            fe
+                .getValue("observedAt")
+                .jsonPrimitive.content
+                .toLong(),
+        )
     }
 
     @Test
     fun `hello omits floorEstimate when null`() {
-        val payload = buildWatchdogHelloJson(
-            deviceId = "serial-789",
-            seq = 0,
-            sentAt = 1_700_000_000_000L,
-            capabilityManifest = null,
-            floorEstimate = null,
-        )
+        val payload =
+            buildWatchdogHelloJson(
+                deviceId = "serial-789",
+                seq = 0,
+                sentAt = 1_700_000_000_000L,
+                capabilityManifest = null,
+                floorEstimate = null,
+            )
 
         val root = Json.parseToJsonElement(payload).jsonObject
         assertFalse(root.containsKey("floorEstimate"))
@@ -123,8 +157,20 @@ class WatchdogServiceHelloPayloadTest {
     fun `seq monotonically increases across two hello builds`() {
         val p1 = buildWatchdogHelloJson("d", seq = 0, sentAt = 1L, capabilityManifest = null)
         val p2 = buildWatchdogHelloJson("d", seq = 1, sentAt = 2L, capabilityManifest = null)
-        val s1 = Json.parseToJsonElement(p1).jsonObject.getValue("seq").jsonPrimitive.content.toInt()
-        val s2 = Json.parseToJsonElement(p2).jsonObject.getValue("seq").jsonPrimitive.content.toInt()
+        val s1 =
+            Json
+                .parseToJsonElement(p1)
+                .jsonObject
+                .getValue("seq")
+                .jsonPrimitive.content
+                .toInt()
+        val s2 =
+            Json
+                .parseToJsonElement(p2)
+                .jsonObject
+                .getValue("seq")
+                .jsonPrimitive.content
+                .toInt()
         assertTrue(s2 > s1)
     }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
@@ -154,23 +154,15 @@ class WatchdogServiceHelloPayloadTest {
     }
 
     @Test
-    fun `seq monotonically increases across two hello builds`() {
-        val p1 = buildWatchdogHelloJson("d", seq = 0, sentAt = 1L, capabilityManifest = null)
-        val p2 = buildWatchdogHelloJson("d", seq = 1, sentAt = 2L, capabilityManifest = null)
-        val s1 =
+    fun `seq field is serialized into hello JSON`() {
+        val payload = buildWatchdogHelloJson("d", seq = 7, sentAt = 1L, capabilityManifest = null)
+        val seq =
             Json
-                .parseToJsonElement(p1)
+                .parseToJsonElement(payload)
                 .jsonObject
                 .getValue("seq")
                 .jsonPrimitive.content
                 .toInt()
-        val s2 =
-            Json
-                .parseToJsonElement(p2)
-                .jsonObject
-                .getValue("seq")
-                .jsonPrimitive.content
-                .toInt()
-        assertTrue(s2 > s1)
+        assertEquals(7, seq)
     }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceHelloPayloadTest.kt
@@ -3,57 +3,128 @@ package com.wscanplus.app
 import com.wscanplus.app.capabilities.AcousticStatus
 import com.wscanplus.app.capabilities.CameraIrStatus
 import com.wscanplus.app.capabilities.DeviceCapabilityManifest
+import com.wscanplus.app.sensor.FloorEstimate
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class WatchdogServiceHelloPayloadTest {
+
+    private val manifest = DeviceCapabilityManifest(
+        deviceModel = "Pixel Test",
+        wifiScan = true,
+        wifiRtt = true,
+        wifiAware = false,
+        uwb = false,
+        barometer = true,
+        nsd = true,
+        bluetoothLe = true,
+        proximity = true,
+        magnetometer = true,
+        accelerometer = true,
+        gyroscope = true,
+        wifiRttAvailableNow = true,
+        cameraIrCapable = CameraIrStatus.UNTESTED,
+        acousticSonarCapable = AcousticStatus.UNTESTED,
+    )
+
     @Test
-    fun `hello message contains capabilities when manifest is present`() {
-        val manifest =
-            DeviceCapabilityManifest(
-                deviceModel = "Pixel Test",
-                wifiScan = true,
-                wifiRtt = true,
-                wifiAware = false,
-                uwb = false,
-                barometer = true,
-                nsd = true,
-                bluetoothLe = true,
-                proximity = true,
-                magnetometer = true,
-                accelerometer = true,
-                gyroscope = true,
-                wifiRttAvailableNow = true,
-                cameraIrCapable = CameraIrStatus.UNTESTED,
-                acousticSonarCapable = AcousticStatus.UNTESTED,
-            )
+    fun `hello contains type, deviceId, seq, and sentAt`() {
+        val sentAt = 1_700_000_000_000L
+        val payload = buildWatchdogHelloJson(
+            deviceId = "serial-123",
+            seq = 3,
+            sentAt = sentAt,
+            capabilityManifest = null,
+        )
 
-        val payload =
-            buildWatchdogHelloJson(
-                deviceId = "serial-123",
-                capabilityManifest = manifest,
-            )
-
-        val root =
-            Json
-                .parseToJsonElement(payload)
-                .jsonObject
+        val root = Json.parseToJsonElement(payload).jsonObject
 
         assertEquals("hello", root.getValue("type").jsonPrimitive.content)
         assertEquals("serial-123", root.getValue("deviceId").jsonPrimitive.content)
+        assertEquals(3, root.getValue("seq").jsonPrimitive.content.toInt())
+        assertEquals(sentAt, root.getValue("sentAt").jsonPrimitive.content.toLong())
+    }
+
+    @Test
+    fun `hello contains capabilities when manifest is present`() {
+        val payload = buildWatchdogHelloJson(
+            deviceId = "serial-123",
+            seq = 0,
+            sentAt = 1_700_000_000_000L,
+            capabilityManifest = manifest,
+        )
+
+        val root = Json.parseToJsonElement(payload).jsonObject
+
         assertTrue(root.containsKey("capabilities"))
         assertEquals(
             "Pixel Test",
-            root
-                .getValue("capabilities")
-                .jsonObject
-                .getValue("deviceModel")
-                .jsonPrimitive
-                .content,
+            root.getValue("capabilities").jsonObject.getValue("deviceModel").jsonPrimitive.content,
         )
+    }
+
+    @Test
+    fun `hello omits capabilities when manifest is null`() {
+        val payload = buildWatchdogHelloJson(
+            deviceId = "serial-456",
+            seq = 0,
+            sentAt = 1_700_000_000_000L,
+            capabilityManifest = null,
+        )
+
+        val root = Json.parseToJsonElement(payload).jsonObject
+
+        assertFalse(root.containsKey("capabilities"))
+    }
+
+    @Test
+    fun `hello includes floorEstimate when provided`() {
+        val estimate = FloorEstimate(
+            relativeFloor = 2,
+            deltaHpa = 0.71f,
+            confidenceMeters = 1.5f,
+            observedAt = 1_700_000_001_000L,
+        )
+        val payload = buildWatchdogHelloJson(
+            deviceId = "serial-789",
+            seq = 1,
+            sentAt = 1_700_000_000_000L,
+            capabilityManifest = null,
+            floorEstimate = estimate,
+        )
+
+        val root = Json.parseToJsonElement(payload).jsonObject
+        assertTrue(root.containsKey("floorEstimate"))
+        val fe = root.getValue("floorEstimate").jsonObject
+        assertEquals(2, fe.getValue("relativeFloor").jsonPrimitive.content.toInt())
+        assertEquals(1_700_000_001_000L, fe.getValue("observedAt").jsonPrimitive.content.toLong())
+    }
+
+    @Test
+    fun `hello omits floorEstimate when null`() {
+        val payload = buildWatchdogHelloJson(
+            deviceId = "serial-789",
+            seq = 0,
+            sentAt = 1_700_000_000_000L,
+            capabilityManifest = null,
+            floorEstimate = null,
+        )
+
+        val root = Json.parseToJsonElement(payload).jsonObject
+        assertFalse(root.containsKey("floorEstimate"))
+    }
+
+    @Test
+    fun `seq monotonically increases across two hello builds`() {
+        val p1 = buildWatchdogHelloJson("d", seq = 0, sentAt = 1L, capabilityManifest = null)
+        val p2 = buildWatchdogHelloJson("d", seq = 1, sentAt = 2L, capabilityManifest = null)
+        val s1 = Json.parseToJsonElement(p1).jsonObject.getValue("seq").jsonPrimitive.content.toInt()
+        val s2 = Json.parseToJsonElement(p2).jsonObject.getValue("seq").jsonPrimitive.content.toInt()
+        assertTrue(s2 > s1)
     }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
@@ -88,11 +88,12 @@ class BarometerSamplerTest {
     @Test
     fun `observedAt is set to the provided epoch millis`() {
         val fixedTime = 1_700_000_000_000L
-        val estimate = computeFloorEstimate(
-            currentHpa = 1013.25f,
-            baselineHpa = 1013.25f,
-            observedAt = fixedTime,
-        )
+        val estimate =
+            computeFloorEstimate(
+                currentHpa = 1013.25f,
+                baselineHpa = 1013.25f,
+                observedAt = fixedTime,
+            )
         assertEquals(fixedTime, estimate.observedAt)
     }
 

--- a/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/sensor/BarometerSamplerTest.kt
@@ -86,6 +86,28 @@ class BarometerSamplerTest {
     }
 
     @Test
+    fun `observedAt is set to the provided epoch millis`() {
+        val fixedTime = 1_700_000_000_000L
+        val estimate = computeFloorEstimate(
+            currentHpa = 1013.25f,
+            baselineHpa = 1013.25f,
+            observedAt = fixedTime,
+        )
+        assertEquals(fixedTime, estimate.observedAt)
+    }
+
+    @Test
+    fun `observedAt defaults to a recent timestamp when not provided`() {
+        val before = System.currentTimeMillis()
+        val estimate = computeFloorEstimate(currentHpa = 1013.25f, baselineHpa = 1013.25f)
+        val after = System.currentTimeMillis()
+        assertTrue(
+            "observedAt=${estimate.observedAt} should be in [$before, $after]",
+            estimate.observedAt in before..after,
+        )
+    }
+
+    @Test
     fun `constants are physically reasonable`() {
         assertTrue("Expected 7-10 m/hPa, got $METERS_PER_HPA", METERS_PER_HPA in 7f..10f)
         assertTrue("Expected 2.5-4 m/floor, got $FLOOR_HEIGHT_METERS", FLOOR_HEIGHT_METERS in 2.5f..4f)

--- a/desktop/adb/AdbTransport.js
+++ b/desktop/adb/AdbTransport.js
@@ -22,7 +22,7 @@ export class AdbTransport extends EventEmitter {
   #bufferedText = '';
   /** @type {ReadableStreamDefaultReader<Uint8Array> | undefined} */
   #reader;
-  /** @type {{ serial: string, deviceId: string | null, capabilities: object | null } | null} */
+  /** @type {{ serial: string, deviceId: string | null, capabilities: object | null, seq: number | null, sentAt: number | null, receivedAt: number, latencyMs: number | null } | null} */
   #session = null;
   /** @type {{ readable: ReadableStream<Uint8Array>, writable: WritableStream<Uint8Array>, closed: Promise<undefined>, close: () => Promise<void>, transportId?: bigint } | undefined} */
   #socket;
@@ -47,8 +47,10 @@ export class AdbTransport extends EventEmitter {
   /**
    * Returns the last parsed hello session for the connected device.
    * `capabilities` is `null` when the Android side omits the key.
+   * `seq` and `sentAt` are `null` when the Android side omits them (older builds).
+   * `latencyMs` is `null` when `sentAt` was not present in the hello.
    *
-   * @returns {{ serial: string, deviceId: string | null, capabilities: object | null } | null}
+   * @returns {{ serial: string, deviceId: string | null, capabilities: object | null, seq: number | null, sentAt: number | null, receivedAt: number, latencyMs: number | null } | null}
    */
   get session() {
     return this.#session;
@@ -199,13 +201,34 @@ export class AdbTransport extends EventEmitter {
       return;
     }
 
+    const receivedAt = Date.now();
+    const sentAt = typeof message.sentAt === 'number' ? message.sentAt : null;
     this.#session = {
       serial: this.#connectedSerial ?? '',
-      deviceId:
-        typeof message.deviceId === 'string' ? message.deviceId : null,
+      deviceId: typeof message.deviceId === 'string' ? message.deviceId : null,
       capabilities: message.capabilities ?? null,
+      seq: typeof message.seq === 'number' ? message.seq : null,
+      sentAt,
+      receivedAt,
+      latencyMs: sentAt !== null ? receivedAt - sentAt : null,
     };
 
     this.emit('hello', this.#session);
+    void this.#sendAck(this.#session.seq ?? 0);
+  }
+
+  async #sendAck(seq) {
+    if (!this.#socket) return;
+    try {
+      const ack = JSON.stringify({ type: 'ack', seq }) + '\n';
+      const writer = this.#socket.writable.getWriter();
+      try {
+        await writer.write(new TextEncoder().encode(ack));
+      } finally {
+        writer.releaseLock();
+      }
+    } catch (error) {
+      this.emit('error', error);
+    }
   }
 }

--- a/desktop/adb/AdbTransport.js
+++ b/desktop/adb/AdbTransport.js
@@ -48,7 +48,8 @@ export class AdbTransport extends EventEmitter {
    * Returns the last parsed hello session for the connected device.
    * `capabilities` is `null` when the Android side omits the key.
    * `seq` and `sentAt` are `null` when the Android side omits them (older builds).
-   * `latencyMs` is `null` when `sentAt` was not present in the hello.
+   * `latencyMs` is `null` when `sentAt` was not present in the hello, or when
+   * `receivedAt < sentAt` (device clock skew between Android and desktop).
    *
    * @returns {{ serial: string, deviceId: string | null, capabilities: object | null, seq: number | null, sentAt: number | null, receivedAt: number, latencyMs: number | null } | null}
    */
@@ -210,7 +211,7 @@ export class AdbTransport extends EventEmitter {
       seq: typeof message.seq === 'number' ? message.seq : null,
       sentAt,
       receivedAt,
-      latencyMs: sentAt !== null ? receivedAt - sentAt : null,
+      latencyMs: sentAt !== null && receivedAt >= sentAt ? receivedAt - sentAt : null,
     };
 
     this.emit('hello', this.#session);

--- a/desktop/adb/AdbTransport.js
+++ b/desktop/adb/AdbTransport.js
@@ -223,7 +223,7 @@ export class AdbTransport extends EventEmitter {
       const ack = JSON.stringify({ type: 'ack', seq }) + '\n';
       const writer = this.#socket.writable.getWriter();
       try {
-        await writer.write(new TextEncoder().encode(ack));
+        await writer.write(Buffer.from(ack, 'utf8'));
       } finally {
         writer.releaseLock();
       }

--- a/desktop/adb/AdbTransport.test.js
+++ b/desktop/adb/AdbTransport.test.js
@@ -59,18 +59,22 @@ const createSocket = ({ chunks = [], autoClose = true, transportId = 1n } = {}) 
     return Promise.resolve();
   });
 
+  // Shared mock so tests can assert what was written back to Android.
+  const mockWrite = jest.fn().mockResolvedValue(undefined);
+
   return {
     transportId,
     readable,
     writable: {
       getWriter: () => ({
-        write: jest.fn(),
+        write: mockWrite,
         releaseLock: jest.fn(),
         close: jest.fn(),
       }),
     },
     closed,
     close,
+    _mockWrite: mockWrite,
   };
 };
 
@@ -144,18 +148,91 @@ describe('AdbTransport.connect', () => {
     await transport.connect('serial-123');
     await flushMicrotasks();
 
-    expect(transport.session).toEqual({
+    // Core identity fields
+    expect(transport.session).toMatchObject({
       serial: 'serial-123',
       deviceId: 'android-123',
       capabilities: null,
+      seq: null,
+      sentAt: null,
+      latencyMs: null,
     });
-    expect(helloEvents).toEqual([
-      {
-        serial: 'serial-123',
-        deviceId: 'android-123',
-        capabilities: null,
-      },
-    ]);
+    // receivedAt must be a recent timestamp
+    expect(typeof transport.session.receivedAt).toBe('number');
+    expect(transport.session.receivedAt).toBeGreaterThan(0);
+  });
+
+  test('session captures seq, sentAt, receivedAt, and latencyMs from hello', async () => {
+    const sentAt = Date.now() - 20; // simulate 20 ms in-flight
+    const hello = `${JSON.stringify({
+      type: 'hello',
+      deviceId: 'android-456',
+      seq: 5,
+      sentAt,
+    })}\n`;
+    const socket = createSocket({
+      chunks: [Buffer.from(hello, 'utf8')],
+      autoClose: false,
+    });
+    mockCreateDeviceConnection.mockResolvedValue(socket);
+    mockWaitForDisconnect.mockResolvedValue();
+
+    const transport = new AdbTransport();
+    await transport.connect('serial-456');
+    await flushMicrotasks();
+
+    const session = transport.session;
+    expect(session.seq).toBe(5);
+    expect(session.sentAt).toBe(sentAt);
+    expect(typeof session.receivedAt).toBe('number');
+    expect(session.receivedAt).toBeGreaterThanOrEqual(sentAt);
+    expect(typeof session.latencyMs).toBe('number');
+    expect(session.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('sends ack back to Android after receiving hello (bidirectional smoke)', async () => {
+    const hello = `${JSON.stringify({
+      type: 'hello',
+      deviceId: 'android-789',
+      seq: 3,
+      sentAt: Date.now(),
+    })}\n`;
+    const socket = createSocket({
+      chunks: [Buffer.from(hello, 'utf8')],
+      autoClose: false,
+    });
+    mockCreateDeviceConnection.mockResolvedValue(socket);
+    mockWaitForDisconnect.mockResolvedValue();
+
+    const transport = new AdbTransport();
+    await transport.connect('serial-789');
+    await flushMicrotasks();
+
+    expect(socket._mockWrite).toHaveBeenCalledTimes(1);
+    const written = Buffer.from(socket._mockWrite.mock.calls[0][0]).toString('utf8');
+    const ack = JSON.parse(written.trim());
+    expect(ack.type).toBe('ack');
+    expect(ack.seq).toBe(3);
+  });
+
+  test('ack seq defaults to 0 when hello has no seq field', async () => {
+    const hello = `${JSON.stringify({ type: 'hello', deviceId: 'android-000' })}\n`;
+    const socket = createSocket({
+      chunks: [Buffer.from(hello, 'utf8')],
+      autoClose: false,
+    });
+    mockCreateDeviceConnection.mockResolvedValue(socket);
+    mockWaitForDisconnect.mockResolvedValue();
+
+    const transport = new AdbTransport();
+    await transport.connect('serial-000');
+    await flushMicrotasks();
+
+    expect(socket._mockWrite).toHaveBeenCalledTimes(1);
+    const written = Buffer.from(socket._mockWrite.mock.calls[0][0]).toString('utf8');
+    const ack = JSON.parse(written.trim());
+    expect(ack.type).toBe('ack');
+    expect(ack.seq).toBe(0);
   });
 
   test('disconnect closes the socket and emits disconnect once', async () => {


### PR DESCRIPTION
Closes #222

## Summary
- Made by: Claude (Anthropic)
- Add minimal telemetry evidence fields to the Android hello transport so sensor/backend state is verifiable instead of inferred
- Capture hello receipt metadata on desktop and close the bidirectional loop with an ack message back to Android
- Keep scope narrow: no new dependencies, no unrelated UI work, no Gemini/Vertex changes

## Why
The existing chain already exists:
- Android probes `DeviceCapabilityManifest`
- Android starts `BarometerSampler`
- `WatchdogService` stores `currentFloorEstimate`
- Android sends hello payload over localhost tcp:9000
- Desktop parses the hello payload

What was missing is proof of freshness and delivery:
- no hello sequence number
- no hello sent timestamp
- no floor estimate timestamp / observedAt on sensor readings
- no desktop receipt timestamp or latency
- no bidirectional signal (desktop never replied to Android)

This PR adds the minimum evidence needed to prove:
**sensor → service → hello transport → desktop receipt → ack back to Android**

## Scope

### Android
- `FloorEstimate` gains `observedAt: Long` (epoch ms at sensor reading time)
- `BarometerSampler.computeFloorEstimate()` accepts optional `observedAt` param (defaults to `currentTimeMillis()`); all existing call sites unaffected
- `WatchdogHelloPayload` gains `seq: Int` (monotonic per-connection counter) and `sentAt: Long`
- Hello payload optionally carries a `FloorEstimateSummary` snapshot (relativeFloor, deltaHpa, confidenceMeters, observedAt) from the live barometer at connection time
- `WatchdogService` reads incoming desktop messages line-by-line via `bufferedReader`; parses `DesktopMessageEnvelope` and stores `lastDesktopAckSeq` when desktop sends an ack
- Removed stale TODO comment (ServerSocket already runs on background thread)

### Desktop
- `AdbTransport` session gains `seq`, `sentAt`, `receivedAt` (`Date.now()`), and `latencyMs` (`receivedAt - sentAt`); null when `sentAt` absent (older builds tolerated)
- After parsing hello, transport writes `{"type":"ack","seq":N}\n` back to Android — closing the bidirectional evidence loop

## Rules followed
- One feature only
- References exactly one GitHub Issue (#222)
- No new dependencies
- Small atomic change set
- Gemini/Vertex integration untouched

## Validation
- [ ] `./gradlew :core:test`
- [ ] `./gradlew :app:testDebugUnitTest`
- [ ] `./gradlew :app:assembleDebug`
- [ ] `npm test` in `desktop/`
- [ ] `npm run lint` in `desktop/`
- [ ] confirm `.env` / `local.properties` not tracked

## Checklist
- [x] Made by: Claude (Anthropic)
- [x] References exactly one GitHub Issue (#222)
- [ ] CI is green before marking Ready for Review
- [x] One feature OR one bugfix (not both)
- [x] < 200 LOC changed (tests excluded)
- [x] No new dependencies mixed in
- [x] Meaningful tests included/updated (2 new Android tests, 3 new desktop tests, existing assertions updated)
- [x] Errors are logged, not silently swallowed
- [ ] Documentation updated (or doc issue filed)
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets of any kind committed
- [ ] Required platform checks passed
- [x] Merged via Squash and merge only
- [x] Gemini/Vertex integration untouched