### PR TITLE
fix(ui): Kismet Settings URL hidden + Diagnostics refresh timestamp

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -21,6 +21,7 @@ class DiagnosticActivity : Activity() {
     private var serviceBound = false
     private lateinit var content: LinearLayout
     private val handler = Handler(Looper.getMainLooper())
+    private var lastRefreshedAt: Long = 0L
 
     private val refreshRunnable: Runnable =
         object : Runnable {
@@ -94,6 +95,7 @@ class DiagnosticActivity : Activity() {
         if (!serviceBound) {
             serviceBound = bindService(Intent(this, WatchdogService::class.java), serviceConnection, 0)
         }
+        lastRefreshedAt = System.currentTimeMillis()
         content.removeAllViews()
         val binder = boundBinder
         if (binder == null) {
@@ -114,6 +116,7 @@ class DiagnosticActivity : Activity() {
             if (binder.isDegraded) "RUNNING · DEGRADED" else "RUNNING",
             if (binder.isDegraded) WscanUi.COLOR_WARN else WscanUi.COLOR_OK,
         )
+        WscanUi.metricRow(serviceCard, "Last refreshed", formatMs(lastRefreshedAt), WscanUi.COLOR_MUTED)
         WscanUi.actionButton(serviceCard, "Refresh Diagnostics") { refreshDiagnostics() }
 
         val capsCard = WscanUi.card(content)
@@ -170,6 +173,7 @@ class DiagnosticActivity : Activity() {
         val card = WscanUi.card(content)
         WscanUi.sectionTitle(card, "Service")
         WscanUi.metricRow(card, "WatchdogService", state, color)
+        WscanUi.metricRow(card, "Last refreshed", formatMs(lastRefreshedAt), WscanUi.COLOR_MUTED)
         WscanUi.body(card, message, muted = true)
         WscanUi.actionButton(card, "Refresh Diagnostics") { refreshDiagnostics() }
     }

--- a/android/app/src/main/kotlin/com/wscanplus/app/KismetSettingsActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/KismetSettingsActivity.kt
@@ -8,7 +8,11 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import com.wscanplus.app.kismet.KismetConfig
 import com.wscanplus.app.kismet.KismetConfigStore
 import com.wscanplus.app.privacy.ConsentStore
@@ -31,6 +35,18 @@ class KismetSettingsActivity : Activity() {
                 orientation = LinearLayout.VERTICAL
                 setPadding(48, 48, 48, 48)
             }
+
+        val scrollView =
+            ScrollView(this).apply {
+                isFillViewport = true
+                addView(root)
+            }
+
+        ViewCompat.setOnApplyWindowInsetsListener(scrollView) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(top = bars.top, bottom = bars.bottom)
+            insets
+        }
 
         enabledCheckbox =
             CheckBox(this).apply {
@@ -66,7 +82,7 @@ class KismetSettingsActivity : Activity() {
         root.addView(consentCheckbox)
         root.addView(statusView)
         root.addView(saveButton)
-        setContentView(root)
+        setContentView(scrollView)
     }
 
     private fun buildInput(


### PR DESCRIPTION
## Summary
- **Kismet Settings**: Wraps content in `ScrollView` + applies `WindowInsetsCompat` top/bottom padding so the Kismet URL input field is no longer occluded by the status bar under Android 15+ edge-to-edge enforcement. The field was completely unreachable before this fix.
- **Diagnostics**: Adds a "Last refreshed" timestamp row to the service card so tapping the Refresh Diagnostics button gives visible confirmation a refresh occurred.

## Test plan
- [ ] Open Kismet Settings — Kismet URL and token fields visible at top of screen
- [ ] Scroll down — CrowdSec checkbox and Save button still reachable
- [ ] Open Diagnostics — "Last refreshed" row visible under WatchdogService status
- [ ] Tap Refresh Diagnostics — timestamp updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)