### PR TITLE
feat(map): add Center on Me FAB to Scan Map

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -1,8 +1,10 @@
 package com.wscanplus.app
 
+import android.Manifest
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.IBinder
@@ -11,7 +13,9 @@ import android.util.Log
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -19,6 +23,7 @@ import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.TileOverlayOptions
+import android.widget.ImageButton
 import com.google.maps.android.heatmaps.HeatmapTileProvider
 import com.google.maps.android.heatmaps.WeightedLatLng
 import com.wscanplus.app.db.DbPassphraseProvider
@@ -38,6 +43,8 @@ class ScanMapActivity :
     private var statusPanel: View? = null
     private var statusTitle: TextView? = null
     private var statusBody: TextView? = null
+    private var fabCenterOnMe: ImageButton? = null
+    private var googleMap: GoogleMap? = null
     private var isServiceBound = false
     private val dismissStatusRunnable = Runnable { statusPanel?.visibility = View.GONE }
 
@@ -82,6 +89,8 @@ class ScanMapActivity :
         statusPanel = findViewById(R.id.map_status_panel)
         statusTitle = findViewById(R.id.map_status_title)
         statusBody = findViewById(R.id.map_status_body)
+        fabCenterOnMe = findViewById(R.id.fab_center_on_me)
+        fabCenterOnMe?.setOnClickListener { centerOnMe() }
         setMapStatus("Loading scan map", "Preparing Google Maps and encrypted scan database.")
 
         val mapFragment = SupportMapFragment.newInstance()
@@ -133,6 +142,7 @@ class ScanMapActivity :
     }
 
     override fun onMapReady(map: GoogleMap) {
+        googleMap = map
         setMapStatus("Map ready", "Loading GPS-tagged scan records and heatmap points.")
         executor.execute {
             try {
@@ -239,6 +249,26 @@ class ScanMapActivity :
                 }
             }
         }
+    }
+
+    private fun centerOnMe() {
+        val map = googleMap ?: return
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Toast.makeText(this, "Location permission required.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        LocationServices.getFusedLocationProviderClient(this).lastLocation
+            .addOnSuccessListener { location ->
+                if (location != null) {
+                    map.animateCamera(
+                        CameraUpdateFactory.newLatLngZoom(LatLng(location.latitude, location.longitude), 16f),
+                    )
+                } else {
+                    Toast.makeText(this, "Location not yet available.", Toast.LENGTH_SHORT).show()
+                }
+            }
     }
 
     private fun setMapStatus(

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.util.Log
 import android.view.View
+import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -23,7 +24,6 @@ import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.TileOverlayOptions
-import android.widget.ImageButton
 import com.google.maps.android.heatmaps.HeatmapTileProvider
 import com.google.maps.android.heatmaps.WeightedLatLng
 import com.wscanplus.app.db.DbPassphraseProvider
@@ -259,7 +259,9 @@ class ScanMapActivity :
             Toast.makeText(this, "Location permission required.", Toast.LENGTH_SHORT).show()
             return
         }
-        LocationServices.getFusedLocationProviderClient(this).lastLocation
+        LocationServices
+            .getFusedLocationProviderClient(this)
+            .lastLocation
             .addOnSuccessListener { location ->
                 if (location != null) {
                     map.animateCamera(

--- a/android/app/src/main/res/drawable/bg_fab_center.xml
+++ b/android/app/src/main/res/drawable/bg_fab_center.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#2040C4FF">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="#111C2F" />
+            <stroke
+                android:width="1.5dp"
+                android:color="#40C4FF" />
+        </shape>
+    </item>
+</ripple>

--- a/android/app/src/main/res/layout/activity_scan_map.xml
+++ b/android/app/src/main/res/layout/activity_scan_map.xml
@@ -39,6 +39,19 @@
             android:textSize="13sp" />
     </LinearLayout>
 
+    <ImageButton
+        android:id="@+id/fab_center_on_me"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_fab_center"
+        android:contentDescription="Center on my location"
+        android:src="@android:drawable/ic_menu_mylocation"
+        android:tint="#40C4FF"
+        android:elevation="6dp"
+        android:padding="14dp" />
+
     <TextView
         android:id="@+id/floor_badge"
         android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- Adds a circular `ImageButton` FAB to the bottom-right corner of `ScanMapActivity`
- On tap, calls `FusedLocationProviderClient.lastLocation` and animates the camera to the user's current GPS position at zoom 16
- Background: `bg_fab_center.xml` — circular ripple drawable, dark fill `#111C2F`, cyan accent stroke `#40C4FF`, matching the wscan+ dark theme
- No new dependencies — uses existing `play-services-location` already in the project

## Test plan
- [ ] Open Scan Map — FAB visible bottom-right
- [ ] Pan map away from current location
- [ ] Tap FAB — map animates back to user's position
- [ ] With location permission denied — toast "Location permission required."
- [ ] With location not yet available — toast "Location not yet available."

🤖 Generated with [Claude Code](https://claude.com/claude-code)