### PR TITLE
fix(diag): rename Camera depth/IR and add Camera (photo) readiness row

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -135,7 +135,14 @@ class DiagnosticActivity : Activity() {
             WscanUi.metricRow(capsCard, "UWB", caps.uwb.toReadyLabel(), WscanUi.statusColor(caps.uwb))
             WscanUi.metricRow(capsCard, "Barometer", caps.barometer.toReadyLabel(), WscanUi.statusColor(caps.barometer))
             WscanUi.metricRow(capsCard, "BLE", caps.bluetoothLe.toReadyLabel(), WscanUi.statusColor(caps.bluetoothLe))
-            WscanUi.metricRow(capsCard, "Camera depth/IR", caps.cameraIrCapable.toDisplayLabel(), caps.cameraIrCapable.statusColor())
+            val hasCamera = packageManager.hasSystemFeature(android.content.pm.PackageManager.FEATURE_CAMERA_ANY)
+            WscanUi.metricRow(
+                capsCard,
+                "Camera (photo)",
+                if (hasCamera) "READY" else "UNAVAILABLE",
+                if (hasCamera) WscanUi.COLOR_OK else WscanUi.COLOR_BAD,
+            )
+            WscanUi.metricRow(capsCard, "Depth camera (ToF)", caps.cameraIrCapable.toDisplayLabel(), caps.cameraIrCapable.statusColor())
             WscanUi.metricRow(capsCard, "Acoustic", caps.acousticSonarCapable.toDisplayLabel(), caps.acousticSonarCapable.statusColor())
         } else {
             WscanUi.body(capsCard, "Capability probe has not completed yet.", muted = true)


### PR DESCRIPTION
## Summary
- Renames **"Camera depth/IR"** → **"Depth camera (ToF)"** to make clear this row only reflects ToF/depth sensor hardware, not front/rear photo cameras
- Adds a new **"Camera (photo)"** row checked via `PackageManager.FEATURE_CAMERA_ANY` — shows READY/UNAVAILABLE independently of depth sensor state
- Fixes the misleading **NOT CAPABLE** label on Pixel 10 Pro XL (and similar devices with no ToF sensor but fully functional cameras) found during smoke test

## Test plan
- [ ] Open Diagnostics on Pixel 10 Pro XL — "Camera (photo)" shows READY, "Depth camera (ToF)" shows NOT CAPABLE
- [ ] Open Diagnostics on device with ToF sensor — both rows show READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)