### PR TITLE
docs: align repo state, declare SESSION_STATE authoritative, add PRODUCT_SPEC

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,7 @@
 
 ## Current State
 - docs/SESSION_STATE.md — architecture decisions, locked choices, current phase + next steps
+- docs/PRODUCT_SPEC.md — product architecture, evidence/output model, language rules, and capability status labels
 - [docs/SESSION_STATE.md#2026-03-20-handoff-snapshot](docs/SESSION_STATE.md#2026-03-20-handoff-snapshot) — fastest re-entry point for the next AI session
 
 ## Device Testing

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -150,8 +150,9 @@ Before expanding UI or alerting features, the pipeline must reliably produce all
 ### 3. Capability status
 - What this device can actually do natively
 - Which features require ADB-assisted mode
+- Which features are enhanced by ADB-assisted mode
 - Which features are degraded or unavailable
-- `WORKS_NATIVE / WORKS_ADB / WORKS_DEGRADED / FAILS / UNTESTED` per feature
+- `WORKS_NATIVE / WORKS_ADB / WORKS_ADB_ENHANCED / WORKS_DEGRADED / FAILS / UNTESTED` per feature
 
 ### 4. Session summary
 - Key events from the session

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -1,0 +1,201 @@
+# wscan+ Product Specification
+
+> This document defines the product architecture, output model, and language standards for wscan+.
+> All agents must follow this spec when building or modifying UI, reporting, or alert logic.
+
+---
+
+## Core Principle
+
+**One evidence pipeline. Three presentation layers.**
+
+wscan+ maintains a single detection and storage model. Output depth varies by user tier. There are no separate detection engines for different users — only different views of the same evidence.
+
+```
+Evidence pipeline (shared)
+  └── Observation capture
+  └── Anomaly detection
+  └── Recurrence correlation
+  └── Capability-aware weighting
+  └── Session summarization
+  └── Export artifacts
+
+Presentation layers (per tier)
+  ├── Newbie     — plain language, calm, minimal
+  ├── Advanced   — evidence categories, reasons, identifiers
+  └── Professional — full fidelity, raw + derived, provenance
+```
+
+---
+
+## User Tiers
+
+### Tier 1 — Newbie
+
+**Who:** Elderly residents, nontechnical users, people who need clear summaries without jargon.
+
+**Output style:** Simple status. Plain language. Strong warnings only when evidence is solid.
+
+**Show:**
+- Anomaly detected / not detected
+- Recurring event / not recurring
+- "Suspicious network activity observed"
+- "Investigation recommended"
+- Visual timeline and map emphasis
+- Export/report button
+
+**Hide by default:**
+- MAC addresses
+- Certificate chain details
+- RSSI spread values
+- Raw heuristic confidence scores
+- Provider-specific markers
+- Debug output
+
+---
+
+### Tier 2 — Advanced
+
+**Who:** Security-aware users, technical tenants, people comfortable with logs but not full analyst workflows.
+
+**Output style:** Show evidence categories and reasons. Surface identifiers. Show capability state.
+
+**Show:**
+- Heuristic reasons (plain English)
+- Recurrence count and window
+- Source device
+- Environment type
+- Baseline deviation
+- Portal comparison result (if applicable)
+- BLE anomaly summary
+- Capability / ADB-assisted / degraded mode status
+- Export as JSON or CSV
+
+**Hide by default:**
+- Full debug traces
+- All raw scan records
+- Internal model metadata
+- Verbose correlation internals
+
+---
+
+### Tier 3 — Professional
+
+**Who:** The developer, security researchers, analysts, power users validating behavior.
+
+**Output style:** Full fidelity. Raw and derived data. Provenance and uncertainty included.
+
+**Show:**
+- All threat signals with confidence values
+- All reasons with provenance
+- Timestamps and identifiers
+- Historical context and recurrence windows
+- Portal fingerprints (redirect chain, TLS, structural markers)
+- BLE anomaly raw counts
+- Capability manifest state
+- ADB-assisted / native / degraded classification per feature
+- Export artifacts (JSON, PCAP reference)
+- Test and diagnostic output
+
+---
+
+## Language Rules
+
+### Use these terms
+
+| Term | When to use |
+|---|---|
+| `observation` | Something was detected and recorded |
+| `anomaly` | A deviation from the established baseline |
+| `recurring anomaly` | Same pattern detected across multiple sessions |
+| `correlated event` | Multiple signals pointing to the same cause |
+| `suspicious portal` | Captive portal that does not match known-good baseline |
+| `investigation recommended` | Evidence warrants further review but is not confirmed |
+| `enhanced mode available` | ADB-assisted features can improve detection on this device |
+| `ADB-assisted mode required` | This feature requires ADB on this device |
+| `degraded mode` | Running with reduced capability (e.g. fine location denied, background access unavailable) |
+
+### Avoid these terms
+
+| Term | Why |
+|---|---|
+| `attacker confirmed` | Attribution is an inference, not a measured fact |
+| `attacker detected` | Same — overstates certainty |
+| `compromised` | Too absolute for the evidence level this app produces |
+| `hidden camera detected` | Not a claim this evidence pipeline can support |
+| `BLE spam tool confirmed` | Tooling type is inference, not observation |
+| `Flipper / ESP32 detected` | Device class cannot be confirmed from BLE advertisement data alone |
+| `resident confirmed` | Personal attribution from RF evidence alone is not defensible |
+| `proven` | wscan+ produces evidence, not legal proof |
+
+**General rule:** wscan+ is an evidence collection and analysis tool, not an attribution engine. Language must reflect what was observed and measured, not what was inferred about intent or actor identity. Reports must be defensible to nontechnical stakeholders, building management, and support services.
+
+---
+
+## Minimum Evidence Requirements
+
+Before expanding UI or alerting features, the pipeline must reliably produce all five evidence objects:
+
+### 1. Observation
+- What happened (heuristic type, signal category)
+- When (timestamp)
+- Where (GPS coordinates if available, floor estimate if barometer present)
+- Which device saw it (device serial, capability state)
+
+### 2. Anomaly
+- What deviated from the baseline
+- Why it deviated (reason strings, max 3 per signal)
+- Whether recurrence exists across sessions
+
+### 3. Capability status
+- What this device can actually do natively
+- Which features require ADB-assisted mode
+- Which features are degraded or unavailable
+- `WORKS_NATIVE / WORKS_ADB / WORKS_DEGRADED / FAILS / UNTESTED` per feature
+
+### 4. Session summary
+- Key events from the session
+- Environment context
+- Confidence level of findings
+- Exportable report artifact
+
+### 5. Cross-session recurrence
+- Same anomaly pattern seen before?
+- Same location?
+- Same time window?
+- Same source device(s)?
+
+**Gate condition:** If these five evidence objects are not yet reliably produced, UI should remain minimal. Do not build polished alert dashboards or advanced correlation views before the underlying data is trustworthy.
+
+---
+
+## UI Build Sequencing
+
+### Build now (data is sufficient)
+- Diagnostics / capability screen
+- Session summary screen
+- Scan history timeline
+- Map / heatmap overlay
+- Export / report screen
+
+### Defer until evidence objects are validated
+- Polished multi-tier alert dashboards
+- Advanced campaign or actor views
+- Complicated cross-session correlation UI
+- Portal or BLE specialized screens
+- Desktop orchestration UI
+
+---
+
+## Detection Output Classification
+
+Capability status labels (used in reporting and UI):
+
+| Label | Meaning |
+|---|---|
+| `WORKS_NATIVE` | Feature functions without ADB or special permissions |
+| `WORKS_ADB` | Feature functions only with ADB-assisted mode active |
+| `WORKS_ADB_ENHANCED` | Feature functions natively but improves significantly with ADB |
+| `WORKS_DEGRADED` | Feature runs but with reduced data quality or coverage |
+| `FAILS` | Feature does not function on this device/OS combination |
+| `UNTESTED` | Not yet validated on this device |

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -20,7 +20,7 @@ An Android app that runs on your phone and detects WiFi-layer attacks in real ti
 
 **Three components:**
 
-1. **Android companion app** (Kotlin) — the field sensor. Runs on any Android 7+ device. Scans passively, detects threats, stores results locally, syncs to desktop.
+1. **Android companion app** (Kotlin) — the field sensor. Runs on Android API 24+ through the current target API. Scans passively, detects threats, stores results locally, syncs to desktop.
 2. **Desktop hub** (Electron, Linux-first) — aggregates data from one or more Android devices, runs deeper analysis, integrates with Kismet/BetterCap for professional use.
 3. **Web UI** (PWA) — dashboard served locally by the desktop. Not a standalone product.
 
@@ -31,7 +31,7 @@ An Android app that runs on your phone and detects WiFi-layer attacks in real ti
 **Phase 0–1 — Foundation + scanner (complete)**
 - WatchdogService: foreground service, survives background/keyguard/Android 15 restrictions
 - Scanner chain: USB adapter (priority) → Standard WiFi scan. Root is dev-only opt-in.
-- Permission handling for Android 7–15 (fine/coarse/background location)
+- Permission handling for Android API 24+ through the current target API (fine/coarse/background location)
 - App icon, versioning (v0.1.0), data extraction rules, settings deep links
 
 **Phase 2 — Local threat detection (complete)**

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,6 +1,8 @@
 # wscan+ — What This Project Is and Where It Stands
 
-*Written 2026-03-23. Plain language. No jargon.*
+> **State as of 2026-04-22.**
+> For implementation decisions, always use [SESSION_STATE.md](SESSION_STATE.md) as the authoritative source.
+> This document gives a plain-language overview only.
 
 ---
 
@@ -24,69 +26,82 @@ An Android app that runs on your phone and detects WiFi-layer attacks in real ti
 
 ---
 
-## What's actually built and working
+## What's built (current state — Phases 0–4 complete)
 
-**Phase 1 — Scanner foundation (complete)**
-- WatchdogService: foreground service that keeps scanning alive across background/keyguard/Android 15 restrictions
-- Scanner chain: USB adapter (priority) → Standard WiFi scan. Root is dev-only opt-in, never a silent fallback.
-- Passive scanning works even with WiFi radio OFF (wifi_scan_always_enabled)
-- Permission handling for Android 7–15 across fine/coarse/background location
-- ADB transport: Android listens on localhost:9000, desktop connects via ADB (Phase 3 implementation)
+**Phase 0–1 — Foundation + scanner (complete)**
+- WatchdogService: foreground service, survives background/keyguard/Android 15 restrictions
+- Scanner chain: USB adapter (priority) → Standard WiFi scan. Root is dev-only opt-in.
+- Permission handling for Android 7–15 (fine/coarse/background location)
 - App icon, versioning (v0.1.0), data extraction rules, settings deep links
 
 **Phase 2 — Local threat detection (complete)**
 - 7 WiFi threat heuristics running on every scan:
   1. WEP/Open network detection
-  2. Evil twin detection (5 composite signals: OUI mismatch, security mismatch, channel, new BSSID, RSSI)
-  3. Encryption downgrade (WPA2/3 → Open/WEP)
-  4. Karma attack (WiFi Pineapple — multiple SSIDs on one BSSID)
-  5. SSID flooding (beacon spam — z-score vs rolling baseline)
-  6. RSSI proximity anomaly (transmitter in same room)
-  7. BSSID fingerprint rotation (attacker hardware swap)
-- HeuristicEngine coordinator + PolicyGate (confidence threshold 0.3)
-- Room database: scan sessions, scan results, BSSID fingerprints, threat signals, CTI cache
+  2. Evil twin detection (5 composite signals)
+  3. Encryption downgrade
+  4. Karma attack (WiFi Pineapple)
+  5. SSID flooding (beacon spam, z-score vs rolling baseline)
+  6. RSSI proximity anomaly
+  7. BSSID fingerprint rotation
+- HeuristicEngine + PolicyGate (confidence threshold 0.3)
+- Room database: scan sessions, results, BSSID fingerprints, threat signals, CTI cache
 - OUI vendor lookup (IEEE database bundled as asset)
 - ~100 unit tests passing
 
-**What's NOT built yet (Phase 3+)**
-- CTI integration (CrowdSec API — IP reputation lookup)
-- Gemini AI threat narrative generation (firebase-ai)
-- Scan history accumulation and baseline population
-- Desktop hub ADB library (deferred — ESM compatibility issue)
-- Google Maps threat heatmap (issue #9)
-- VpnService network traffic pipeline (deferred — out of scope for companion app)
+**Phase 3 — Privacy + CTI integration (complete)**
+- Consent framework (opt-in, GDPR/CCPA compliant)
+- CrowdSec CTI client (OkHttp, `/v2/smoke/{ip}`, quota guardrails, degraded-mode handler)
+- CTI Room cache (smoke TTL 48h, fire TTL 6h)
+- Google Maps threat heatmap + GPS-tagged scan history
+- SQLCipher AES-256 database encryption + 30-day retention purge
+
+**Phase 4 — AI layer + reporting (complete)**
+- GeminiThreatAnalyzer (firebase-ai, consent-gated, 5-min cooldown)
+- Scan history timeline activity
+- Scan history export (JSON)
+- ADB transport (WatchdogService tcp:9000, `@yume-chan/adb` on desktop)
+- Companion shell + Android session artifact import
+
+**Phase 5 — Desktop hub + companion sync (partial)**
+- Desktop flat layout + IPC bridge ✅
+- CompanionServer (WebSocket, token auth, rate limiting) ✅
+- Scanner + detector + store wired into Electron main ✅
+- CapabilityProbe layer (DeviceCapabilityManifest + DetectorGate) ✅
+- Transport hello with capability manifest ✅
+- Barometer-based floor tracking ✅
+- **Remaining:** darklotusLABS web UI (Sentinel Prism theme, NYX assistant, Vite build)
+- **Remaining:** Desktop CTI client (fetch-based)
+- **Remaining:** Unified timeline + map overlay
 
 ---
 
-## Current blockers
+## Known hardening items (in-progress, not blockers)
 
-Three P1 Android 15 bugs on Revvl Tab 2 that need resolution before new features:
-- `#122` — missing app-side ADB logs on Android 15
-- `#124` — coarse-only location fails scan retrieval
-- `#125` — backgrounded scan loses location access
+These are real gaps between what the architecture describes and what the runtime currently does:
 
-These do not affect the Moto G Play (API 34) or Pixel 10 Pro XL.
+- `knownProfiles` is not yet populated from Room DB at decision time — three heuristics (EncryptionDowngrade, BssidFingerprint, SsidFlooding) are structurally present but receive no historical data
+- `environmentType` defaults to `RESIDENTIAL` rather than being inferred from context
+- CTI and Gemini run as parallel informational tracks; they do not yet feed back into confidence scoring
+- `CapabilityManifest` is probed and transported but not yet used in scoring weights
+
+These are tracked as runtime drift corrections and will be addressed before further feature expansion.
 
 ---
 
 ## The agents
 
-- **Claude** — primary coding agent. Writes everything, opens PRs, merges. Runs with your GitHub token.
-- **Codex** — secondary. Activated only when Claude gives you a prompt to trigger it.
-- **Copilot** — reviews PRs automatically. Must be checked before merging.
-- **Gemini** — in-app threat analysis only (firebase-ai). Not a coding agent. Cannot see this repo.
-- **@dvntone** — direction, approval, final call. Does not write code.
+- **Claude** — primary coding agent. Opens PRs, writes code. Uses `claude/` branch prefix.
+- **Copilot/Codex** — secondary coding agent. Uses `copilot/` branch prefix.
+- **Gemini** — in-app threat analysis only (firebase-ai). Not a coding agent.
+- **@dvntone** — direction, approval, final call. Only person who merges.
 
 ---
 
-## What comes next (Phase 3)
+## What comes next
 
-1. Fix the 3 P1 Android 15 bugs
-2. Scan history accumulation — populate knownProfiles and baseline network counts
-3. CTI client — CrowdSec API with Room cache (smoke TTL 48h, fire TTL 6h)
-4. Gemini AI analysis layer — plain-language threat narrative from combined heuristic + CTI signal
-5. ADB desktop library decision (Tango ADB ESM evaluation)
+Per [SESSION_STATE.md](SESSION_STATE.md) (authoritative):
 
----
-
-*This document reflects the actual state of the repo as of 2026-03-23. It is not aspirational — everything in "what's built" is merged to main and verified.*
+1. Documentation alignment (underway)
+2. Runtime drift correction — wire Room/history into ScanContext, remove hardcoded environment defaults, harden PolicyGate
+3. Phase 5 remaining work — darklotusLABS web UI, desktop CTI client, unified timeline
+4. Device validation matrix across test devices before broader UI expansion

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,15 +53,16 @@ On-device heuristics engine is now live on Android and runs without third-party 
 
 Delivered through PRs `#96-#117`, `#127`, and follow-on device-validation/docs work on 2026-03-20.
 
-### Phase 2 follow-on items deferred beyond the baseline
+### Runtime hardening (in-progress, tracked separately from phase completion)
 
-These are real remaining tasks, but they are no longer reasons to treat Phase 2 as mostly incomplete:
+Phase 2 is complete. The following items are known gaps between the architecture and the current runtime behavior. They are tracked as drift corrections, not new features:
 
-- [ ] Scan history accumulation to populate `knownProfiles` and network baselines
+- [ ] Wire Room DB into `ScanContext` at decision time — `knownProfiles`, `baselineNetworkCount`, `baselineStdDev` are always empty/null at runtime; three heuristics (EncryptionDowngrade, BssidFingerprint, SsidFlooding) receive no historical data
+- [ ] Remove hardcoded `EnvironmentType.RESIDENTIAL` in `WatchdogService` — infer from context or default to `UNKNOWN`
+- [ ] Heuristic-aware gate hardening in `PolicyGate` — recurrence/corroboration weighting for behavioral detections; structural detections (WEP/Open) always pass
 - [ ] OuiAssetLoader integration in `WatchdogService` so BSSID vendor lookup is no longer wired as `null`
 - [ ] False-positive brakes backed by real CTI/context instead of stub logic
-- [ ] DAO instrumentation tests using an Android emulator path
-- [ ] Additional pure-logic unit tests around heuristic edge cases
+- [ ] Capability-aware scoring weight once context wiring is stable
 
 ### Locked permission stance from device validation
 
@@ -96,18 +97,22 @@ PRs: #183–#195
 
 Desktop receives and aggregates data from Android companion(s).
 
+### Complete
 - [x] Desktop flat layout + IPC bridge (PR #200)
 - [x] ADB transport — `@yume-chan/adb`, WatchdogService tcp:9000 (PRs #192–#195)
 - [x] Android ServerSocket(9000) implementation (PR #193)
 - [x] CompanionServer (WebSocket, token auth, rate limiting) (PR #200)
 - [x] Scanner + detector + store wired into Electron main (PR #200)
 - [x] CapabilityProbe layer — DeviceCapabilityManifest + DetectorGate + self-tests (PR #198)
-- [ ] Transport hello — include DeviceCapabilityManifest JSON in WatchdogService hello
-- [ ] Spatial WiFi floor tracking — barometer-based relative floor detection
+- [x] Transport hello — DeviceCapabilityManifest serialized in hello (PR #209 Android, PR #211 desktop)
+- [x] Spatial WiFi floor tracking — BarometerSampler + FloorEstimate (PR #217, #219, #221)
+
+### Remaining
+- [ ] darklotusLABS web UI — Sentinel Prism theme, NYX assistant, Vite build (app.darklotuslabs.com)
 - [ ] Desktop CTI client (fetch-based)
 - [ ] Unified timeline + map overlay
 
-~6-8 PRs remaining
+> **Authoritative state:** See SESSION_STATE.md. This checklist may lag.
 
 ## Phase 6 — Packaging + Release
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,7 +60,6 @@ Phase 2 is complete. The following items are known gaps between the architecture
 - [ ] Wire Room DB into `ScanContext` at decision time — `knownProfiles`, `baselineNetworkCount`, `baselineStdDev` are always empty/null at runtime; three heuristics (EncryptionDowngrade, BssidFingerprint, SsidFlooding) receive no historical data
 - [ ] Remove hardcoded `EnvironmentType.RESIDENTIAL` in `WatchdogService` — infer from context or default to `UNKNOWN`
 - [ ] Heuristic-aware gate hardening in `PolicyGate` — recurrence/corroboration weighting for behavioral detections; structural detections (WEP/Open) always pass
-- [ ] OuiAssetLoader integration in `WatchdogService` so BSSID vendor lookup is no longer wired as `null`
 - [ ] False-positive brakes backed by real CTI/context instead of stub logic
 - [ ] Capability-aware scoring weight once context wiring is stable
 

--- a/docs/SESSION_STATE.md
+++ b/docs/SESSION_STATE.md
@@ -1,5 +1,9 @@
 # SESSION_STATE (source of truth)
 
+> **THIS DOCUMENT IS THE AUTHORITATIVE SOURCE OF CURRENT PROJECT STATE.**
+> For any question about what is implemented, merged, or pending — use this document.
+> Other docs (`PROJECT_OVERVIEW.md`, `ROADMAP.md`) may lag and must not be used alone for implementation decisions.
+
 Repo: https://github.com/dvntone/wscanplus
 Name: wscan+ (WiFi Scan + Companion)
 Audience: professional / advanced users (defensive detection & assessment)


### PR DESCRIPTION
## Summary

Closes #231

Fixes documentation drift that caused agents to operate on stale assumptions. `PROJECT_OVERVIEW.md` was 4 phases behind current state, claiming CTI, Gemini, scan history, and Maps were not yet built — all four are complete. No document declared `SESSION_STATE.md` as authoritative, so agents had no clear source of truth.

## Changes

**`docs/PROJECT_OVERVIEW.md`**
- Removed "What's NOT built yet (Phase 3+)" section which incorrectly listed CTI, Gemini, scan history, and Maps as missing
- Replaced with accurate phase-by-phase summary (Phases 0–4 complete, Phase 5 partial)
- Added known runtime hardening gaps section (knownProfiles, environmentType, CTI/Gemini scoring, capability weight)
- Added pointer to SESSION_STATE.md as authoritative source

**`docs/SESSION_STATE.md`**
- Added authoritative-source declaration at top of file

**`docs/ROADMAP.md`**
- Fixed stale Phase 5 checklist: transport hello (PR #209, #211) and floor tracking (PR #217–#221) were complete but still marked pending
- Replaced vague "~6-8 PRs remaining" with explicit remaining item list
- Converted Phase 2 follow-on items to clearly-labeled "Runtime hardening" section (drift corrections, not new features)
- Added SESSION_STATE.md authority note on Phase 5 section

**`docs/PRODUCT_SPEC.md`** *(new file)*
- One evidence pipeline / three presentation tiers (Newbie, Advanced, Professional)
- Approved and avoided language rules
- Minimum evidence requirements (5 objects) and UI gate condition
- Capability status labels (WORKS_NATIVE / WORKS_ADB / WORKS_ADB_ENHANCED / WORKS_DEGRADED / FAILS / UNTESTED)

## Constraints

- No code changes
- No refactors
- No new features

## Agent

Claude (anthropic-code-agent) — guided by AGENTS.md, docs-only PR, single issue reference

https://claude.ai/code/session_01GZMsPzvfkdaPKFAVNUkqEq