### PR TITLE
fix(android): reset lastDesktopAckSeq on reconnect

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -500,6 +500,7 @@ class WatchdogService : Service() {
 
     private fun handleHelloConnection(clientSocket: Socket) {
         helloClientSocket = clientSocket
+        lastDesktopAckSeq = -1
 
         try {
             val seq = helloSeq.getAndIncrement()


### PR DESCRIPTION
## Summary
- Made by: Claude (Anthropic)
- Reset `lastDesktopAckSeq = -1` at the start of each new hello connection in `handleHelloConnection`

## Why
Post-merge review of #223 identified that `lastDesktopAckSeq` was never reset between connections. After a reconnect, the field retained the seq from the previous session until a new ack arrived. A caller checking it during that window would see a stale value and incorrectly conclude delivery was confirmed for the new session.

## Change
One line added before the hello is sent:
```kotlin
lastDesktopAckSeq = -1
```

Placed immediately after `helloClientSocket = clientSocket`, before `helloSeq.getAndIncrement()` and before any writes to the socket.

## Checklist
- [x] Made by: Claude (Anthropic)
- [x] References exactly one GitHub Issue (follow-up from #223 post-merge review)
- [x] One feature OR one bugfix (not both)
- [x] < 200 LOC changed (tests excluded)
- [x] No new dependencies mixed in
- [x] Errors are logged, not silently swallowed
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets of any kind committed
- [x] Merged via Squash and merge only
- [x] Gemini/Vertex integration untouched

https://claude.ai/code/session_01T4sMEpn7ims5DVR1Scz1YV