### PR TITLE
fix(session): close orphaned open sessions on new scan start

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -588,15 +588,19 @@ class WatchdogService : Service() {
                     error.message?.contains("closed", ignoreCase = true) == true
             )
 
-    private fun createSession(): Long =
-        database.scanSessionDao().insert(
+    private fun createSession(): Long {
+        val now = System.currentTimeMillis()
+        // Close any sessions left open by a previous crash or forced stop before starting a new one.
+        database.scanSessionDao().closeOrphanedSessions(endedAt = now)
+        return database.scanSessionDao().insert(
             ScanSessionEntity(
-                startedAt = System.currentTimeMillis(),
+                startedAt = now,
                 endedAt = null,
                 environmentType = EnvironmentType.RESIDENTIAL,
                 deviceSerial = buildDeviceIdentifier(),
             ),
         )
+    }
 
     private fun buildDeviceIdentifier(): String = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID) ?: "unknown-device"
 

--- a/android/core/src/main/kotlin/com/wscanplus/core/db/dao/ScanSessionDao.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/db/dao/ScanSessionDao.kt
@@ -27,6 +27,9 @@ interface ScanSessionDao {
         to: Long,
     ): List<ScanSessionEntity>
 
+    @Query("UPDATE scan_sessions SET endedAt = :endedAt WHERE endedAt IS NULL")
+    fun closeOrphanedSessions(endedAt: Long)
+
     /**
      * Delete completed sessions whose [ScanSessionEntity.endedAt] is before [cutoffMs].
      * Deletion cascades to scan_results and threat_signals via their FK constraints.


### PR DESCRIPTION
## Summary
Sessions left open by a crash or forced stop never had `endedAt` written, causing Scan History to show them as **"in progress"** indefinitely (confirmed in smoke test on Pixel 10 Pro XL).

- Adds `ScanSessionDao.closeOrphanedSessions(endedAt)` — stamps `endedAt = now` on all sessions where `endedAt IS NULL`
- Calls it at the top of `createSession()` so any orphan from the previous run is closed before a new session opens
- Clean `onDestroy()` path is unchanged — it still writes the accurate end time for the current session

## Test plan
- [ ] Start app — previous "in progress" sessions now show a duration in Scan History
- [ ] Kill app via task manager, relaunch — prior session closes, new session opens correctly
- [ ] Normal stop via `onDestroy()` — session still closes with accurate end time

🤖 Generated with [Claude Code](https://claude.com/claude-code)