### PR TITLE
feat(android): add capability readiness state model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Android Unit Tests
         if: steps.check_gradlew.outputs.skip != 'true'
         working-directory: android
-        run: ./gradlew :core:test
+        run: ./gradlew :core:test :app:test
 
       - name: Kotlin Lint (ktlint)
         if: steps.check_gradlew.outputs.skip != 'true'

--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.location.LocationManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -16,6 +15,7 @@ import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import com.wscanplus.app.capabilities.DeviceLocationState
 import com.wscanplus.app.privacy.ConsentStore
 
 class MainActivity : Activity() {
@@ -174,7 +174,7 @@ class MainActivity : Activity() {
             showPreciseLocationRequired()
             return
         }
-        if (isDeviceLocationEnabled().not()) {
+        if (DeviceLocationState.isLocationEnabled(this).not()) {
             showLocationServicesRequired()
             return
         }
@@ -224,20 +224,6 @@ class MainActivity : Activity() {
 
     private fun openDiagnostics() {
         startActivity(Intent(this, DiagnosticActivity::class.java))
-    }
-
-    private fun isDeviceLocationEnabled(): Boolean {
-        val locationManager = getSystemService(LocationManager::class.java)
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            locationManager.isLocationEnabled
-        } else {
-            @Suppress("DEPRECATION")
-            Settings.Secure.getInt(
-                contentResolver,
-                Settings.Secure.LOCATION_MODE,
-                Settings.Secure.LOCATION_MODE_OFF,
-            ) != Settings.Secure.LOCATION_MODE_OFF
-        }
     }
 
     private fun configureActionButton(

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -100,7 +100,7 @@ class CapabilityReadinessSurveyor(
             if (hasWifiSupport && !inputs.hasChangeWifiState) {
                 blockers += ReadinessBlocker.MISSING_CHANGE_WIFI_STATE
             }
-            if (!inputs.locationServicesEnabled) {
+            if (!inputs.locationServicesEnabled && fineLocationAffectsSupportedModule) {
                 blockers += ReadinessBlocker.LOCATION_SERVICES_DISABLED
             }
             if (hasWifiSupport && !hasNearbyWifiDevices) {
@@ -160,10 +160,7 @@ class CapabilityReadinessSurveyor(
             val cellularState =
                 when {
                     !hasCellularSupport -> CapabilityState.UNSUPPORTED_BY_HARDWARE
-                    !inputs.hasFineLocation -> {
-                        blockers += ReadinessBlocker.CELL_PERMISSION_MISSING
-                        CapabilityState.SUPPORTED_PERMISSION_MISSING
-                    }
+                    !inputs.hasFineLocation -> CapabilityState.SUPPORTED_PERMISSION_MISSING
                     else -> CapabilityState.SUPPORTED_AND_READY
                 }
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -4,93 +4,181 @@ import android.Manifest
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorManager
 import android.location.LocationManager
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.provider.Settings
+import android.telephony.TelephonyManager
 import androidx.core.content.ContextCompat
 
 class CapabilityReadinessSurveyor(
     private val context: Context,
 ) : PermissionReadinessProvider {
     override fun current(): PermissionReadiness {
-        val blockers = mutableSetOf<ReadinessBlocker>()
-
         val packageManager = context.packageManager
         val locationManager = context.getSystemService(LocationManager::class.java)
         val wifiManager = context.getSystemService(WifiManager::class.java)
         val bluetoothManager = context.getSystemService(BluetoothManager::class.java)
         val bluetoothAdapter = bluetoothManager?.adapter
+        val telephonyManager = context.getSystemService(TelephonyManager::class.java)
+        val sensorManager = context.getSystemService(SensorManager::class.java)
 
-        val hasFineLocation = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-        val hasAccessWifiState = hasPermission(Manifest.permission.ACCESS_WIFI_STATE)
-        val hasChangeWifiState = hasPermission(Manifest.permission.CHANGE_WIFI_STATE)
-        val locationServicesEnabled = locationManager?.isLocationEnabled ?: false
-        val hasWifiHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI)
-        val hasNearbyWifiDevices =
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-                hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
-
-        if (!hasFineLocation) blockers += ReadinessBlocker.MISSING_FINE_LOCATION
-        if (!hasAccessWifiState) blockers += ReadinessBlocker.MISSING_ACCESS_WIFI_STATE
-        if (!hasChangeWifiState) blockers += ReadinessBlocker.MISSING_CHANGE_WIFI_STATE
-        if (!locationServicesEnabled) blockers += ReadinessBlocker.LOCATION_SERVICES_DISABLED
-        if (!hasNearbyWifiDevices) blockers += ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES
-
-        val wifiPermissionMissing =
-            !hasFineLocation ||
-                !hasAccessWifiState ||
-                !hasChangeWifiState ||
-                !hasNearbyWifiDevices
-
-        val wifiState =
-            when {
-                !hasWifiHardware || wifiManager == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
-                wifiPermissionMissing -> CapabilityState.SUPPORTED_PERMISSION_MISSING
-                !locationServicesEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
-                else -> CapabilityState.SUPPORTED_AND_READY
-            }
-
-        val hasBleHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
-        val bleScanPermissionMissing =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                !hasPermission(Manifest.permission.BLUETOOTH_SCAN)
-            } else {
-                !hasFineLocation
-            }
-        val bleConnectPermissionMissing =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-                !hasPermission(Manifest.permission.BLUETOOTH_CONNECT)
-
-        if (bleScanPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
-        if (bleConnectPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION
-        if (bluetoothAdapter?.isEnabled == false) blockers += ReadinessBlocker.BLUETOOTH_DISABLED
-
-        val bleState =
-            when {
-                !hasBleHardware || bluetoothAdapter == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
-                bleScanPermissionMissing || bleConnectPermissionMissing ->
-                    CapabilityState.SUPPORTED_PERMISSION_MISSING
-                bluetoothAdapter.isEnabled == false -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
-                else -> CapabilityState.SUPPORTED_AND_READY
-            }
-
-        val cellularState =
-            if (hasFineLocation) {
-                CapabilityState.SUPPORTED_AND_READY
-            } else {
-                blockers += ReadinessBlocker.CELL_PERMISSION_MISSING
-                CapabilityState.SUPPORTED_PERMISSION_MISSING
-            }
-
-        return PermissionReadiness(
-            wifi = wifiState,
-            ble = bleState,
-            cellular = cellularState,
-            sensors = CapabilityState.SUPPORTED_AND_READY,
-            blockers = blockers,
+        return evaluate(
+            ReadinessInputs(
+                sdkInt = Build.VERSION.SDK_INT,
+                hasFineLocation = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION),
+                hasAccessWifiState = hasPermission(Manifest.permission.ACCESS_WIFI_STATE),
+                hasChangeWifiState = hasPermission(Manifest.permission.CHANGE_WIFI_STATE),
+                hasNearbyWifiDevicesPermission = hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES),
+                locationServicesEnabled = isDeviceLocationEnabled(locationManager),
+                hasWifiHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI),
+                hasWifiManager = wifiManager != null,
+                hasBleHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE),
+                hasBluetoothAdapter = bluetoothAdapter != null,
+                bluetoothEnabled = bluetoothAdapter?.isEnabled == true,
+                hasBluetoothScanPermission = hasPermission(Manifest.permission.BLUETOOTH_SCAN),
+                hasBluetoothConnectPermission = hasPermission(Manifest.permission.BLUETOOTH_CONNECT),
+                hasTelephonyHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY),
+                hasTelephonyManager = telephonyManager != null,
+                hasAnySupportedSensor = hasAnySupportedSensor(sensorManager),
+            ),
         )
     }
 
     private fun hasPermission(permission: String): Boolean =
         ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+    private fun isDeviceLocationEnabled(locationManager: LocationManager?): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            locationManager?.isLocationEnabled ?: false
+        } else {
+            @Suppress("DEPRECATION")
+            Settings.Secure.getInt(
+                context.contentResolver,
+                Settings.Secure.LOCATION_MODE,
+                Settings.Secure.LOCATION_MODE_OFF,
+            ) != Settings.Secure.LOCATION_MODE_OFF
+        }
+
+    private fun hasAnySupportedSensor(sensorManager: SensorManager?): Boolean =
+        sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null ||
+            sensorManager?.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null ||
+            sensorManager?.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null ||
+            sensorManager?.getDefaultSensor(Sensor.TYPE_PRESSURE) != null ||
+            sensorManager?.getDefaultSensor(Sensor.TYPE_STEP_COUNTER) != null
+
+    data class ReadinessInputs(
+        val sdkInt: Int,
+        val hasFineLocation: Boolean,
+        val hasAccessWifiState: Boolean,
+        val hasChangeWifiState: Boolean,
+        val hasNearbyWifiDevicesPermission: Boolean,
+        val locationServicesEnabled: Boolean,
+        val hasWifiHardware: Boolean,
+        val hasWifiManager: Boolean,
+        val hasBleHardware: Boolean,
+        val hasBluetoothAdapter: Boolean,
+        val bluetoothEnabled: Boolean,
+        val hasBluetoothScanPermission: Boolean,
+        val hasBluetoothConnectPermission: Boolean,
+        val hasTelephonyHardware: Boolean,
+        val hasTelephonyManager: Boolean,
+        val hasAnySupportedSensor: Boolean,
+    )
+
+    companion object {
+        internal fun evaluate(inputs: ReadinessInputs): PermissionReadiness {
+            val blockers = mutableSetOf<ReadinessBlocker>()
+            val hasWifiSupport = inputs.hasWifiHardware && inputs.hasWifiManager
+            val hasNearbyWifiDevices =
+                inputs.sdkInt < Build.VERSION_CODES.TIRAMISU ||
+                    inputs.hasNearbyWifiDevicesPermission
+
+            if (!inputs.hasFineLocation) blockers += ReadinessBlocker.MISSING_FINE_LOCATION
+            if (hasWifiSupport && !inputs.hasAccessWifiState) {
+                blockers += ReadinessBlocker.MISSING_ACCESS_WIFI_STATE
+            }
+            if (hasWifiSupport && !inputs.hasChangeWifiState) {
+                blockers += ReadinessBlocker.MISSING_CHANGE_WIFI_STATE
+            }
+            if (!inputs.locationServicesEnabled) {
+                blockers += ReadinessBlocker.LOCATION_SERVICES_DISABLED
+            }
+            if (hasWifiSupport && !hasNearbyWifiDevices) {
+                blockers += ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES
+            }
+
+            val wifiPermissionMissing =
+                hasWifiSupport &&
+                    (!inputs.hasFineLocation ||
+                        !inputs.hasAccessWifiState ||
+                        !inputs.hasChangeWifiState ||
+                        !hasNearbyWifiDevices)
+
+            val wifiState =
+                when {
+                    !hasWifiSupport -> CapabilityState.UNSUPPORTED_BY_HARDWARE
+                    wifiPermissionMissing -> CapabilityState.SUPPORTED_PERMISSION_MISSING
+                    !inputs.locationServicesEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+                    else -> CapabilityState.SUPPORTED_AND_READY
+                }
+
+            val bleScanPermissionMissing =
+                if (inputs.sdkInt >= Build.VERSION_CODES.S) {
+                    !inputs.hasBluetoothScanPermission
+                } else {
+                    !inputs.hasFineLocation
+                }
+            val bleConnectPermissionMissing =
+                inputs.sdkInt >= Build.VERSION_CODES.S &&
+                    !inputs.hasBluetoothConnectPermission
+
+            if (bleScanPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
+            if (bleConnectPermissionMissing) {
+                blockers += ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION
+            }
+            if (inputs.hasBluetoothAdapter && !inputs.bluetoothEnabled) {
+                blockers += ReadinessBlocker.BLUETOOTH_DISABLED
+            }
+
+            val bleState =
+                when {
+                    !inputs.hasBleHardware || !inputs.hasBluetoothAdapter ->
+                        CapabilityState.UNSUPPORTED_BY_HARDWARE
+                    bleScanPermissionMissing || bleConnectPermissionMissing ->
+                        CapabilityState.SUPPORTED_PERMISSION_MISSING
+                    !inputs.bluetoothEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+                    else -> CapabilityState.SUPPORTED_AND_READY
+                }
+
+            val hasCellularSupport = inputs.hasTelephonyHardware && inputs.hasTelephonyManager
+            val cellularState =
+                when {
+                    !hasCellularSupport -> CapabilityState.UNSUPPORTED_BY_HARDWARE
+                    !inputs.hasFineLocation -> {
+                        blockers += ReadinessBlocker.CELL_PERMISSION_MISSING
+                        CapabilityState.SUPPORTED_PERMISSION_MISSING
+                    }
+                    else -> CapabilityState.SUPPORTED_AND_READY
+                }
+
+            val sensorsState =
+                if (inputs.hasAnySupportedSensor) {
+                    CapabilityState.SUPPORTED_AND_READY
+                } else {
+                    blockers += ReadinessBlocker.SENSOR_UNAVAILABLE
+                    CapabilityState.UNSUPPORTED_BY_HARDWARE
+                }
+
+            return PermissionReadiness(
+                wifi = wifiState,
+                ble = bleState,
+                cellular = cellularState,
+                sensors = sensorsState,
+                blockers = blockers,
+            )
+        }
+    }
 }

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -9,14 +9,6 @@ import android.net.wifi.WifiManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 
-/**
- * Produces a runtime readiness snapshot for scan modules.
- *
- * Hardware support is not enough: Android can still block scanning through
- * permissions, disabled system services, radio state, background policy, or
- * stale/throttled scan results. This class centralizes those runtime checks so
- * collectors and UI can share the same degraded-state language.
- */
 class CapabilityReadinessSurveyor(
     private val context: Context,
 ) : PermissionReadinessProvider {
@@ -34,33 +26,37 @@ class CapabilityReadinessSurveyor(
         val hasChangeWifiState = hasPermission(Manifest.permission.CHANGE_WIFI_STATE)
         val locationServicesEnabled = locationManager?.isLocationEnabled ?: false
         val hasWifiHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI)
+        val hasNearbyWifiDevices =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
 
         if (!hasFineLocation) blockers += ReadinessBlocker.MISSING_FINE_LOCATION
         if (!hasAccessWifiState) blockers += ReadinessBlocker.MISSING_ACCESS_WIFI_STATE
         if (!hasChangeWifiState) blockers += ReadinessBlocker.MISSING_CHANGE_WIFI_STATE
         if (!locationServicesEnabled) blockers += ReadinessBlocker.LOCATION_SERVICES_DISABLED
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-            !hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
-        ) {
-            blockers += ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES
-        }
+        if (!hasNearbyWifiDevices) blockers += ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES
 
-        val wifiState = when {
-            !hasWifiHardware || wifiManager == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
-            !hasFineLocation || !hasAccessWifiState || !hasChangeWifiState ||
-                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                    !hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES)) ->
-                CapabilityState.SUPPORTED_PERMISSION_MISSING
-            !locationServicesEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
-            else -> CapabilityState.SUPPORTED_AND_READY
-        }
+        val wifiPermissionMissing =
+            !hasFineLocation ||
+                !hasAccessWifiState ||
+                !hasChangeWifiState ||
+                !hasNearbyWifiDevices
+
+        val wifiState =
+            when {
+                !hasWifiHardware || wifiManager == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
+                wifiPermissionMissing -> CapabilityState.SUPPORTED_PERMISSION_MISSING
+                !locationServicesEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+                else -> CapabilityState.SUPPORTED_AND_READY
+            }
 
         val hasBleHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
-        val bleScanPermissionMissing = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            !hasPermission(Manifest.permission.BLUETOOTH_SCAN)
-        } else {
-            !hasFineLocation
-        }
+        val bleScanPermissionMissing =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                !hasPermission(Manifest.permission.BLUETOOTH_SCAN)
+            } else {
+                !hasFineLocation
+            }
         val bleConnectPermissionMissing =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                 !hasPermission(Manifest.permission.BLUETOOTH_CONNECT)
@@ -69,28 +65,28 @@ class CapabilityReadinessSurveyor(
         if (bleConnectPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION
         if (bluetoothAdapter?.isEnabled == false) blockers += ReadinessBlocker.BLUETOOTH_DISABLED
 
-        val bleState = when {
-            !hasBleHardware || bluetoothAdapter == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
-            bleScanPermissionMissing || bleConnectPermissionMissing ->
+        val bleState =
+            when {
+                !hasBleHardware || bluetoothAdapter == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
+                bleScanPermissionMissing || bleConnectPermissionMissing ->
+                    CapabilityState.SUPPORTED_PERMISSION_MISSING
+                bluetoothAdapter.isEnabled == false -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+                else -> CapabilityState.SUPPORTED_AND_READY
+            }
+
+        val cellularState =
+            if (hasFineLocation) {
+                CapabilityState.SUPPORTED_AND_READY
+            } else {
+                blockers += ReadinessBlocker.CELL_PERMISSION_MISSING
                 CapabilityState.SUPPORTED_PERMISSION_MISSING
-            bluetoothAdapter.isEnabled == false -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
-            else -> CapabilityState.SUPPORTED_AND_READY
-        }
-
-        val cellularState = if (hasFineLocation) {
-            CapabilityState.SUPPORTED_AND_READY
-        } else {
-            blockers += ReadinessBlocker.CELL_PERMISSION_MISSING
-            CapabilityState.SUPPORTED_PERMISSION_MISSING
-        }
-
-        val sensorsState = CapabilityState.SUPPORTED_AND_READY
+            }
 
         return PermissionReadiness(
             wifi = wifiState,
             ble = bleState,
             cellular = cellularState,
-            sensors = sensorsState,
+            sensors = CapabilityState.SUPPORTED_AND_READY,
             blockers = blockers,
         )
     }

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -127,12 +127,11 @@ class CapabilityReadinessSurveyor(
             val bleConnectPermissionMissing =
                 inputs.sdkInt >= Build.VERSION_CODES.S &&
                     !inputs.hasBluetoothConnectPermission
-
-            if (
-                hasBleSupport &&
-                    inputs.sdkInt >= Build.VERSION_CODES.S &&
+            val modernBleScanPermissionMissing =
+                inputs.sdkInt >= Build.VERSION_CODES.S &&
                     bleScanPermissionMissing
-            ) {
+
+            if (hasBleSupport && modernBleScanPermissionMissing) {
                 blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
             }
             if (hasBleSupport && bleConnectPermissionMissing) {

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -80,6 +80,10 @@ class CapabilityReadinessSurveyor(
             val blockers = mutableSetOf<ReadinessBlocker>()
             val hasWifiSupport = inputs.hasWifiHardware && inputs.hasWifiManager
             val hasBleSupport = inputs.hasBleHardware && inputs.hasBluetoothAdapter
+            val hasCellularSupport = inputs.hasTelephonyHardware && inputs.hasTelephonyManager
+            val legacyBleNeedsFineLocation = hasBleSupport && inputs.sdkInt < Build.VERSION_CODES.S
+            val fineLocationAffectsSupportedModule =
+                hasWifiSupport || hasCellularSupport || legacyBleNeedsFineLocation
             val legacyBleLocationDisabled =
                 inputs.sdkInt < Build.VERSION_CODES.S &&
                     !inputs.locationServicesEnabled
@@ -87,7 +91,9 @@ class CapabilityReadinessSurveyor(
                 inputs.sdkInt < Build.VERSION_CODES.TIRAMISU ||
                     inputs.hasNearbyWifiDevicesPermission
 
-            if (!inputs.hasFineLocation) blockers += ReadinessBlocker.MISSING_FINE_LOCATION
+            if (!inputs.hasFineLocation && fineLocationAffectsSupportedModule) {
+                blockers += ReadinessBlocker.MISSING_FINE_LOCATION
+            }
             if (hasWifiSupport && !inputs.hasAccessWifiState) {
                 blockers += ReadinessBlocker.MISSING_ACCESS_WIFI_STATE
             }
@@ -151,7 +157,6 @@ class CapabilityReadinessSurveyor(
                     else -> CapabilityState.SUPPORTED_AND_READY
                 }
 
-            val hasCellularSupport = inputs.hasTelephonyHardware && inputs.hasTelephonyManager
             val cellularState =
                 when {
                     !hasCellularSupport -> CapabilityState.UNSUPPORTED_BY_HARDWARE

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -92,6 +92,7 @@ class CapabilityReadinessSurveyor(
         internal fun evaluate(inputs: ReadinessInputs): PermissionReadiness {
             val blockers = mutableSetOf<ReadinessBlocker>()
             val hasWifiSupport = inputs.hasWifiHardware && inputs.hasWifiManager
+            val hasBleSupport = inputs.hasBleHardware && inputs.hasBluetoothAdapter
             val hasNearbyWifiDevices =
                 inputs.sdkInt < Build.VERSION_CODES.TIRAMISU ||
                     inputs.hasNearbyWifiDevicesPermission
@@ -137,18 +138,19 @@ class CapabilityReadinessSurveyor(
                 inputs.sdkInt >= Build.VERSION_CODES.S &&
                     !inputs.hasBluetoothConnectPermission
 
-            if (bleScanPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
-            if (bleConnectPermissionMissing) {
+            if (hasBleSupport && bleScanPermissionMissing) {
+                blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
+            }
+            if (hasBleSupport && bleConnectPermissionMissing) {
                 blockers += ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION
             }
-            if (inputs.hasBluetoothAdapter && !inputs.bluetoothEnabled) {
+            if (hasBleSupport && !inputs.bluetoothEnabled) {
                 blockers += ReadinessBlocker.BLUETOOTH_DISABLED
             }
 
             val bleState =
                 when {
-                    !inputs.hasBleHardware || !inputs.hasBluetoothAdapter ->
-                        CapabilityState.UNSUPPORTED_BY_HARDWARE
+                    !hasBleSupport -> CapabilityState.UNSUPPORTED_BY_HARDWARE
                     bleScanPermissionMissing || bleConnectPermissionMissing ->
                         CapabilityState.SUPPORTED_PERMISSION_MISSING
                     !inputs.bluetoothEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -1,0 +1,100 @@
+package com.wscanplus.app.capabilities
+
+import android.Manifest
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import android.net.wifi.WifiManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Produces a runtime readiness snapshot for scan modules.
+ *
+ * Hardware support is not enough: Android can still block scanning through
+ * permissions, disabled system services, radio state, background policy, or
+ * stale/throttled scan results. This class centralizes those runtime checks so
+ * collectors and UI can share the same degraded-state language.
+ */
+class CapabilityReadinessSurveyor(
+    private val context: Context,
+) : PermissionReadinessProvider {
+    override fun current(): PermissionReadiness {
+        val blockers = mutableSetOf<ReadinessBlocker>()
+
+        val packageManager = context.packageManager
+        val locationManager = context.getSystemService(LocationManager::class.java)
+        val wifiManager = context.getSystemService(WifiManager::class.java)
+        val bluetoothManager = context.getSystemService(BluetoothManager::class.java)
+        val bluetoothAdapter = bluetoothManager?.adapter
+
+        val hasFineLocation = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+        val hasAccessWifiState = hasPermission(Manifest.permission.ACCESS_WIFI_STATE)
+        val hasChangeWifiState = hasPermission(Manifest.permission.CHANGE_WIFI_STATE)
+        val locationServicesEnabled = locationManager?.isLocationEnabled ?: false
+        val hasWifiHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI)
+
+        if (!hasFineLocation) blockers += ReadinessBlocker.MISSING_FINE_LOCATION
+        if (!hasAccessWifiState) blockers += ReadinessBlocker.MISSING_ACCESS_WIFI_STATE
+        if (!hasChangeWifiState) blockers += ReadinessBlocker.MISSING_CHANGE_WIFI_STATE
+        if (!locationServicesEnabled) blockers += ReadinessBlocker.LOCATION_SERVICES_DISABLED
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            !hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES)
+        ) {
+            blockers += ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES
+        }
+
+        val wifiState = when {
+            !hasWifiHardware || wifiManager == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
+            !hasFineLocation || !hasAccessWifiState || !hasChangeWifiState ||
+                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    !hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES)) ->
+                CapabilityState.SUPPORTED_PERMISSION_MISSING
+            !locationServicesEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+            else -> CapabilityState.SUPPORTED_AND_READY
+        }
+
+        val hasBleHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
+        val bleScanPermissionMissing = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            !hasPermission(Manifest.permission.BLUETOOTH_SCAN)
+        } else {
+            !hasFineLocation
+        }
+        val bleConnectPermissionMissing =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                !hasPermission(Manifest.permission.BLUETOOTH_CONNECT)
+
+        if (bleScanPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
+        if (bleConnectPermissionMissing) blockers += ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION
+        if (bluetoothAdapter?.isEnabled == false) blockers += ReadinessBlocker.BLUETOOTH_DISABLED
+
+        val bleState = when {
+            !hasBleHardware || bluetoothAdapter == null -> CapabilityState.UNSUPPORTED_BY_HARDWARE
+            bleScanPermissionMissing || bleConnectPermissionMissing ->
+                CapabilityState.SUPPORTED_PERMISSION_MISSING
+            bluetoothAdapter.isEnabled == false -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+            else -> CapabilityState.SUPPORTED_AND_READY
+        }
+
+        val cellularState = if (hasFineLocation) {
+            CapabilityState.SUPPORTED_AND_READY
+        } else {
+            blockers += ReadinessBlocker.CELL_PERMISSION_MISSING
+            CapabilityState.SUPPORTED_PERMISSION_MISSING
+        }
+
+        val sensorsState = CapabilityState.SUPPORTED_AND_READY
+
+        return PermissionReadiness(
+            wifi = wifiState,
+            ble = bleState,
+            cellular = cellularState,
+            sensors = sensorsState,
+            blockers = blockers,
+        )
+    }
+
+    private fun hasPermission(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -6,24 +6,23 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorManager
-import android.location.LocationManager
 import android.net.wifi.WifiManager
 import android.os.Build
-import android.provider.Settings
 import android.telephony.TelephonyManager
 import androidx.core.content.ContextCompat
 
 class CapabilityReadinessSurveyor(
-    private val context: Context,
+    context: Context,
 ) : PermissionReadinessProvider {
+    private val appContext = context.applicationContext
+
     override fun current(): PermissionReadiness {
-        val packageManager = context.packageManager
-        val locationManager = context.getSystemService(LocationManager::class.java)
-        val wifiManager = context.getSystemService(WifiManager::class.java)
-        val bluetoothManager = context.getSystemService(BluetoothManager::class.java)
+        val packageManager = appContext.packageManager
+        val wifiManager = appContext.getSystemService(WifiManager::class.java)
+        val bluetoothManager = appContext.getSystemService(BluetoothManager::class.java)
         val bluetoothAdapter = bluetoothManager?.adapter
-        val telephonyManager = context.getSystemService(TelephonyManager::class.java)
-        val sensorManager = context.getSystemService(SensorManager::class.java)
+        val telephonyManager = appContext.getSystemService(TelephonyManager::class.java)
+        val sensorManager = appContext.getSystemService(SensorManager::class.java)
 
         return evaluate(
             ReadinessInputs(
@@ -32,7 +31,7 @@ class CapabilityReadinessSurveyor(
                 hasAccessWifiState = hasPermission(Manifest.permission.ACCESS_WIFI_STATE),
                 hasChangeWifiState = hasPermission(Manifest.permission.CHANGE_WIFI_STATE),
                 hasNearbyWifiDevicesPermission = hasPermission(Manifest.permission.NEARBY_WIFI_DEVICES),
-                locationServicesEnabled = isDeviceLocationEnabled(locationManager),
+                locationServicesEnabled = DeviceLocationState.isLocationEnabled(appContext),
                 hasWifiHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI),
                 hasWifiManager = wifiManager != null,
                 hasBleHardware = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE),
@@ -48,19 +47,7 @@ class CapabilityReadinessSurveyor(
     }
 
     private fun hasPermission(permission: String): Boolean =
-        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-
-    private fun isDeviceLocationEnabled(locationManager: LocationManager?): Boolean =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            locationManager?.isLocationEnabled ?: false
-        } else {
-            @Suppress("DEPRECATION")
-            Settings.Secure.getInt(
-                context.contentResolver,
-                Settings.Secure.LOCATION_MODE,
-                Settings.Secure.LOCATION_MODE_OFF,
-            ) != Settings.Secure.LOCATION_MODE_OFF
-        }
+        ContextCompat.checkSelfPermission(appContext, permission) == PackageManager.PERMISSION_GRANTED
 
     private fun hasAnySupportedSensor(sensorManager: SensorManager?): Boolean =
         sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null ||
@@ -93,6 +80,9 @@ class CapabilityReadinessSurveyor(
             val blockers = mutableSetOf<ReadinessBlocker>()
             val hasWifiSupport = inputs.hasWifiHardware && inputs.hasWifiManager
             val hasBleSupport = inputs.hasBleHardware && inputs.hasBluetoothAdapter
+            val legacyBleLocationDisabled =
+                inputs.sdkInt < Build.VERSION_CODES.S &&
+                    !inputs.locationServicesEnabled
             val hasNearbyWifiDevices =
                 inputs.sdkInt < Build.VERSION_CODES.TIRAMISU ||
                     inputs.hasNearbyWifiDevicesPermission
@@ -138,7 +128,11 @@ class CapabilityReadinessSurveyor(
                 inputs.sdkInt >= Build.VERSION_CODES.S &&
                     !inputs.hasBluetoothConnectPermission
 
-            if (hasBleSupport && bleScanPermissionMissing) {
+            if (
+                hasBleSupport &&
+                    inputs.sdkInt >= Build.VERSION_CODES.S &&
+                    bleScanPermissionMissing
+            ) {
                 blockers += ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION
             }
             if (hasBleSupport && bleConnectPermissionMissing) {
@@ -153,7 +147,8 @@ class CapabilityReadinessSurveyor(
                     !hasBleSupport -> CapabilityState.UNSUPPORTED_BY_HARDWARE
                     bleScanPermissionMissing || bleConnectPermissionMissing ->
                         CapabilityState.SUPPORTED_PERMISSION_MISSING
-                    !inputs.bluetoothEnabled -> CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
+                    legacyBleLocationDisabled || !inputs.bluetoothEnabled ->
+                        CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM
                     else -> CapabilityState.SUPPORTED_AND_READY
                 }
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -101,14 +101,14 @@ class CapabilityReadinessSurveyor(
                 blockers += ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES
             }
 
-            val wifiPermissionMissing =
-                hasWifiSupport &&
-                    listOf(
-                        !inputs.hasFineLocation,
-                        !inputs.hasAccessWifiState,
-                        !inputs.hasChangeWifiState,
-                        !hasNearbyWifiDevices,
-                    ).any { it }
+            val missingWifiPrerequisites =
+                listOf(
+                    !inputs.hasFineLocation,
+                    !inputs.hasAccessWifiState,
+                    !inputs.hasChangeWifiState,
+                    !hasNearbyWifiDevices,
+                ).any { it }
+            val wifiPermissionMissing = hasWifiSupport && missingWifiPrerequisites
 
             val wifiState =
                 when {

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityReadinessSurveyor.kt
@@ -112,10 +112,12 @@ class CapabilityReadinessSurveyor(
 
             val wifiPermissionMissing =
                 hasWifiSupport &&
-                    (!inputs.hasFineLocation ||
-                        !inputs.hasAccessWifiState ||
-                        !inputs.hasChangeWifiState ||
-                        !hasNearbyWifiDevices)
+                    listOf(
+                        !inputs.hasFineLocation,
+                        !inputs.hasAccessWifiState,
+                        !inputs.hasChangeWifiState,
+                        !hasNearbyWifiDevices,
+                    ).any { it }
 
             val wifiState =
                 when {

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityState.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityState.kt
@@ -67,6 +67,7 @@ data class PermissionReadiness(
     val degraded: Boolean
         get() =
             blockers.isNotEmpty() ||
+                wifi != CapabilityState.SUPPORTED_AND_READY ||
                 ble != CapabilityState.SUPPORTED_AND_READY ||
                 cellular != CapabilityState.SUPPORTED_AND_READY ||
                 sensors != CapabilityState.SUPPORTED_AND_READY

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityState.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityState.kt
@@ -60,14 +60,16 @@ data class PermissionReadiness(
     val checkedAtMs: Long = System.currentTimeMillis(),
 ) {
     val canRunMinimumScan: Boolean
-        get() = wifi == CapabilityState.SUPPORTED_AND_READY &&
-            !blockers.contains(ReadinessBlocker.LOCATION_SERVICES_DISABLED)
+        get() =
+            wifi == CapabilityState.SUPPORTED_AND_READY &&
+                !blockers.contains(ReadinessBlocker.LOCATION_SERVICES_DISABLED)
 
     val degraded: Boolean
-        get() = blockers.isNotEmpty() ||
-            ble != CapabilityState.SUPPORTED_AND_READY ||
-            cellular != CapabilityState.SUPPORTED_AND_READY ||
-            sensors != CapabilityState.SUPPORTED_AND_READY
+        get() =
+            blockers.isNotEmpty() ||
+                ble != CapabilityState.SUPPORTED_AND_READY ||
+                cellular != CapabilityState.SUPPORTED_AND_READY ||
+                sensors != CapabilityState.SUPPORTED_AND_READY
 }
 
 interface PermissionReadinessProvider {

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityState.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityState.kt
@@ -1,0 +1,75 @@
+package com.wscanplus.app.capabilities
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Runtime capability state for a scan module or supporting detector.
+ *
+ * This intentionally distinguishes hardware support from current usability.
+ * A device may support Wi-Fi/BLE/etc. while the app is still blocked by
+ * permissions, disabled system services, battery policy, stale results, or
+ * an untested/OEM-specific path.
+ */
+@Serializable
+enum class CapabilityState {
+    SUPPORTED_AND_READY,
+    SUPPORTED_PERMISSION_MISSING,
+    SUPPORTED_DISABLED_BY_SYSTEM,
+    SUPPORTED_BLOCKED_BY_BATTERY,
+    SUPPORTED_BUT_STALE,
+    UNSUPPORTED_BY_HARDWARE,
+    UNSUPPORTED_BY_OS,
+    UNKNOWN_UNTESTED,
+}
+
+@Serializable
+enum class ReadinessBlocker {
+    MISSING_WIFI_PERMISSION,
+    MISSING_CHANGE_WIFI_STATE,
+    MISSING_ACCESS_WIFI_STATE,
+    MISSING_FINE_LOCATION,
+    MISSING_NEARBY_WIFI_DEVICES,
+    LOCATION_SERVICES_DISABLED,
+
+    MISSING_BLE_SCAN_PERMISSION,
+    MISSING_BLE_CONNECT_PERMISSION,
+    BLUETOOTH_DISABLED,
+
+    CELL_PERMISSION_MISSING,
+
+    BACKGROUND_LOCATION_MISSING,
+    BACKGROUND_RESTRICTED,
+    BATTERY_OPTIMIZATION_ACTIVE,
+    FOREGROUND_SERVICE_NOT_RUNNING,
+
+    SCAN_THROTTLED,
+    SCAN_RESULTS_STALE,
+    DEVICE_OEM_QUIRK_ACTIVE,
+
+    SENSOR_UNAVAILABLE,
+    UNKNOWN,
+}
+
+@Serializable
+data class PermissionReadiness(
+    val wifi: CapabilityState,
+    val ble: CapabilityState,
+    val cellular: CapabilityState,
+    val sensors: CapabilityState,
+    val blockers: Set<ReadinessBlocker>,
+    val checkedAtMs: Long = System.currentTimeMillis(),
+) {
+    val canRunMinimumScan: Boolean
+        get() = wifi == CapabilityState.SUPPORTED_AND_READY &&
+            !blockers.contains(ReadinessBlocker.LOCATION_SERVICES_DISABLED)
+
+    val degraded: Boolean
+        get() = blockers.isNotEmpty() ||
+            ble != CapabilityState.SUPPORTED_AND_READY ||
+            cellular != CapabilityState.SUPPORTED_AND_READY ||
+            sensors != CapabilityState.SUPPORTED_AND_READY
+}
+
+interface PermissionReadinessProvider {
+    fun current(): PermissionReadiness
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DeviceLocationState.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/DeviceLocationState.kt
@@ -1,0 +1,24 @@
+package com.wscanplus.app.capabilities
+
+import android.content.Context
+import android.location.LocationManager
+import android.os.Build
+import android.provider.Settings
+
+object DeviceLocationState {
+    fun isLocationEnabled(context: Context): Boolean {
+        val appContext = context.applicationContext
+        val locationManager = appContext.getSystemService(LocationManager::class.java)
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            locationManager?.isLocationEnabled ?: false
+        } else {
+            @Suppress("DEPRECATION")
+            Settings.Secure.getInt(
+                appContext.contentResolver,
+                Settings.Secure.LOCATION_MODE,
+                Settings.Secure.LOCATION_MODE_OFF,
+            ) != Settings.Secure.LOCATION_MODE_OFF
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
@@ -109,13 +109,54 @@ class PermissionReadinessTest {
     }
 
     @Test
+    fun evaluate_ready_baseline_reports_all_modules_ready() {
+        val readiness = CapabilityReadinessSurveyor.evaluate(readyInputs())
+
+        assertEquals(CapabilityState.SUPPORTED_AND_READY, readiness.wifi)
+        assertEquals(CapabilityState.SUPPORTED_AND_READY, readiness.ble)
+        assertEquals(CapabilityState.SUPPORTED_AND_READY, readiness.cellular)
+        assertEquals(CapabilityState.SUPPORTED_AND_READY, readiness.sensors)
+        assertTrue(readiness.canRunMinimumScan)
+        assertFalse(readiness.degraded)
+    }
+
+    @Test
+    fun evaluate_location_services_disabled_marks_wifi_disabled_and_blocks_minimum_scan() {
+        val readiness =
+            CapabilityReadinessSurveyor.evaluate(
+                readyInputs(locationServicesEnabled = false),
+            )
+
+        assertEquals(CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM, readiness.wifi)
+        assertTrue(readiness.blockers.contains(ReadinessBlocker.LOCATION_SERVICES_DISABLED))
+        assertFalse(readiness.canRunMinimumScan)
+        assertTrue(readiness.degraded)
+    }
+
+    @Test
     fun evaluate_does_not_emit_wifi_specific_blockers_without_wifi_support() {
-        val readiness = CapabilityReadinessSurveyor.evaluate(readyInputs(hasWifiHardware = false))
+        val readiness =
+            CapabilityReadinessSurveyor.evaluate(
+                readyInputs(
+                    hasWifiHardware = false,
+                    hasAccessWifiState = false,
+                    hasChangeWifiState = false,
+                    hasNearbyWifiDevicesPermission = false,
+                ),
+            )
 
         assertEquals(CapabilityState.UNSUPPORTED_BY_HARDWARE, readiness.wifi)
         assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_ACCESS_WIFI_STATE))
         assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_CHANGE_WIFI_STATE))
         assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES))
+    }
+
+    @Test
+    fun evaluate_marks_wifi_unsupported_when_wifi_manager_unavailable() {
+        val readiness = CapabilityReadinessSurveyor.evaluate(readyInputs(hasWifiManager = false))
+
+        assertEquals(CapabilityState.UNSUPPORTED_BY_HARDWARE, readiness.wifi)
+        assertTrue(readiness.degraded)
     }
 
     @Test
@@ -147,6 +188,26 @@ class PermissionReadinessTest {
         assertEquals(CapabilityState.SUPPORTED_PERMISSION_MISSING, readiness.ble)
         assertTrue(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION))
         assertTrue(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION))
+    }
+
+    @Test
+    fun evaluate_does_not_emit_ble_blockers_without_ble_support() {
+        val readiness =
+            CapabilityReadinessSurveyor.evaluate(
+                readyInputs(
+                    sdkInt = Build.VERSION_CODES.S,
+                    hasBleHardware = false,
+                    hasBluetoothAdapter = false,
+                    bluetoothEnabled = false,
+                    hasBluetoothScanPermission = false,
+                    hasBluetoothConnectPermission = false,
+                ),
+            )
+
+        assertEquals(CapabilityState.UNSUPPORTED_BY_HARDWARE, readiness.ble)
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION))
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION))
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.BLUETOOTH_DISABLED))
     }
 
     private fun readyInputs(

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
@@ -1,0 +1,105 @@
+package com.wscanplus.app.capabilities
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PermissionReadinessTest {
+    @Test
+    fun canRunMinimumScan_requires_ready_wifi() {
+        val readiness =
+            PermissionReadiness(
+                wifi = CapabilityState.SUPPORTED_PERMISSION_MISSING,
+                ble = CapabilityState.SUPPORTED_AND_READY,
+                cellular = CapabilityState.SUPPORTED_AND_READY,
+                sensors = CapabilityState.SUPPORTED_AND_READY,
+                blockers = emptySet(),
+            )
+
+        assertFalse(readiness.canRunMinimumScan)
+    }
+
+    @Test
+    fun canRunMinimumScan_blocks_when_location_services_disabled() {
+        val readiness =
+            PermissionReadiness(
+                wifi = CapabilityState.SUPPORTED_AND_READY,
+                ble = CapabilityState.SUPPORTED_AND_READY,
+                cellular = CapabilityState.SUPPORTED_AND_READY,
+                sensors = CapabilityState.SUPPORTED_AND_READY,
+                blockers = setOf(ReadinessBlocker.LOCATION_SERVICES_DISABLED),
+            )
+
+        assertFalse(readiness.canRunMinimumScan)
+    }
+
+    @Test
+    fun canRunMinimumScan_allows_ready_wifi_without_location_services_blocker() {
+        val readiness =
+            PermissionReadiness(
+                wifi = CapabilityState.SUPPORTED_AND_READY,
+                ble = CapabilityState.SUPPORTED_AND_READY,
+                cellular = CapabilityState.SUPPORTED_AND_READY,
+                sensors = CapabilityState.SUPPORTED_AND_READY,
+                blockers = emptySet(),
+            )
+
+        assertTrue(readiness.canRunMinimumScan)
+    }
+
+    @Test
+    fun degraded_false_when_every_module_ready_and_no_blockers() {
+        val readiness =
+            PermissionReadiness(
+                wifi = CapabilityState.SUPPORTED_AND_READY,
+                ble = CapabilityState.SUPPORTED_AND_READY,
+                cellular = CapabilityState.SUPPORTED_AND_READY,
+                sensors = CapabilityState.SUPPORTED_AND_READY,
+                blockers = emptySet(),
+            )
+
+        assertFalse(readiness.degraded)
+    }
+
+    @Test
+    fun degraded_true_when_any_blocker_exists() {
+        val readiness =
+            PermissionReadiness(
+                wifi = CapabilityState.SUPPORTED_AND_READY,
+                ble = CapabilityState.SUPPORTED_AND_READY,
+                cellular = CapabilityState.SUPPORTED_AND_READY,
+                sensors = CapabilityState.SUPPORTED_AND_READY,
+                blockers = setOf(ReadinessBlocker.SCAN_RESULTS_STALE),
+            )
+
+        assertTrue(readiness.degraded)
+    }
+
+    @Test
+    fun degraded_true_when_ble_not_ready() {
+        val readiness =
+            PermissionReadiness(
+                wifi = CapabilityState.SUPPORTED_AND_READY,
+                ble = CapabilityState.SUPPORTED_PERMISSION_MISSING,
+                cellular = CapabilityState.SUPPORTED_AND_READY,
+                sensors = CapabilityState.SUPPORTED_AND_READY,
+                blockers = emptySet(),
+            )
+
+        assertTrue(readiness.degraded)
+    }
+
+    @Test
+    fun readiness_blockers_include_required_issue_categories() {
+        val required =
+            setOf(
+                ReadinessBlocker.MISSING_FINE_LOCATION,
+                ReadinessBlocker.LOCATION_SERVICES_DISABLED,
+                ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION,
+                ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION,
+                ReadinessBlocker.UNSUPPORTED_OR_STALE_ALIAS,
+            )
+
+        assertTrue(ReadinessBlocker.entries.containsAll(required - ReadinessBlocker.UNSUPPORTED_OR_STALE_ALIAS))
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
@@ -210,6 +210,35 @@ class PermissionReadinessTest {
         assertFalse(readiness.blockers.contains(ReadinessBlocker.BLUETOOTH_DISABLED))
     }
 
+    @Test
+    fun evaluate_pre_s_ble_location_services_disabled_marks_ble_disabled() {
+        val readiness =
+            CapabilityReadinessSurveyor.evaluate(
+                readyInputs(
+                    sdkInt = Build.VERSION_CODES.R,
+                    locationServicesEnabled = false,
+                ),
+            )
+
+        assertEquals(CapabilityState.SUPPORTED_DISABLED_BY_SYSTEM, readiness.ble)
+        assertTrue(readiness.blockers.contains(ReadinessBlocker.LOCATION_SERVICES_DISABLED))
+    }
+
+    @Test
+    fun evaluate_pre_s_missing_fine_location_does_not_emit_modern_ble_scan_permission_blocker() {
+        val readiness =
+            CapabilityReadinessSurveyor.evaluate(
+                readyInputs(
+                    sdkInt = Build.VERSION_CODES.R,
+                    hasFineLocation = false,
+                ),
+            )
+
+        assertEquals(CapabilityState.SUPPORTED_PERMISSION_MISSING, readiness.ble)
+        assertTrue(readiness.blockers.contains(ReadinessBlocker.MISSING_FINE_LOCATION))
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION))
+    }
+
     private fun readyInputs(
         sdkInt: Int = Build.VERSION_CODES.TIRAMISU,
         hasFineLocation: Boolean = true,

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
@@ -97,9 +97,11 @@ class PermissionReadinessTest {
                 ReadinessBlocker.LOCATION_SERVICES_DISABLED,
                 ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION,
                 ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION,
-                ReadinessBlocker.UNSUPPORTED_OR_STALE_ALIAS,
+                ReadinessBlocker.BATTERY_OPTIMIZATION_ACTIVE,
+                ReadinessBlocker.FOREGROUND_SERVICE_NOT_RUNNING,
+                ReadinessBlocker.SCAN_RESULTS_STALE,
             )
 
-        assertTrue(ReadinessBlocker.entries.containsAll(required - ReadinessBlocker.UNSUPPORTED_OR_STALE_ALIAS))
+        assertTrue(ReadinessBlocker.entries.containsAll(required))
     }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/PermissionReadinessTest.kt
@@ -1,5 +1,7 @@
 package com.wscanplus.app.capabilities
 
+import android.os.Build
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,6 +19,7 @@ class PermissionReadinessTest {
             )
 
         assertFalse(readiness.canRunMinimumScan)
+        assertTrue(readiness.degraded)
     }
 
     @Test
@@ -104,4 +107,82 @@ class PermissionReadinessTest {
 
         assertTrue(ReadinessBlocker.entries.containsAll(required))
     }
+
+    @Test
+    fun evaluate_does_not_emit_wifi_specific_blockers_without_wifi_support() {
+        val readiness = CapabilityReadinessSurveyor.evaluate(readyInputs(hasWifiHardware = false))
+
+        assertEquals(CapabilityState.UNSUPPORTED_BY_HARDWARE, readiness.wifi)
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_ACCESS_WIFI_STATE))
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_CHANGE_WIFI_STATE))
+        assertFalse(readiness.blockers.contains(ReadinessBlocker.MISSING_NEARBY_WIFI_DEVICES))
+    }
+
+    @Test
+    fun evaluate_marks_cellular_unsupported_without_telephony_support() {
+        val readiness = CapabilityReadinessSurveyor.evaluate(readyInputs(hasTelephonyHardware = false))
+
+        assertEquals(CapabilityState.UNSUPPORTED_BY_HARDWARE, readiness.cellular)
+    }
+
+    @Test
+    fun evaluate_marks_sensors_unsupported_when_no_supported_sensor_exists() {
+        val readiness = CapabilityReadinessSurveyor.evaluate(readyInputs(hasAnySupportedSensor = false))
+
+        assertEquals(CapabilityState.UNSUPPORTED_BY_HARDWARE, readiness.sensors)
+        assertTrue(readiness.blockers.contains(ReadinessBlocker.SENSOR_UNAVAILABLE))
+    }
+
+    @Test
+    fun evaluate_marks_ble_scan_and_connect_permissions_separately_on_android_s_plus() {
+        val readiness =
+            CapabilityReadinessSurveyor.evaluate(
+                readyInputs(
+                    sdkInt = Build.VERSION_CODES.S,
+                    hasBluetoothScanPermission = false,
+                    hasBluetoothConnectPermission = false,
+                ),
+            )
+
+        assertEquals(CapabilityState.SUPPORTED_PERMISSION_MISSING, readiness.ble)
+        assertTrue(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_SCAN_PERMISSION))
+        assertTrue(readiness.blockers.contains(ReadinessBlocker.MISSING_BLE_CONNECT_PERMISSION))
+    }
+
+    private fun readyInputs(
+        sdkInt: Int = Build.VERSION_CODES.TIRAMISU,
+        hasFineLocation: Boolean = true,
+        hasAccessWifiState: Boolean = true,
+        hasChangeWifiState: Boolean = true,
+        hasNearbyWifiDevicesPermission: Boolean = true,
+        locationServicesEnabled: Boolean = true,
+        hasWifiHardware: Boolean = true,
+        hasWifiManager: Boolean = true,
+        hasBleHardware: Boolean = true,
+        hasBluetoothAdapter: Boolean = true,
+        bluetoothEnabled: Boolean = true,
+        hasBluetoothScanPermission: Boolean = true,
+        hasBluetoothConnectPermission: Boolean = true,
+        hasTelephonyHardware: Boolean = true,
+        hasTelephonyManager: Boolean = true,
+        hasAnySupportedSensor: Boolean = true,
+    ): CapabilityReadinessSurveyor.ReadinessInputs =
+        CapabilityReadinessSurveyor.ReadinessInputs(
+            sdkInt = sdkInt,
+            hasFineLocation = hasFineLocation,
+            hasAccessWifiState = hasAccessWifiState,
+            hasChangeWifiState = hasChangeWifiState,
+            hasNearbyWifiDevicesPermission = hasNearbyWifiDevicesPermission,
+            locationServicesEnabled = locationServicesEnabled,
+            hasWifiHardware = hasWifiHardware,
+            hasWifiManager = hasWifiManager,
+            hasBleHardware = hasBleHardware,
+            hasBluetoothAdapter = hasBluetoothAdapter,
+            bluetoothEnabled = bluetoothEnabled,
+            hasBluetoothScanPermission = hasBluetoothScanPermission,
+            hasBluetoothConnectPermission = hasBluetoothConnectPermission,
+            hasTelephonyHardware = hasTelephonyHardware,
+            hasTelephonyManager = hasTelephonyManager,
+            hasAnySupportedSensor = hasAnySupportedSensor,
+        )
 }


### PR DESCRIPTION
## Summary

Closes #236

Adds the shared Android capability/readiness model for scan modules before Wi-Fi/BLE/cell collector changes.

## Changes

**`CapabilityState.kt`**
- Adds `CapabilityState`
- Adds `ReadinessBlocker`
- Adds `PermissionReadiness`
- Adds `PermissionReadinessProvider`

**`CapabilityReadinessSurveyor.kt`**
- Adds runtime surveyor for Wi-Fi, BLE, cellular, and sensor readiness
- Distinguishes hardware support from permission/system/radio readiness
- Represents Location Services disabled explicitly
- Separates Android S+ `BLUETOOTH_SCAN` from `BLUETOOTH_CONNECT`
- Avoids emitting Wi-Fi/BLE-specific blockers when the corresponding hardware/service is unsupported
- Uses `applicationContext` internally to avoid leaking Activity/Service contexts
- Uses shared `DeviceLocationState` for API 24+ location-service checks
- Handles legacy pre-S BLE scan usability through fine-location and Location Services state

**`DeviceLocationState.kt`**
- Adds shared API-compatible Location Services helper for API 24+
- Reused by `MainActivity` and `CapabilityReadinessSurveyor`

**`MainActivity.kt`**
- Reuses `DeviceLocationState` instead of duplicating Location Services logic

**`PermissionReadinessTest.kt`**
- Adds JVM unit coverage for readiness computed properties and mapping scenarios
- Covers ready baseline, Location Services disabled, Wi-Fi manager unavailable, unsupported Wi-Fi/BLE/cellular/sensors, Android S+ BLE scan/connect permissions, and legacy pre-S BLE/location behavior

## Constraints

- Does not modify collectors
- Does not modify Room schema
- Does not implement BLE fingerprinting
- Does not implement Wi-Fi freshness
- Keeps existing `DeviceCapabilityManifest`, `CapabilityProbe`, and `DetectorGate` behavior intact

## Agent

ChatGPT / GPT-5.5 Thinking — guided by AGENTS.md and issue #236