### PR TITLE
fix(android): polish test build UI and capability probes

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -5,7 +5,9 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Bundle
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import com.wscanplus.app.capabilities.AcousticStatus
@@ -18,6 +20,15 @@ class DiagnosticActivity : Activity() {
     private var boundBinder: WatchdogService.LocalBinder? = null
     private var serviceBound = false
     private lateinit var content: LinearLayout
+    private val handler = Handler(Looper.getMainLooper())
+
+    private val refreshRunnable: Runnable =
+        object : Runnable {
+            override fun run() {
+                refreshDiagnostics()
+                handler.postDelayed(this, REFRESH_INTERVAL_MS)
+            }
+        }
 
     private val serviceConnection =
         object : ServiceConnection {
@@ -27,11 +38,13 @@ class DiagnosticActivity : Activity() {
             ) {
                 boundBinder = binder as? WatchdogService.LocalBinder
                 refreshDiagnostics()
+                scheduleRefresh()
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {
                 boundBinder = null
                 serviceBound = false
+                handler.removeCallbacks(refreshRunnable)
                 refreshDiagnostics()
             }
         }
@@ -53,23 +66,28 @@ class DiagnosticActivity : Activity() {
             ),
         )
         setContentView(root)
+        renderServicePlaceholder("CONNECTING", "Connecting to the scanner service…", WscanUi.COLOR_WARN)
     }
 
     override fun onStart() {
         super.onStart()
         serviceBound = bindService(Intent(this, WatchdogService::class.java), serviceConnection, 0)
-        if (!serviceBound) {
-            refreshDiagnostics()
-        }
+        refreshDiagnostics()
     }
 
     override fun onStop() {
         super.onStop()
+        handler.removeCallbacks(refreshRunnable)
         if (serviceBound) {
             unbindService(serviceConnection)
             serviceBound = false
         }
         boundBinder = null
+    }
+
+    private fun scheduleRefresh() {
+        handler.removeCallbacks(refreshRunnable)
+        handler.postDelayed(refreshRunnable, REFRESH_INTERVAL_MS)
     }
 
     private fun refreshDiagnostics() {
@@ -79,10 +97,11 @@ class DiagnosticActivity : Activity() {
         content.removeAllViews()
         val binder = boundBinder
         if (binder == null) {
-            val card = WscanUi.card(content)
-            WscanUi.sectionTitle(card, "Service")
-            WscanUi.metricRow(card, "WatchdogService", "NOT RUNNING", WscanUi.COLOR_BAD)
-            WscanUi.body(card, "Start scanning from the main screen, then return here.", muted = true)
+            if (serviceBound) {
+                renderServicePlaceholder("CONNECTING", "Waiting for WatchdogService binder callback…", WscanUi.COLOR_WARN)
+            } else {
+                renderServicePlaceholder("NOT RUNNING", "Start scanning from the main screen, then return here.", WscanUi.COLOR_BAD)
+            }
             return
         }
 
@@ -95,6 +114,7 @@ class DiagnosticActivity : Activity() {
             if (binder.isDegraded) "RUNNING · DEGRADED" else "RUNNING",
             if (binder.isDegraded) WscanUi.COLOR_WARN else WscanUi.COLOR_OK,
         )
+        WscanUi.actionButton(serviceCard, "Refresh Diagnostics") { refreshDiagnostics() }
 
         val capsCard = WscanUi.card(content)
         WscanUi.sectionTitle(capsCard, "Capabilities")
@@ -141,6 +161,19 @@ class DiagnosticActivity : Activity() {
         }
     }
 
+    private fun renderServicePlaceholder(
+        state: String,
+        message: String,
+        color: Int,
+    ) {
+        content.removeAllViews()
+        val card = WscanUi.card(content)
+        WscanUi.sectionTitle(card, "Service")
+        WscanUi.metricRow(card, "WatchdogService", state, color)
+        WscanUi.body(card, message, muted = true)
+        WscanUi.actionButton(card, "Refresh Diagnostics") { refreshDiagnostics() }
+    }
+
     private fun Boolean.toReadyLabel(): String = if (this) "READY" else "UNAVAILABLE"
 
     private fun CameraIrStatus.statusColor(): Int =
@@ -166,7 +199,7 @@ class DiagnosticActivity : Activity() {
             CameraIrStatus.UNTESTED -> "UNTESTED"
             CameraIrStatus.CAPABLE -> "CAPABLE"
             CameraIrStatus.NOT_CAPABLE -> "NOT CAPABLE"
-            CameraIrStatus.PARTIAL -> "UNTESTED"
+            CameraIrStatus.PARTIAL -> "PARTIAL"
         }
 
     private fun AcousticStatus.toDisplayLabel(): String =
@@ -182,5 +215,6 @@ class DiagnosticActivity : Activity() {
     companion object {
         @Suppress("unused")
         private const val TAG = "DiagnosticActivity"
+        private const val REFRESH_INTERVAL_MS = 2_000L
     }
 }

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -100,7 +100,7 @@ class DiagnosticActivity : Activity() {
         if (caps != null) {
             WscanUi.metricRow(capsCard, "Device", caps.deviceModel)
             WscanUi.metricRow(capsCard, "Wi-Fi scan", caps.wifiScan.toReadyLabel(), WscanUi.statusColor(caps.wifiScan))
-            WscanUi.metricRow(capsCard, "Wi-Fi RTT", "${caps.wifiRtt.toReadyLabel()} · now=${caps.wifiRttAvailableNow}")
+            WscanUi.metricRow(capsCard, "Wi-Fi RTT", "${caps.wifiRtt.toReadyLabel()} · now=${caps.wifiRttAvailableNow}", WscanUi.statusColor(caps.wifiRtt))
             WscanUi.metricRow(capsCard, "Wi-Fi Aware", caps.wifiAware.toReadyLabel(), WscanUi.statusColor(caps.wifiAware))
             WscanUi.metricRow(capsCard, "UWB", caps.uwb.toReadyLabel(), WscanUi.statusColor(caps.uwb))
             WscanUi.metricRow(capsCard, "Barometer", caps.barometer.toReadyLabel(), WscanUi.statusColor(caps.barometer))

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -8,6 +8,8 @@ import android.os.Bundle
 import android.os.IBinder
 import android.widget.LinearLayout
 import android.widget.ScrollView
+import com.wscanplus.app.capabilities.AcousticStatus
+import com.wscanplus.app.capabilities.CameraIrStatus
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -100,13 +102,18 @@ class DiagnosticActivity : Activity() {
         if (caps != null) {
             WscanUi.metricRow(capsCard, "Device", caps.deviceModel)
             WscanUi.metricRow(capsCard, "Wi-Fi scan", caps.wifiScan.toReadyLabel(), WscanUi.statusColor(caps.wifiScan))
-            WscanUi.metricRow(capsCard, "Wi-Fi RTT", "${caps.wifiRtt.toReadyLabel()} · now=${caps.wifiRttAvailableNow}", WscanUi.statusColor(caps.wifiRtt))
+            WscanUi.metricRow(
+                capsCard,
+                "Wi-Fi RTT",
+                "${caps.wifiRtt.toReadyLabel()} · now=${caps.wifiRttAvailableNow}",
+                WscanUi.statusColor(caps.wifiRtt),
+            )
             WscanUi.metricRow(capsCard, "Wi-Fi Aware", caps.wifiAware.toReadyLabel(), WscanUi.statusColor(caps.wifiAware))
             WscanUi.metricRow(capsCard, "UWB", caps.uwb.toReadyLabel(), WscanUi.statusColor(caps.uwb))
             WscanUi.metricRow(capsCard, "Barometer", caps.barometer.toReadyLabel(), WscanUi.statusColor(caps.barometer))
             WscanUi.metricRow(capsCard, "BLE", caps.bluetoothLe.toReadyLabel(), WscanUi.statusColor(caps.bluetoothLe))
-            WscanUi.metricRow(capsCard, "Camera depth/IR", caps.cameraIrCapable.name, caps.cameraIrCapable.name.statusColor())
-            WscanUi.metricRow(capsCard, "Acoustic", caps.acousticSonarCapable.name, caps.acousticSonarCapable.name.statusColor())
+            WscanUi.metricRow(capsCard, "Camera depth/IR", caps.cameraIrCapable.toDisplayLabel(), caps.cameraIrCapable.statusColor())
+            WscanUi.metricRow(capsCard, "Acoustic", caps.acousticSonarCapable.toDisplayLabel(), caps.acousticSonarCapable.statusColor())
         } else {
             WscanUi.body(capsCard, "Capability probe has not completed yet.", muted = true)
         }
@@ -140,17 +147,36 @@ class DiagnosticActivity : Activity() {
         when (this) {
             CameraIrStatus.CAPABLE -> WscanUi.COLOR_OK
             CameraIrStatus.PARTIAL,
-            CameraIrStatus.DEVICE_VARIABLE -> WscanUi.COLOR_WARN
+            CameraIrStatus.UNTESTED,
+            -> WscanUi.COLOR_WARN
             CameraIrStatus.NOT_CAPABLE -> WscanUi.COLOR_BAD
         }
 
     private fun AcousticStatus.statusColor(): Int =
         when (this) {
             AcousticStatus.CAPABLE -> WscanUi.COLOR_OK
-            AcousticStatus.PARTIAL,
-            AcousticStatus.DEVICE_VARIABLE -> WscanUi.COLOR_WARN
+            AcousticStatus.UNTESTED,
+            AcousticStatus.DEVICE_VARIABLE,
+            -> WscanUi.COLOR_WARN
             AcousticStatus.NOT_CAPABLE -> WscanUi.COLOR_BAD
         }
+
+    private fun CameraIrStatus.toDisplayLabel(): String =
+        when (this) {
+            CameraIrStatus.UNTESTED -> "UNTESTED"
+            CameraIrStatus.CAPABLE -> "CAPABLE"
+            CameraIrStatus.NOT_CAPABLE -> "NOT CAPABLE"
+            CameraIrStatus.PARTIAL -> "PARTIAL"
+        }
+
+    private fun AcousticStatus.toDisplayLabel(): String =
+        when (this) {
+            AcousticStatus.UNTESTED -> "UNTESTED"
+            AcousticStatus.CAPABLE -> "CAPABLE"
+            AcousticStatus.NOT_CAPABLE -> "NOT CAPABLE"
+            AcousticStatus.DEVICE_VARIABLE -> "DEVICE VARIABLE"
+        }
+
     private fun formatMs(epochMs: Long): String = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault()).format(Date(epochMs))
 
     companion object {

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -166,7 +166,7 @@ class DiagnosticActivity : Activity() {
             CameraIrStatus.UNTESTED -> "UNTESTED"
             CameraIrStatus.CAPABLE -> "CAPABLE"
             CameraIrStatus.NOT_CAPABLE -> "NOT CAPABLE"
-            CameraIrStatus.PARTIAL -> "PARTIAL"
+            CameraIrStatus.PARTIAL -> "UNTESTED"
         }
 
     private fun AcousticStatus.toDisplayLabel(): String =

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -136,14 +136,21 @@ class DiagnosticActivity : Activity() {
 
     private fun Boolean.toReadyLabel(): String = if (this) "READY" else "UNAVAILABLE"
 
-    private fun String.statusColor(): Int =
+    private fun CameraIrStatus.statusColor(): Int =
         when (this) {
-            "CAPABLE" -> WscanUi.COLOR_OK
-            "PARTIAL", "DEVICE_VARIABLE" -> WscanUi.COLOR_WARN
-            "NOT_CAPABLE" -> WscanUi.COLOR_BAD
-            else -> WscanUi.COLOR_MUTED
+            CameraIrStatus.CAPABLE -> WscanUi.COLOR_OK
+            CameraIrStatus.PARTIAL,
+            CameraIrStatus.DEVICE_VARIABLE -> WscanUi.COLOR_WARN
+            CameraIrStatus.NOT_CAPABLE -> WscanUi.COLOR_BAD
         }
 
+    private fun AcousticStatus.statusColor(): Int =
+        when (this) {
+            AcousticStatus.CAPABLE -> WscanUi.COLOR_OK
+            AcousticStatus.PARTIAL,
+            AcousticStatus.DEVICE_VARIABLE -> WscanUi.COLOR_WARN
+            AcousticStatus.NOT_CAPABLE -> WscanUi.COLOR_BAD
+        }
     private fun formatMs(epochMs: Long): String = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault()).format(Date(epochMs))
 
     companion object {

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -4,13 +4,10 @@ import android.app.Activity
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
-import android.graphics.Typeface
 import android.os.Bundle
 import android.os.IBinder
-import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.ScrollView
-import android.widget.TextView
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -18,7 +15,7 @@ import java.util.Locale
 class DiagnosticActivity : Activity() {
     private var boundBinder: WatchdogService.LocalBinder? = null
     private var serviceBound = false
-    private lateinit var diagnosticText: TextView
+    private lateinit var content: LinearLayout
 
     private val serviceConnection =
         object : ServiceConnection {
@@ -40,33 +37,19 @@ class DiagnosticActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val root =
-            LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                setPadding(48, 48, 48, 48)
-            }
-        val title =
-            TextView(this).apply {
-                text = "WatchdogService Diagnostics"
-                textSize = 18f
-            }
-        val refreshButton =
-            Button(this).apply {
-                text = "Refresh"
-                setOnClickListener { refreshDiagnostics() }
-            }
-        diagnosticText =
-            TextView(this).apply {
-                textSize = 13f
-                typeface = Typeface.MONOSPACE
-                text = "Connecting…"
-            }
-        val scroll = ScrollView(this)
-        scroll.addView(diagnosticText)
-
-        root.addView(title)
-        root.addView(refreshButton)
-        root.addView(scroll)
+        val root = WscanUi.shell(this)
+        WscanUi.header(root, "Diagnostics", "Runtime scanner, capability, floor, and desktop-link state")
+        val scroll = ScrollView(this).apply { isFillViewport = true }
+        content = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        scroll.addView(content)
+        root.addView(
+            scroll,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                0,
+                1f,
+            ),
+        )
         setContentView(root)
     }
 
@@ -91,56 +74,75 @@ class DiagnosticActivity : Activity() {
         if (!serviceBound) {
             serviceBound = bindService(Intent(this, WatchdogService::class.java), serviceConnection, 0)
         }
+        content.removeAllViews()
         val binder = boundBinder
         if (binder == null) {
-            diagnosticText.text = "Service: NOT RUNNING"
+            val card = WscanUi.card(content)
+            WscanUi.sectionTitle(card, "Service")
+            WscanUi.metricRow(card, "WatchdogService", "NOT RUNNING", WscanUi.COLOR_BAD)
+            WscanUi.body(card, "Start scanning from the main screen, then return here.", muted = true)
             return
         }
 
         val svc = binder.getService()
-        val sb = StringBuilder()
+        val serviceCard = WscanUi.card(content)
+        WscanUi.sectionTitle(serviceCard, "Service")
+        WscanUi.metricRow(
+            serviceCard,
+            "WatchdogService",
+            if (binder.isDegraded) "RUNNING · DEGRADED" else "RUNNING",
+            if (binder.isDegraded) WscanUi.COLOR_WARN else WscanUi.COLOR_OK,
+        )
 
-        sb.append("Service: RUNNING")
-        if (binder.isDegraded) sb.append(" (degraded)")
-        sb.append("\n\n")
-
-        sb.append("── Capabilities ──\n")
+        val capsCard = WscanUi.card(content)
+        WscanUi.sectionTitle(capsCard, "Capabilities")
         val caps = binder.capabilityManifest
         if (caps != null) {
-            sb.append("Device:       ${caps.deviceModel}\n")
-            sb.append("WiFi scan:    ${caps.wifiScan}\n")
-            sb.append("WiFi RTT:     ${caps.wifiRtt}  now=${caps.wifiRttAvailableNow}\n")
-            sb.append("WiFi Aware:   ${caps.wifiAware}\n")
-            sb.append("UWB:          ${caps.uwb}\n")
-            sb.append("Barometer:    ${caps.barometer}\n")
-            sb.append("BLE:          ${caps.bluetoothLe}\n")
-            sb.append("Camera IR:    ${caps.cameraIrCapable}\n")
-            sb.append("Acoustic:     ${caps.acousticSonarCapable}\n")
+            WscanUi.metricRow(capsCard, "Device", caps.deviceModel)
+            WscanUi.metricRow(capsCard, "Wi-Fi scan", caps.wifiScan.toReadyLabel(), WscanUi.statusColor(caps.wifiScan))
+            WscanUi.metricRow(capsCard, "Wi-Fi RTT", "${caps.wifiRtt.toReadyLabel()} · now=${caps.wifiRttAvailableNow}")
+            WscanUi.metricRow(capsCard, "Wi-Fi Aware", caps.wifiAware.toReadyLabel(), WscanUi.statusColor(caps.wifiAware))
+            WscanUi.metricRow(capsCard, "UWB", caps.uwb.toReadyLabel(), WscanUi.statusColor(caps.uwb))
+            WscanUi.metricRow(capsCard, "Barometer", caps.barometer.toReadyLabel(), WscanUi.statusColor(caps.barometer))
+            WscanUi.metricRow(capsCard, "BLE", caps.bluetoothLe.toReadyLabel(), WscanUi.statusColor(caps.bluetoothLe))
+            WscanUi.metricRow(capsCard, "Camera depth/IR", caps.cameraIrCapable.name, caps.cameraIrCapable.name.statusColor())
+            WscanUi.metricRow(capsCard, "Acoustic", caps.acousticSonarCapable.name, caps.acousticSonarCapable.name.statusColor())
         } else {
-            sb.append("Not probed yet\n")
+            WscanUi.body(capsCard, "Capability probe has not completed yet.", muted = true)
         }
 
-        sb.append("\n── Floor Estimate ──\n")
+        val floorCard = WscanUi.card(content)
+        WscanUi.sectionTitle(floorCard, "Floor estimate")
         val fe = svc.currentFloorEstimate
         if (fe != null) {
-            sb.append("Relative floor:  ${fe.relativeFloor}\n")
-            sb.append("Delta hPa:       ${"%.2f".format(fe.deltaHpa)}\n")
-            sb.append("Confidence:      ${"%.1f".format(fe.confidenceMeters)} m\n")
-            sb.append("observedAt:      ${formatMs(fe.observedAt)}\n")
+            WscanUi.metricRow(floorCard, "Relative floor", fe.relativeFloor.toString())
+            WscanUi.metricRow(floorCard, "Delta hPa", "%.2f".format(fe.deltaHpa))
+            WscanUi.metricRow(floorCard, "Confidence", "%.1f m".format(fe.confidenceMeters))
+            WscanUi.metricRow(floorCard, "Observed", formatMs(fe.observedAt))
         } else {
-            sb.append("Absent\n")
+            WscanUi.body(floorCard, "No barometer-backed floor estimate available yet.", muted = true)
         }
 
-        sb.append("\n── Desktop Link ──\n")
+        val linkCard = WscanUi.card(content)
+        WscanUi.sectionTitle(linkCard, "Desktop link")
         val ackSeq = svc.lastDesktopAckSeq
         if (ackSeq == -1) {
-            sb.append("No ack received (desktop not connected)\n")
+            WscanUi.metricRow(linkCard, "ADB desktop", "NO ACK", WscanUi.COLOR_WARN)
+            WscanUi.body(linkCard, "Desktop is not connected or has not acknowledged this device.", muted = true)
         } else {
-            sb.append("Last ack seq: $ackSeq\n")
+            WscanUi.metricRow(linkCard, "Last ack seq", ackSeq.toString(), WscanUi.COLOR_OK)
         }
-
-        diagnosticText.text = sb.toString()
     }
+
+    private fun Boolean.toReadyLabel(): String = if (this) "READY" else "UNAVAILABLE"
+
+    private fun String.statusColor(): Int =
+        when (this) {
+            "CAPABLE" -> WscanUi.COLOR_OK
+            "PARTIAL", "DEVICE_VARIABLE" -> WscanUi.COLOR_WARN
+            "NOT_CAPABLE" -> WscanUi.COLOR_BAD
+            else -> WscanUi.COLOR_MUTED
+        }
 
     private fun formatMs(epochMs: Long): String = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault()).format(Date(epochMs))
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -22,57 +22,42 @@ class MainActivity : Activity() {
     private lateinit var statusView: TextView
     private lateinit var rootLayout: LinearLayout
     private lateinit var actionButton: Button
-    private lateinit var settingsButton: Button
+    private lateinit var scannerCard: LinearLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        rootLayout =
-            LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                setPadding(48, 48, 48, 48)
-            }
-        statusView =
-            TextView(this).apply {
-                text = "wscan+ needs Wi-Fi scan permissions to start the scanner."
-                textSize = 16f
-            }
+        rootLayout = WscanUi.shell(this)
+        WscanUi.header(
+            rootLayout,
+            title = "wscan+",
+            subtitle = "Wireless signal intelligence · readiness · field diagnostics",
+        )
+
+        scannerCard = WscanUi.card(rootLayout)
+        WscanUi.sectionTitle(scannerCard, "Scanner status")
+        statusView = WscanUi.body(scannerCard, "Preparing scanner readiness checks…")
         actionButton =
-            Button(this).apply {
+            WscanUi.actionButton(scannerCard, "Open App Settings") { openAppSettings() }.apply {
                 visibility = View.GONE
             }
-        settingsButton =
-            Button(this).apply {
-                text = "Kismet Settings"
-                setOnClickListener { openKismetSettings() }
-            }
-        val mapButton =
-            Button(this).apply {
-                text = "View Scan Map"
-                setOnClickListener { openScanMap() }
-            }
-        val threatResultsButton =
-            Button(this).apply {
-                text = "View Threat Results"
-                setOnClickListener { openThreatResults() }
-            }
-        val historyButton =
-            Button(this).apply {
-                text = "View Scan History"
-                setOnClickListener { openScanHistory() }
-            }
-        val diagnosticButton =
-            Button(this).apply {
-                text = "Diagnostics"
-                setOnClickListener { openDiagnostics() }
-            }
-        rootLayout.addView(statusView)
-        rootLayout.addView(actionButton)
-        rootLayout.addView(settingsButton)
-        rootLayout.addView(mapButton)
-        rootLayout.addView(threatResultsButton)
-        rootLayout.addView(historyButton)
-        rootLayout.addView(diagnosticButton)
+
+        val toolsCard = WscanUi.card(rootLayout)
+        WscanUi.sectionTitle(toolsCard, "Field tools")
+        WscanUi.actionButton(toolsCard, "Kismet Settings") { openKismetSettings() }
+        WscanUi.actionButton(toolsCard, "View Scan Map") { openScanMap() }
+        WscanUi.actionButton(toolsCard, "View Threat Results") { openThreatResults() }
+        WscanUi.actionButton(toolsCard, "View Scan History") { openScanHistory() }
+        WscanUi.actionButton(toolsCard, "Diagnostics") { openDiagnostics() }
+
+        val noteCard = WscanUi.card(rootLayout)
+        WscanUi.sectionTitle(noteCard, "Test build")
+        WscanUi.body(
+            noteCard,
+            "Debug artifact build. Google services may use CI placeholders; validate local scanner and UI behavior first.",
+            muted = true,
+        )
+
         setContentView(rootLayout)
 
         if (!ConsentStore(this).isConsentGiven()) {
@@ -86,7 +71,6 @@ class MainActivity : Activity() {
 
     override fun onResume() {
         super.onResume()
-        // Re-check permissions when returning from Settings
         refreshScannerState()
     }
 
@@ -106,14 +90,12 @@ class MainActivity : Activity() {
     }
 
     private fun showPermissionDenied() {
-        statusView.text =
-            "Scanning disabled. Grant Wi-Fi and location permissions in Settings to start."
+        statusView.text = "Scanning disabled. Grant Wi-Fi and location permissions in Settings to start."
         configureActionButton("Open App Settings") { openAppSettings() }
     }
 
     private fun showPreciseLocationRequired() {
-        statusView.text =
-            "Precise location is required for Wi-Fi scanning. Enable it in App Settings."
+        statusView.text = "Precise location is required for Wi-Fi scanning. Enable it in App Settings."
         configureActionButton("Open App Settings") { openAppSettings() }
     }
 
@@ -178,8 +160,6 @@ class MainActivity : Activity() {
             showLocationServicesRequired()
             return
         }
-        // Background location missing: start in degraded mode (no GPS sampler, limited to
-        // foreground sessions). Scanner chain still runs with ACCESS_FINE_LOCATION.
         val degraded = requiresBackgroundLocationPrompt()
         startWatchdog(degraded = degraded)
     }
@@ -189,15 +169,8 @@ class MainActivity : Activity() {
             hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) &&
             hasPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION).not()
 
-    private fun showBackgroundLocationRequired() {
-        statusView.text =
-            "Field mode needs 'Allow all the time' location access. Without it, locked-screen and background scanning is unreliable."
-        configureActionButton("Open App Settings") { openAppSettings() }
-    }
-
     private fun showLocationServicesRequired() {
-        statusView.text =
-            "Scanning cannot start until device location services are turned on."
+        statusView.text = "Scanning cannot start until device location services are turned on."
         configureActionButton("Open Location Settings") { openLocationSettings() }
     }
 
@@ -226,10 +199,7 @@ class MainActivity : Activity() {
         startActivity(Intent(this, DiagnosticActivity::class.java))
     }
 
-    private fun configureActionButton(
-        text: String,
-        onClick: () -> Unit,
-    ) {
+    private fun configureActionButton(text: String, onClick: () -> Unit) {
         actionButton.text = text
         actionButton.setOnClickListener { onClick() }
         actionButton.visibility = View.VISIBLE
@@ -238,9 +208,9 @@ class MainActivity : Activity() {
     private fun startWatchdog(degraded: Boolean = false) {
         statusView.text =
             if (degraded) {
-                "Starting scanner (degraded — fine location only, without background location)..."
+                "Scanner running in degraded mode: foreground fine-location scanning only."
             } else {
-                "Starting scanner..."
+                "Scanner service running. Ready for local field validation."
             }
         actionButton.visibility = View.GONE
         val intent =

--- a/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/MainActivity.kt
@@ -199,7 +199,10 @@ class MainActivity : Activity() {
         startActivity(Intent(this, DiagnosticActivity::class.java))
     }
 
-    private fun configureActionButton(text: String, onClick: () -> Unit) {
+    private fun configureActionButton(
+        text: String,
+        onClick: () -> Unit,
+    ) {
         actionButton.text = text
         actionButton.setOnClickListener { onClick() }
         actionButton.visibility = View.VISIBLE

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -39,6 +39,7 @@ class ScanMapActivity :
     private var statusTitle: TextView? = null
     private var statusBody: TextView? = null
     private var isServiceBound = false
+    private val dismissStatusRunnable = Runnable { statusPanel?.visibility = View.GONE }
 
     private val serviceConnection =
         object : ServiceConnection {
@@ -100,6 +101,7 @@ class ScanMapActivity :
     override fun onStop() {
         super.onStop()
         handler.removeCallbacks(floorUpdateRunnable)
+        handler.removeCallbacks(dismissStatusRunnable)
         if (isServiceBound) {
             unbindService(serviceConnection)
             isServiceBound = false
@@ -225,9 +227,9 @@ class ScanMapActivity :
             runOnUiThread {
                 map.addTileOverlay(TileOverlayOptions().tileProvider(provider))
                 setMapStatus("Heatmap rendered", "${points.size} GPS-tagged scan points loaded.")
-                handler.postDelayed({ statusPanel?.visibility = View.GONE }, MAP_SUCCESS_DISMISS_MS)
                 try {
                     map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 64))
+                    handler.postDelayed(dismissStatusRunnable, MAP_SUCCESS_DISMISS_MS)
                 } catch (e: Exception) {
                     Log.w(TAG, "Camera bounds fit failed — map may be too small", e)
                     setMapStatus(
@@ -243,6 +245,7 @@ class ScanMapActivity :
         title: String,
         body: String,
     ) {
+        handler.removeCallbacks(dismissStatusRunnable)
         statusTitle?.text = title
         statusBody?.text = body
         statusPanel?.visibility = View.VISIBLE
@@ -250,6 +253,7 @@ class ScanMapActivity :
 
     override fun onDestroy() {
         super.onDestroy()
+        handler.removeCallbacks(dismissStatusRunnable)
         executor.shutdownNow()
     }
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -27,18 +27,6 @@ import net.sqlcipher.database.SQLiteDatabase
 import net.sqlcipher.database.SupportFactory
 import java.util.concurrent.Executors
 
-/**
- * Displays a GPS-tagged scan history heatmap using Google Maps.
- *
- * Each point corresponds to a scan result with a recorded GPS location.
- * Points are weighted by the maximum threat signal confidence for that BSSID — threat
- * detections appear as hot zones; clean BSSIDs contribute minimal baseline heat.
- *
- * When WatchdogService is running and the device has a barometer, a floor badge is
- * shown in the top-left corner reflecting the current relative floor estimate.
- *
- * Requires GOOGLE_MAPS_API_KEY in local.properties (injected via secrets-gradle-plugin).
- */
 class ScanMapActivity :
     FragmentActivity(),
     OnMapReadyCallback {
@@ -47,6 +35,9 @@ class ScanMapActivity :
 
     private var watchdogService: WatchdogService? = null
     private var floorBadge: TextView? = null
+    private var statusPanel: View? = null
+    private var statusTitle: TextView? = null
+    private var statusBody: TextView? = null
     private var isServiceBound = false
 
     private val serviceConnection =
@@ -77,9 +68,20 @@ class ScanMapActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WscanUi.prepareWindow(this)
         setContentView(R.layout.activity_scan_map)
 
+        WscanUi.applySystemInsets(
+            findViewById(R.id.scan_map_root),
+            horizontalPadding = 0,
+            topPadding = 0,
+            bottomPadding = 0,
+        )
         floorBadge = findViewById(R.id.floor_badge)
+        statusPanel = findViewById(R.id.map_status_panel)
+        statusTitle = findViewById(R.id.map_status_title)
+        statusBody = findViewById(R.id.map_status_body)
+        setMapStatus("Loading scan map", "Preparing Google Maps and encrypted scan database.")
 
         val mapFragment = SupportMapFragment.newInstance()
         supportFragmentManager
@@ -91,7 +93,6 @@ class ScanMapActivity :
 
     override fun onStart() {
         super.onStart()
-        // Bind only if the service is already running — do not create it just for the badge.
         val bindIntent = Intent(this, WatchdogService::class.java)
         isServiceBound = bindService(bindIntent, serviceConnection, 0)
     }
@@ -130,6 +131,7 @@ class ScanMapActivity :
     }
 
     override fun onMapReady(map: GoogleMap) {
+        setMapStatus("Map ready", "Loading GPS-tagged scan records and heatmap points.")
         executor.execute {
             try {
                 loadAndRender(map)
@@ -137,6 +139,10 @@ class ScanMapActivity :
                 Log.e(TAG, "Failed to load scan map data", e)
                 if (!isDestroyed) {
                     runOnUiThread {
+                        setMapStatus(
+                            "Map data unavailable",
+                            "Failed to load scan map data. Check database state and Google Maps configuration.",
+                        )
                         Toast.makeText(this, "Failed to load map data.", Toast.LENGTH_LONG).show()
                     }
                 }
@@ -150,31 +156,36 @@ class ScanMapActivity :
             Log.e(TAG, "Encrypted database unavailable — cannot load map data")
             if (!isDestroyed) {
                 runOnUiThread {
-                    Toast.makeText(this, "Encrypted database unavailable.", Toast.LENGTH_LONG).show()
+                    setMapStatus(
+                        "Encrypted database unavailable",
+                        "The scan database could not be opened, so no heatmap can be rendered yet.",
+                    )
                 }
             }
             return
         }
+
         SQLiteDatabase.loadLibs(applicationContext)
         val db = WscanDatabase.getInstance(applicationContext, SupportFactory(passphrase))
         val scanResults = db.scanResultDao().getGpsTagged(limit = 500)
         if (scanResults.isEmpty()) {
             if (!isDestroyed) {
                 runOnUiThread {
-                    Toast.makeText(this, "No GPS-tagged scan data yet.", Toast.LENGTH_LONG).show()
+                    setMapStatus(
+                        "No GPS-tagged scan data",
+                        "Run a scan with location enabled. Heatmap points appear after stored results include latitude and longitude.",
+                    )
                 }
             }
             return
         }
 
-        // BSSID → max threat confidence from stored high-confidence signals.
         val rawSignals = db.threatSignalDao().getHighConfidence(minConfidence = 0.3f, limit = 1000)
         val threatMap =
             rawSignals
                 .groupBy { signal -> signal.bssid }
                 .mapValues { (_, signalList) -> signalList.maxOf { signal -> signal.confidence } }
 
-        // Keep LatLng alongside weight so bounds can be built without re-deriving coordinates.
         data class MapPoint(
             val latLng: LatLng,
             val weight: Double,
@@ -184,7 +195,6 @@ class ScanMapActivity :
             scanResults.mapNotNull { result ->
                 val lat = result.latitude ?: return@mapNotNull null
                 val lng = result.longitude ?: return@mapNotNull null
-                // Threat BSSIDs weighted by confidence (0.3–1.0); clean BSSIDs at 0.1.
                 val weight = (threatMap[result.bssid] ?: 0.1f).toDouble()
                 MapPoint(LatLng(lat, lng), weight)
             }
@@ -192,18 +202,21 @@ class ScanMapActivity :
         if (points.isEmpty()) {
             if (!isDestroyed) {
                 runOnUiThread {
-                    Toast.makeText(this, "Scan results have no GPS coordinates.", Toast.LENGTH_LONG).show()
+                    setMapStatus(
+                        "Scan records lack coordinates",
+                        "Stored scan rows exist, but none include usable GPS coordinates yet.",
+                    )
                 }
             }
             return
         }
 
         val weightedPoints = points.map { p -> WeightedLatLng(p.latLng, p.weight) }
-
-        val heatmapBuilder = HeatmapTileProvider.Builder()
-        heatmapBuilder.weightedData(weightedPoints)
-        heatmapBuilder.radius(50)
-        val provider = heatmapBuilder.build()
+        val provider =
+            HeatmapTileProvider.Builder()
+                .weightedData(weightedPoints)
+                .radius(50)
+                .build()
 
         val boundsBuilder = LatLngBounds.Builder()
         points.forEach { p -> boundsBuilder.include(p.latLng) }
@@ -212,24 +225,38 @@ class ScanMapActivity :
         if (!isDestroyed) {
             runOnUiThread {
                 map.addTileOverlay(TileOverlayOptions().tileProvider(provider))
+                setMapStatus("Heatmap rendered", "${points.size} GPS-tagged scan points loaded.")
+                handler.postDelayed({ statusPanel?.visibility = View.GONE }, MAP_SUCCESS_DISMISS_MS)
                 try {
                     map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 64))
                 } catch (e: Exception) {
                     Log.w(TAG, "Camera bounds fit failed — map may be too small", e)
+                    setMapStatus(
+                        "Heatmap rendered",
+                        "Points loaded, but automatic camera fit failed. You can still pan and zoom the map.",
+                    )
                 }
             }
         }
     }
 
+    private fun setMapStatus(
+        title: String,
+        body: String,
+    ) {
+        statusTitle?.text = title
+        statusBody?.text = body
+        statusPanel?.visibility = View.VISIBLE
+    }
+
     override fun onDestroy() {
         super.onDestroy()
-        // shutdownNow() interrupts any in-flight task; isDestroyed guards prevent
-        // runOnUiThread calls from reaching a destroyed activity.
         executor.shutdownNow()
     }
 
     companion object {
         private const val TAG = "ScanMapActivity"
         private const val FLOOR_UPDATE_INTERVAL_MS = 1000L
+        private const val MAP_SUCCESS_DISMISS_MS = 3000L
     }
 }

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -212,11 +212,10 @@ class ScanMapActivity :
         }
 
         val weightedPoints = points.map { p -> WeightedLatLng(p.latLng, p.weight) }
-        val provider =
-            HeatmapTileProvider.Builder()
-                .weightedData(weightedPoints)
-                .radius(50)
-                .build()
+        val heatmapBuilder = HeatmapTileProvider.Builder()
+        heatmapBuilder.weightedData(weightedPoints)
+        heatmapBuilder.radius(50)
+        val provider = heatmapBuilder.build()
 
         val boundsBuilder = LatLngBounds.Builder()
         points.forEach { p -> boundsBuilder.include(p.latLng) }

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:function-signature")
-
 package com.wscanplus.app
 
 import android.app.Activity

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import java.util.Locale
 
 object WscanUi {
     val COLOR_NAVY: Int = Color.rgb(2, 28, 55)
@@ -62,7 +63,11 @@ object WscanUi {
         }
     }
 
-    fun header(parent: LinearLayout, title: String, subtitle: String? = null) {
+    fun header(
+        parent: LinearLayout,
+        title: String,
+        subtitle: String? = null,
+    ) {
         parent.addView(
             TextView(parent.context).apply {
                 text = title
@@ -91,19 +96,23 @@ object WscanUi {
                 background = rounded(COLOR_CARD, parent.dp(16), strokeColor = Color.rgb(38, 57, 87))
                 parent.addView(
                     this,
-                    LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT,
-                    ).apply {
-                        bottomMargin = parent.dp(12)
-                    },
+                    LinearLayout
+                        .LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT,
+                        ).apply {
+                            bottomMargin = parent.dp(12)
+                        },
                 )
             }
 
-    fun sectionTitle(parent: LinearLayout, text: String) {
+    fun sectionTitle(
+        parent: LinearLayout,
+        text: String,
+    ) {
         parent.addView(
             TextView(parent.context).apply {
-                this.text = text.uppercase()
+                this.text = text.uppercase(Locale.ROOT)
                 textSize = 11f
                 letterSpacing = 0.12f
                 typeface = Typeface.DEFAULT_BOLD
@@ -113,7 +122,11 @@ object WscanUi {
         )
     }
 
-    fun body(parent: LinearLayout, text: String, muted: Boolean = false): TextView =
+    fun body(
+        parent: LinearLayout,
+        text: String,
+        muted: Boolean = false,
+    ): TextView =
         TextView(parent.context).apply {
             this.text = text
             textSize = 14f
@@ -122,7 +135,12 @@ object WscanUi {
             parent.addView(this)
         }
 
-    fun metricRow(parent: LinearLayout, label: String, value: String, valueColor: Int = COLOR_TEXT) {
+    fun metricRow(
+        parent: LinearLayout,
+        label: String,
+        value: String,
+        valueColor: Int = COLOR_TEXT,
+    ) {
         val row =
             LinearLayout(parent.context).apply {
                 orientation = LinearLayout.HORIZONTAL
@@ -147,7 +165,11 @@ object WscanUi {
         parent.addView(row)
     }
 
-    fun actionButton(parent: LinearLayout, text: String, onClick: () -> Unit): Button =
+    fun actionButton(
+        parent: LinearLayout,
+        text: String,
+        onClick: () -> Unit,
+    ): Button =
         Button(parent.context)
             .apply {
                 this.text = text
@@ -159,18 +181,23 @@ object WscanUi {
                 setOnClickListener { onClick() }
                 parent.addView(
                     this,
-                    LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        parent.dp(52),
-                    ).apply {
-                        bottomMargin = parent.dp(10)
-                    },
+                    LinearLayout
+                        .LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            parent.dp(52),
+                        ).apply {
+                            bottomMargin = parent.dp(10)
+                        },
                 )
             }
 
     fun statusColor(value: Boolean): Int = if (value) COLOR_OK else COLOR_BAD
 
-    fun rounded(color: Int, radius: Int, strokeColor: Int? = null): GradientDrawable =
+    fun rounded(
+        color: Int,
+        radius: Int,
+        strokeColor: Int? = null,
+    ): GradientDrawable =
         GradientDrawable().apply {
             setColor(color)
             cornerRadius = radius.toFloat()

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -1,4 +1,4 @@
-@file:Suppress("ktlint:standard:function-signature", "ktlint:standard:chain-wrapping")
+@file:Suppress("ktlint:standard:function-signature")
 
 package com.wscanplus.app
 
@@ -86,20 +86,21 @@ object WscanUi {
     }
 
     fun card(parent: LinearLayout): LinearLayout =
-        LinearLayout(parent.context).apply {
-            orientation = LinearLayout.VERTICAL
-            setPadding(parent.dp(16), parent.dp(14), parent.dp(16), parent.dp(14))
-            background = rounded(COLOR_CARD, parent.dp(16), strokeColor = Color.rgb(38, 57, 87))
-            parent.addView(
-                this,
-                LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT,
-                ).apply {
-                    bottomMargin = parent.dp(12)
-                },
-            )
-        }
+        LinearLayout(parent.context)
+            .apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(parent.dp(16), parent.dp(14), parent.dp(16), parent.dp(14))
+                background = rounded(COLOR_CARD, parent.dp(16), strokeColor = Color.rgb(38, 57, 87))
+                parent.addView(
+                    this,
+                    LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                    ).apply {
+                        bottomMargin = parent.dp(12)
+                    },
+                )
+            }
 
     fun sectionTitle(parent: LinearLayout, text: String) {
         parent.addView(
@@ -149,24 +150,25 @@ object WscanUi {
     }
 
     fun actionButton(parent: LinearLayout, text: String, onClick: () -> Unit): Button =
-        Button(parent.context).apply {
-            this.text = text
-            setTextColor(COLOR_TEXT)
-            textSize = 13f
-            typeface = Typeface.DEFAULT_BOLD
-            background = rounded(COLOR_CARD_ALT, parent.dp(14), strokeColor = COLOR_ACCENT)
-            setPadding(parent.dp(12), parent.dp(10), parent.dp(12), parent.dp(10))
-            setOnClickListener { onClick() }
-            parent.addView(
-                this,
-                LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    parent.dp(52),
-                ).apply {
-                    bottomMargin = parent.dp(10)
-                },
-            )
-        }
+        Button(parent.context)
+            .apply {
+                this.text = text
+                setTextColor(COLOR_TEXT)
+                textSize = 13f
+                typeface = Typeface.DEFAULT_BOLD
+                background = rounded(COLOR_CARD_ALT, parent.dp(14), strokeColor = COLOR_ACCENT)
+                setPadding(parent.dp(12), parent.dp(10), parent.dp(12), parent.dp(10))
+                setOnClickListener { onClick() }
+                parent.addView(
+                    this,
+                    LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        parent.dp(52),
+                    ).apply {
+                        bottomMargin = parent.dp(10)
+                    },
+                )
+            }
 
     fun statusColor(value: Boolean): Int = if (value) COLOR_OK else COLOR_BAD
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -6,7 +6,6 @@ import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import android.view.View
-import android.view.Window
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -62,9 +61,6 @@ object WscanUi {
             applySystemInsets(this)
         }
     }
-
-    fun title(text: String): TextView =
-        TextView(null).also { _ -> }
 
     fun header(parent: LinearLayout, title: String, subtitle: String? = null) {
         parent.addView(

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -1,0 +1,185 @@
+package com.wscanplus.app
+
+import android.app.Activity
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.view.View
+import android.view.Window
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+
+object WscanUi {
+    const val COLOR_NAVY: Int = Color.rgb(2, 28, 55)
+    const val COLOR_BG: Int = Color.rgb(11, 18, 32)
+    const val COLOR_CARD: Int = Color.rgb(17, 28, 47)
+    const val COLOR_CARD_ALT: Int = Color.rgb(21, 35, 58)
+    const val COLOR_TEXT: Int = Color.rgb(232, 240, 255)
+    const val COLOR_MUTED: Int = Color.rgb(147, 163, 184)
+    const val COLOR_ACCENT: Int = Color.rgb(64, 196, 255)
+    const val COLOR_WARN: Int = Color.rgb(255, 193, 7)
+    const val COLOR_OK: Int = Color.rgb(55, 214, 122)
+    const val COLOR_BAD: Int = Color.rgb(255, 94, 94)
+
+    fun prepareWindow(activity: Activity) {
+        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        activity.window.statusBarColor = COLOR_NAVY
+        activity.window.navigationBarColor = COLOR_BG
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            activity.window.navigationBarDividerColor = COLOR_BG
+        }
+    }
+
+    fun applySystemInsets(
+        root: View,
+        horizontalPadding: Int = root.dp(20),
+        topPadding: Int = root.dp(18),
+        bottomPadding: Int = root.dp(18),
+    ) {
+        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(
+                bars.left + horizontalPadding,
+                bars.top + topPadding,
+                bars.right + horizontalPadding,
+                bars.bottom + bottomPadding,
+            )
+            insets
+        }
+        ViewCompat.requestApplyInsets(root)
+    }
+
+    fun shell(activity: Activity): LinearLayout {
+        prepareWindow(activity)
+        return LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(COLOR_BG)
+            applySystemInsets(this)
+        }
+    }
+
+    fun title(text: String): TextView =
+        TextView(null).also { _ -> }
+
+    fun header(parent: LinearLayout, title: String, subtitle: String? = null) {
+        parent.addView(
+            TextView(parent.context).apply {
+                text = title
+                textSize = 24f
+                setTextColor(COLOR_TEXT)
+                typeface = Typeface.DEFAULT_BOLD
+            },
+        )
+        if (subtitle != null) {
+            parent.addView(
+                TextView(parent.context).apply {
+                    text = subtitle
+                    textSize = 13f
+                    setTextColor(COLOR_MUTED)
+                    setPadding(0, parent.dp(6), 0, parent.dp(14))
+                },
+            )
+        }
+    }
+
+    fun card(parent: LinearLayout): LinearLayout =
+        LinearLayout(parent.context).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(parent.dp(16), parent.dp(14), parent.dp(16), parent.dp(14))
+            background = rounded(COLOR_CARD, parent.dp(16), strokeColor = Color.rgb(38, 57, 87))
+            parent.addView(
+                this,
+                LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                ).apply {
+                    bottomMargin = parent.dp(12)
+                },
+            )
+        }
+
+    fun sectionTitle(parent: LinearLayout, text: String) {
+        parent.addView(
+            TextView(parent.context).apply {
+                this.text = text.uppercase()
+                textSize = 11f
+                letterSpacing = 0.12f
+                typeface = Typeface.DEFAULT_BOLD
+                setTextColor(COLOR_ACCENT)
+                setPadding(0, 0, 0, parent.dp(8))
+            },
+        )
+    }
+
+    fun body(parent: LinearLayout, text: String, muted: Boolean = false): TextView =
+        TextView(parent.context).apply {
+            this.text = text
+            textSize = 14f
+            setTextColor(if (muted) COLOR_MUTED else COLOR_TEXT)
+            setLineSpacing(0f, 1.12f)
+            parent.addView(this)
+        }
+
+    fun metricRow(parent: LinearLayout, label: String, value: String, valueColor: Int = COLOR_TEXT) {
+        val row =
+            LinearLayout(parent.context).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(0, parent.dp(4), 0, parent.dp(4))
+            }
+        row.addView(
+            TextView(parent.context).apply {
+                text = label
+                textSize = 13f
+                setTextColor(COLOR_MUTED)
+            },
+            LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f),
+        )
+        row.addView(
+            TextView(parent.context).apply {
+                text = value
+                textSize = 13f
+                typeface = Typeface.MONOSPACE
+                setTextColor(valueColor)
+            },
+        )
+        parent.addView(row)
+    }
+
+    fun actionButton(parent: LinearLayout, text: String, onClick: () -> Unit): Button =
+        Button(parent.context).apply {
+            this.text = text
+            setTextColor(COLOR_TEXT)
+            textSize = 13f
+            typeface = Typeface.DEFAULT_BOLD
+            background = rounded(COLOR_CARD_ALT, parent.dp(14), strokeColor = COLOR_ACCENT)
+            setPadding(parent.dp(12), parent.dp(10), parent.dp(12), parent.dp(10))
+            setOnClickListener { onClick() }
+            parent.addView(
+                this,
+                LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    parent.dp(52),
+                ).apply {
+                    bottomMargin = parent.dp(10)
+                },
+            )
+        }
+
+    fun statusColor(value: Boolean): Int = if (value) COLOR_OK else COLOR_BAD
+
+    fun rounded(color: Int, radius: Int, strokeColor: Int? = null): GradientDrawable =
+        GradientDrawable().apply {
+            setColor(color)
+            cornerRadius = radius.toFloat()
+            if (strokeColor != null) {
+                setStroke(1, strokeColor)
+            }
+        }
+
+    fun View.dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -14,16 +14,16 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 
 object WscanUi {
-    const val COLOR_NAVY: Int = Color.rgb(2, 28, 55)
-    const val COLOR_BG: Int = Color.rgb(11, 18, 32)
-    const val COLOR_CARD: Int = Color.rgb(17, 28, 47)
-    const val COLOR_CARD_ALT: Int = Color.rgb(21, 35, 58)
-    const val COLOR_TEXT: Int = Color.rgb(232, 240, 255)
-    const val COLOR_MUTED: Int = Color.rgb(147, 163, 184)
-    const val COLOR_ACCENT: Int = Color.rgb(64, 196, 255)
-    const val COLOR_WARN: Int = Color.rgb(255, 193, 7)
-    const val COLOR_OK: Int = Color.rgb(55, 214, 122)
-    const val COLOR_BAD: Int = Color.rgb(255, 94, 94)
+    val COLOR_NAVY: Int = Color.rgb(2, 28, 55)
+    val COLOR_BG: Int = Color.rgb(11, 18, 32)
+    val COLOR_CARD: Int = Color.rgb(17, 28, 47)
+    val COLOR_CARD_ALT: Int = Color.rgb(21, 35, 58)
+    val COLOR_TEXT: Int = Color.rgb(232, 240, 255)
+    val COLOR_MUTED: Int = Color.rgb(147, 163, 184)
+    val COLOR_ACCENT: Int = Color.rgb(64, 196, 255)
+    val COLOR_WARN: Int = Color.rgb(255, 193, 7)
+    val COLOR_OK: Int = Color.rgb(55, 214, 122)
+    val COLOR_BAD: Int = Color.rgb(255, 94, 94)
 
     fun prepareWindow(activity: Activity) {
         WindowCompat.setDecorFitsSystemWindows(activity.window, false)

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:function-signature", "ktlint:standard:chain-wrapping")
+
 package com.wscanplus.app
 
 import android.app.Activity

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:function-expression-body")
+
 package com.wscanplus.app.capabilities
 
 import android.Manifest

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -6,35 +6,31 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorManager
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
 import android.net.wifi.rtt.WifiRttManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 
 object CapabilityProbe {
     suspend fun probe(context: Context): DeviceCapabilityManifest {
-        val packageManager = context.packageManager
-        val sensorManager = context.getSystemService(SensorManager::class.java)
+        val appContext = context.applicationContext
+        val packageManager = appContext.packageManager
+        val sensorManager = appContext.getSystemService(SensorManager::class.java)
 
-        val wifiFeature =
-            packageManager.hasSystemFeature(
-                PackageManager.FEATURE_WIFI,
-            )
-        val locationGranted = hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+        val wifiFeature = packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI)
+        val locationGranted = hasPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION)
         val wifiPermissionsGranted =
-            hasPermission(context, Manifest.permission.CHANGE_WIFI_STATE) &&
-                hasPermission(context, Manifest.permission.ACCESS_WIFI_STATE) &&
+            hasPermission(appContext, Manifest.permission.CHANGE_WIFI_STATE) &&
+                hasPermission(appContext, Manifest.permission.ACCESS_WIFI_STATE) &&
                 locationGranted
         val wifiRttFeature =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
                 packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_RTT)
         val wifiRttAvailableNow =
-            if (wifiRttFeature && locationGranted) {
-                context
-                    .getSystemService(WifiRttManager::class.java)
-                    ?.isAvailable == true
-            } else {
-                false
-            }
+            wifiRttFeature &&
+                locationGranted &&
+                appContext.getSystemService(WifiRttManager::class.java)?.isAvailable == true
         val uwb =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 @Suppress("InlinedApi")
@@ -55,28 +51,65 @@ object CapabilityProbe {
             nsd = true,
             bluetoothLe =
                 packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE) &&
-                    context
-                        .getSystemService(BluetoothManager::class.java)
-                        ?.adapter != null,
+                    appContext.getSystemService(BluetoothManager::class.java)?.adapter != null,
             proximity = hasSensor(sensorManager, Sensor.TYPE_PROXIMITY),
             magnetometer = hasSensor(sensorManager, Sensor.TYPE_MAGNETIC_FIELD),
             accelerometer = hasSensor(sensorManager, Sensor.TYPE_ACCELEROMETER),
             gyroscope = hasSensor(sensorManager, Sensor.TYPE_GYROSCOPE),
             wifiRttAvailableNow = wifiRttAvailableNow,
-            cameraIrCapable = CameraIrStatus.UNTESTED,
-            acousticSonarCapable = AcousticStatus.UNTESTED,
+            cameraIrCapable = probeCameraDepth(appContext, packageManager),
+            acousticSonarCapable = probeAcoustic(appContext, packageManager),
         )
+    }
+
+    private fun probeCameraDepth(
+        context: Context,
+        packageManager: PackageManager,
+    ): CameraIrStatus {
+        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) {
+            return CameraIrStatus.NOT_CAPABLE
+        }
+        val cameraManager = context.getSystemService(CameraManager::class.java) ?: return CameraIrStatus.PARTIAL
+        return try {
+            val hasDepthOutput =
+                cameraManager.cameraIdList.any { cameraId ->
+                    val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+                    val capabilities =
+                        characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES) ?: intArrayOf()
+                    capabilities.contains(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES_DEPTH_OUTPUT)
+                }
+            if (hasDepthOutput) CameraIrStatus.PARTIAL else CameraIrStatus.NOT_CAPABLE
+        } catch (_: Exception) {
+            CameraIrStatus.PARTIAL
+        }
+    }
+
+    private fun probeAcoustic(
+        context: Context,
+        packageManager: PackageManager,
+    ): AcousticStatus {
+        val hasMicrophone = packageManager.hasSystemFeature(PackageManager.FEATURE_MICROPHONE)
+        val hasAudioOutput = packageManager.hasSystemFeature(FEATURE_AUDIO_OUTPUT)
+        if (!hasMicrophone || !hasAudioOutput) {
+            return AcousticStatus.NOT_CAPABLE
+        }
+        return if (hasPermission(context, Manifest.permission.RECORD_AUDIO)) {
+            AcousticStatus.CAPABLE
+        } else {
+            AcousticStatus.DEVICE_VARIABLE
+        }
     }
 
     private fun hasPermission(
         context: Context,
         permission: String,
     ): Boolean =
-        ContextCompat
-            .checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 
     private fun hasSensor(
         sensorManager: SensorManager?,
         sensorType: Int,
     ): Boolean = sensorManager?.getDefaultSensor(sensorType) != null
+
+    private const val FEATURE_AUDIO_OUTPUT = "android.hardware.audio.output"
 }

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -103,8 +103,9 @@ object CapabilityProbe {
     private fun hasPermission(
         context: Context,
         permission: String,
-    ): Boolean =
-        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    ): Boolean {
+        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
 
     private fun hasSensor(
         sensorManager: SensorManager?,

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:function-expression-body")
-
 package com.wscanplus.app.capabilities
 
 import android.Manifest

--- a/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/capabilities/CapabilityProbe.kt
@@ -71,7 +71,7 @@ object CapabilityProbe {
         if (!packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) {
             return CameraIrStatus.NOT_CAPABLE
         }
-        val cameraManager = context.getSystemService(CameraManager::class.java) ?: return CameraIrStatus.PARTIAL
+        val cameraManager = context.getSystemService(CameraManager::class.java) ?: return CameraIrStatus.UNTESTED
         return try {
             val hasDepthOutput =
                 cameraManager.cameraIdList.any { cameraId ->
@@ -80,9 +80,9 @@ object CapabilityProbe {
                         characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES) ?: intArrayOf()
                     capabilities.contains(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES_DEPTH_OUTPUT)
                 }
-            if (hasDepthOutput) CameraIrStatus.PARTIAL else CameraIrStatus.NOT_CAPABLE
+            if (hasDepthOutput) CameraIrStatus.CAPABLE else CameraIrStatus.NOT_CAPABLE
         } catch (_: Exception) {
-            CameraIrStatus.PARTIAL
+            CameraIrStatus.UNTESTED
         }
     }
 
@@ -105,9 +105,7 @@ object CapabilityProbe {
     private fun hasPermission(
         context: Context,
         permission: String,
-    ): Boolean {
-        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-    }
+    ): Boolean = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 
     private fun hasSensor(
         sensorManager: SensorManager?,

--- a/android/app/src/main/res/layout/activity_scan_map.xml
+++ b/android/app/src/main/res/layout/activity_scan_map.xml
@@ -2,22 +2,50 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/scan_map_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="#0B1220">
 
-    <!-- Map fragment container fills the full screen -->
     <FrameLayout
         android:id="@+id/map_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <!-- Floor badge — top-start corner, hidden until a floor estimate is available -->
+    <LinearLayout
+        android:id="@+id/map_status_panel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:layout_margin="16dp"
+        android:background="#E6111C2F"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/map_status_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Loading scan map"
+            android:textColor="#E8F0FF"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/map_status_body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="Preparing heatmap provider and encrypted scan database."
+            android:textColor="#93A3B8"
+            android:textSize="13sp" />
+    </LinearLayout>
+
     <TextView
         android:id="@+id/floor_badge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="top|start"
-        android:layout_margin="12dp"
-        android:background="#CC000000"
+        android:layout_gravity="bottom|start"
+        android:layout_margin="16dp"
+        android:background="#E6111C2F"
         android:paddingStart="10dp"
         android:paddingEnd="10dp"
         android:paddingTop="6dp"


### PR DESCRIPTION
## Summary

Closes #239

Polishes the debug APK test-build surfaces that were blocking useful device validation after PR #237.

## Changes

- Adds lightweight branded `WscanUi` helpers for tactical dark shell, cards, metrics, buttons, and system-bar safe-area padding.
- Replaces the prototype MainActivity button stack with branded cards and actions.
- Replaces raw Diagnostics monospace dump with structured service, capability, floor, and desktop-link cards.
- Adds visible map status overlay states for loading, encrypted database unavailable, no GPS-tagged scan data, rows without coordinates, and successful heatmap render.
- Replaces hard-coded `Camera IR: UNTESTED` and `Acoustic: UNTESTED` capability defaults with non-invasive runtime probes.

## Test focus

- Pixel 10 Pro XL portrait and landscape smoke test.
- Main screen should no longer show default gray buttons.
- Diagnostics should no longer collide with app/status bars or show a raw text dump.
- Map should no longer appear as an unexplained blank area.
- Camera/acoustic capability rows should no longer stay permanently `UNTESTED`.

## Constraints

- No Room schema changes.
- No collector behavior changes.
- No release signing changes.
- CI debug APK may still use mock Google services.