### PR TITLE
feat(android): on-device diagnostic screen + ack parsing tests (#225)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -96,6 +96,10 @@
             android:name=".ScanHistoryActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".DiagnosticActivity"
+            android:exported="false" />
+
         <!--
             FileProvider for sharing JSON exports from ScanDataExporter.
             Exposes cacheDir/exports/ only — no other paths.

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -32,6 +32,7 @@ class DiagnosticActivity : Activity() {
 
             override fun onServiceDisconnected(name: ComponentName?) {
                 boundBinder = null
+                serviceBound = false
                 refreshDiagnostics()
             }
         }
@@ -87,6 +88,9 @@ class DiagnosticActivity : Activity() {
     }
 
     private fun refreshDiagnostics() {
+        if (!serviceBound) {
+            serviceBound = bindService(Intent(this, WatchdogService::class.java), serviceConnection, 0)
+        }
         val binder = boundBinder
         if (binder == null) {
             diagnosticText.text = "Service: NOT RUNNING"

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -1,0 +1,147 @@
+package com.wscanplus.app
+
+import android.app.Activity
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.graphics.Typeface
+import android.os.Bundle
+import android.os.IBinder
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class DiagnosticActivity : Activity() {
+    private var boundBinder: WatchdogService.LocalBinder? = null
+    private var serviceBound = false
+    private lateinit var diagnosticText: TextView
+
+    private val serviceConnection =
+        object : ServiceConnection {
+            override fun onServiceConnected(
+                name: ComponentName?,
+                binder: IBinder?,
+            ) {
+                boundBinder = binder as? WatchdogService.LocalBinder
+                refreshDiagnostics()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                boundBinder = null
+                refreshDiagnostics()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val root =
+            LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(48, 48, 48, 48)
+            }
+        val title =
+            TextView(this).apply {
+                text = "WatchdogService Diagnostics"
+                textSize = 18f
+            }
+        val refreshButton =
+            Button(this).apply {
+                text = "Refresh"
+                setOnClickListener { refreshDiagnostics() }
+            }
+        diagnosticText =
+            TextView(this).apply {
+                textSize = 13f
+                typeface = Typeface.MONOSPACE
+                text = "Connecting…"
+            }
+        val scroll = ScrollView(this)
+        scroll.addView(diagnosticText)
+
+        root.addView(title)
+        root.addView(refreshButton)
+        root.addView(scroll)
+        setContentView(root)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        serviceBound = bindService(Intent(this, WatchdogService::class.java), serviceConnection, 0)
+        if (!serviceBound) {
+            refreshDiagnostics()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (serviceBound) {
+            unbindService(serviceConnection)
+            serviceBound = false
+        }
+        boundBinder = null
+    }
+
+    private fun refreshDiagnostics() {
+        val binder = boundBinder
+        if (binder == null) {
+            diagnosticText.text = "Service: NOT RUNNING"
+            return
+        }
+
+        val svc = binder.getService()
+        val sb = StringBuilder()
+
+        sb.append("Service: RUNNING")
+        if (binder.isDegraded) sb.append(" (degraded)")
+        sb.append("\n\n")
+
+        sb.append("── Capabilities ──\n")
+        val caps = binder.capabilityManifest
+        if (caps != null) {
+            sb.append("Device:       ${caps.deviceModel}\n")
+            sb.append("WiFi scan:    ${caps.wifiScan}\n")
+            sb.append("WiFi RTT:     ${caps.wifiRtt}  now=${caps.wifiRttAvailableNow}\n")
+            sb.append("WiFi Aware:   ${caps.wifiAware}\n")
+            sb.append("UWB:          ${caps.uwb}\n")
+            sb.append("Barometer:    ${caps.barometer}\n")
+            sb.append("BLE:          ${caps.bluetoothLe}\n")
+            sb.append("Camera IR:    ${caps.cameraIrCapable}\n")
+            sb.append("Acoustic:     ${caps.acousticSonarCapable}\n")
+        } else {
+            sb.append("Not probed yet\n")
+        }
+
+        sb.append("\n── Floor Estimate ──\n")
+        val fe = svc.currentFloorEstimate
+        if (fe != null) {
+            sb.append("Relative floor:  ${fe.relativeFloor}\n")
+            sb.append("Delta hPa:       ${"%.2f".format(fe.deltaHpa)}\n")
+            sb.append("Confidence:      ${"%.1f".format(fe.confidenceMeters)} m\n")
+            sb.append("observedAt:      ${formatMs(fe.observedAt)}\n")
+        } else {
+            sb.append("Absent\n")
+        }
+
+        sb.append("\n── Desktop Link ──\n")
+        val ackSeq = svc.lastDesktopAckSeq
+        if (ackSeq == -1) {
+            sb.append("No ack received (desktop not connected)\n")
+        } else {
+            sb.append("Last ack seq: $ackSeq\n")
+        }
+
+        diagnosticText.text = sb.toString()
+    }
+
+    private fun formatMs(epochMs: Long): String = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault()).format(Date(epochMs))
+
+    companion object {
+        @Suppress("unused")
+        private const val TAG = "DiagnosticActivity"
+    }
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -61,12 +61,18 @@ class MainActivity : Activity() {
                 text = "View Scan History"
                 setOnClickListener { openScanHistory() }
             }
+        val diagnosticButton =
+            Button(this).apply {
+                text = "Diagnostics"
+                setOnClickListener { openDiagnostics() }
+            }
         rootLayout.addView(statusView)
         rootLayout.addView(actionButton)
         rootLayout.addView(settingsButton)
         rootLayout.addView(mapButton)
         rootLayout.addView(threatResultsButton)
         rootLayout.addView(historyButton)
+        rootLayout.addView(diagnosticButton)
         setContentView(rootLayout)
 
         if (!ConsentStore(this).isConsentGiven()) {
@@ -214,6 +220,10 @@ class MainActivity : Activity() {
 
     private fun openScanHistory() {
         startActivity(Intent(this, ScanHistoryActivity::class.java))
+    }
+
+    private fun openDiagnostics() {
+        startActivity(Intent(this, DiagnosticActivity::class.java))
     }
 
     private fun isDeviceLocationEnabled(): Boolean {

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -178,6 +178,12 @@ class WatchdogService : Service() {
 
     inner class LocalBinder : Binder() {
         fun getService(): WatchdogService = this@WatchdogService
+
+        val capabilityManifest: DeviceCapabilityManifest?
+            get() = this@WatchdogService.capabilityManifest
+
+        val isDegraded: Boolean
+            get() = this@WatchdogService.degradedMode
     }
 
     private val binder = LocalBinder()

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -550,7 +550,11 @@ class WatchdogService : Service() {
     }
 
     private fun parseDesktopMessage(line: String) {
-        val msg = parseDesktopMessageLine(line, inboundJson) ?: return
+        val msg =
+            parseDesktopMessageLine(line, inboundJson) ?: run {
+                Log.w(TAG, "Failed to parse desktop message")
+                return
+            }
         if (msg.type == "ack") {
             lastDesktopAckSeq = msg.seq
             Log.d(TAG, "Desktop ack received: seq=${msg.seq}")

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -544,14 +544,10 @@ class WatchdogService : Service() {
     }
 
     private fun parseDesktopMessage(line: String) {
-        try {
-            val msg = inboundJson.decodeFromString<DesktopMessageEnvelope>(line)
-            if (msg.type == "ack") {
-                lastDesktopAckSeq = msg.seq
-                Log.d(TAG, "Desktop ack received: seq=${msg.seq}")
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to parse desktop message", e)
+        val msg = parseDesktopMessageLine(line, inboundJson) ?: return
+        if (msg.type == "ack") {
+            lastDesktopAckSeq = msg.seq
+            Log.d(TAG, "Desktop ack received: seq=${msg.seq}")
         }
     }
 
@@ -759,6 +755,16 @@ internal data class DesktopMessageEnvelope(
     val type: String,
     val seq: Int = -1,
 )
+
+internal fun parseDesktopMessageLine(
+    line: String,
+    json: Json = Json { ignoreUnknownKeys = true },
+): DesktopMessageEnvelope? =
+    try {
+        json.decodeFromString<DesktopMessageEnvelope>(line)
+    } catch (_: Exception) {
+        null
+    }
 
 internal fun buildWatchdogHelloJson(
     deviceId: String,

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -121,6 +121,8 @@ class WatchdogService : Service() {
     private lateinit var ctiCacheRepository: CtiCacheRepository
     private lateinit var retentionManager: RetentionManager
     private lateinit var geminiThreatAnalyzer: GeminiThreatAnalyzer
+
+    @Volatile
     private var capabilityManifest: DeviceCapabilityManifest? = null
     private var barometerSampler: BarometerSampler? = null
 

--- a/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceParseTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceParseTest.kt
@@ -1,0 +1,48 @@
+package com.wscanplus.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WatchdogServiceParseTest {
+    @Test
+    fun `valid ack line returns envelope with type and seq`() {
+        val envelope = parseDesktopMessageLine("""{"type":"ack","seq":5}""")
+        assertEquals("ack", envelope?.type)
+        assertEquals(5, envelope?.seq)
+    }
+
+    @Test
+    fun `seq defaults to minus one when absent`() {
+        val envelope = parseDesktopMessageLine("""{"type":"ack"}""")
+        assertEquals(-1, envelope?.seq)
+    }
+
+    @Test
+    fun `non-ack type is parsed without error`() {
+        val envelope = parseDesktopMessageLine("""{"type":"ping","seq":0}""")
+        assertEquals("ping", envelope?.type)
+    }
+
+    @Test
+    fun `unknown fields are ignored`() {
+        val envelope = parseDesktopMessageLine("""{"type":"ack","seq":3,"extra":"ignored"}""")
+        assertEquals("ack", envelope?.type)
+        assertEquals(3, envelope?.seq)
+    }
+
+    @Test
+    fun `malformed JSON returns null`() {
+        assertNull(parseDesktopMessageLine("not json"))
+    }
+
+    @Test
+    fun `empty string returns null`() {
+        assertNull(parseDesktopMessageLine(""))
+    }
+
+    @Test
+    fun `missing type field returns null`() {
+        assertNull(parseDesktopMessageLine("""{"seq":1}"""))
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DiagnosticActivity` — a minimal on-device screen reachable from MainActivity that binds to `WatchdogService` (no-create) and displays live service state without requiring a desktop connection
- Adds `parseDesktopMessageLine` as an `internal` top-level function extracted from `parseDesktopMessage`, enabling unit testing of ack parsing in isolation
- Adds 7 unit tests in `WatchdogServiceParseTest` covering valid ack, seq default, non-ack type, unknown field tolerance, malformed JSON, empty string, and missing required field

## DiagnosticActivity — what it shows

| Section | Fields |
|---|---|
| Service state | RUNNING / NOT RUNNING, degraded flag |
| Capabilities | Full `DeviceCapabilityManifest` — device model, WiFi scan/RTT/Aware, UWB, barometer, BLE, camera IR, acoustic |
| Floor estimate | `relativeFloor`, `deltaHpa`, `confidenceMeters`, `observedAt` (or Absent) |
| Desktop link | `lastDesktopAckSeq` or "No ack received (desktop not connected)" |

The screen auto-refreshes on `onServiceConnected` / `onServiceDisconnected` and has a manual Refresh button. Shows "Service: NOT RUNNING" if service is not active.

## Local testability without desktop

Before this PR, verifying the telemetry chain required a connected desktop. DiagnosticActivity makes the following observable on-device with no ADB, no desktop, no external tooling:
- Whether the service is running and in what mode
- Whether capability probe completed
- Whether the barometer is producing floor estimates (and when)
- Whether the desktop has connected and sent an ack

## Changes

- `WatchdogService.kt` — `LocalBinder` gains `capabilityManifest` and `isDegraded` read-only property accessors; `parseDesktopMessage` delegates to extracted `parseDesktopMessageLine`
- `DiagnosticActivity.kt` — new Activity, programmatic UI, matches existing app style
- `MainActivity.kt` — "Diagnostics" button added
- `AndroidManifest.xml` — `DiagnosticActivity` registered (not exported)
- `WatchdogServiceParseTest.kt` — 7 ack parsing unit tests

## Test plan

- [ ] ktlint passes (`./gradlew :app:ktlintCheck`) — verified locally
- [ ] Unit tests pass in CI (`./gradlew :app:testDebugUnitTest`)
- [ ] `assembleDebug` passes in CI
- [ ] On device: tap Diagnostics from main screen, confirm service state and capabilities are visible
- [ ] On device (no desktop): confirm "No ack received (desktop not connected)" shown
- [ ] On device (desktop connected): confirm ack seq updates after hello/ack exchange

Closes #225