### PR TITLE
fix: restore desktop pairing UI and CSP hardening

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws://127.0.0.1:* ws://localhost:*;"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws://127.0.0.1:* ws://localhost:*; object-src 'none'; base-uri 'none';"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>wscan+ Desktop Hub</title>
@@ -195,5 +195,6 @@
     </main>
 
     <script type="module" src="./renderer.mjs"></script>
+    <script type="module" src="./pairing.js"></script>
   </body>
 </html>

--- a/desktop/pairing.js
+++ b/desktop/pairing.js
@@ -1,0 +1,73 @@
+/* global window, document */
+
+const api = window.wscan ?? window.wscanplus ?? window.wscanPlus ?? {};
+
+function text(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+
+function showTokenBlock() {
+  const block = document.getElementById('pairing-token-block');
+  if (block) block.hidden = false;
+}
+
+function logPairingEvent(level, message) {
+  const log = document.getElementById('event-log');
+  const count = document.getElementById('event-count');
+  if (!log) return;
+
+  const line = `[${new Date().toLocaleTimeString([], { hour12: false })}] ${level.padEnd(5)} companion  ${message}`;
+  log.textContent = log.textContent ? `${log.textContent}\n${line}` : line;
+
+  if (count) {
+    const current = Number.parseInt(count.textContent, 10);
+    count.textContent = `${Number.isFinite(current) ? current + 1 : 1} events`;
+  }
+}
+
+function formatAddress(result) {
+  if (typeof result?.endpoint === 'string') return result.endpoint;
+  if (typeof result?.url === 'string') return result.url;
+  if (result?.address?.address && result?.address?.port) {
+    return `ws://${result.address.address}:${result.address.port}`;
+  }
+  if (result?.address && result?.port) return `ws://${result.address}:${result.port}`;
+  return 'Pairing endpoint unavailable';
+}
+
+async function pairCompanion() {
+  const button = document.getElementById('pair-companion');
+  if (button) button.disabled = true;
+
+  try {
+    if (typeof api.pairCompanion !== 'function') {
+      throw new Error('pairCompanion preload method unavailable');
+    }
+
+    const result = await api.pairCompanion();
+    if (result?.ok === false) {
+      throw new Error(result.error ?? 'pairing failed');
+    }
+
+    text('pairing-token-value', String(result?.token ?? 'No token returned'));
+    text('pairing-token-address', formatAddress(result));
+    showTokenBlock();
+    logPairingEvent('INFO', 'pairing token generated');
+  } catch (error) {
+    text('pairing-token-value', 'Pairing failed');
+    text('pairing-token-address', error instanceof Error ? error.message : String(error));
+    showTokenBlock();
+    logPairingEvent('ERROR', error instanceof Error ? error.message : String(error));
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+function initPairing() {
+  document.getElementById('pair-companion')?.addEventListener('click', () => {
+    void pairCompanion();
+  });
+}
+
+initPairing();

--- a/desktop/pairing.js
+++ b/desktop/pairing.js
@@ -36,6 +36,43 @@ function formatAddress(result) {
   return 'Pairing endpoint unavailable';
 }
 
+function mountPairingControls() {
+  if (document.getElementById('pair-companion')) return;
+  const panel = document.querySelector('.companion-panel');
+  if (!panel) return;
+
+  const section = document.createElement('section');
+  section.className = 'pairing-box';
+  section.setAttribute('aria-label', 'Companion pairing');
+
+  const button = document.createElement('button');
+  button.id = 'pair-companion';
+  button.className = 'secondary-action pairing-action';
+  button.type = 'button';
+  button.textContent = 'Generate Pairing Token';
+
+  const block = document.createElement('div');
+  block.id = 'pairing-token-block';
+  block.className = 'pairing-token-block';
+  block.hidden = true;
+
+  const label = document.createElement('div');
+  label.className = 'muted pairing-label';
+  label.textContent = 'Token';
+
+  const token = document.createElement('div');
+  token.id = 'pairing-token-value';
+  token.className = 'pairing-token-value';
+
+  const address = document.createElement('div');
+  address.id = 'pairing-token-address';
+  address.className = 'muted pairing-token-address';
+
+  block.append(label, token, address);
+  section.append(button, block);
+  panel.appendChild(section);
+}
+
 async function pairCompanion() {
   const button = document.getElementById('pair-companion');
   if (button) button.disabled = true;
@@ -65,6 +102,7 @@ async function pairCompanion() {
 }
 
 function initPairing() {
+  mountPairingControls();
   document.getElementById('pair-companion')?.addEventListener('click', () => {
     void pairCompanion();
   });


### PR DESCRIPTION
## Summary

Fixes #259

Restores two desktop UI/hardening details after the desktop hub UI v1 replacement.

## Changes

- Restores explicit CSP hardening directives in `desktop/index.html`:
  - `object-src 'none'`
  - `base-uri 'none'`
- Adds a small `desktop/pairing.js` module that self-mounts a companion pairing control into the existing Companion Health panel.
- Uses the existing preload API: `window.wscan.pairCompanion()`.
- Displays token and endpoint using `textContent` only.
- Logs pairing success/failure to the existing event console.

## Scope controls

- Desktop-only.
- No backend companion server changes.
- No Android changes.
- No Google Maps work.
- No Gemini/Vertex changes.
- No new dependencies.

## Verification

- Patch is isolated to desktop UI/hardening.
- Main branch only moved with docs/hardware changes, no conflicting files.
- CI should run Node/Desktop checks, Android checks, secret scan, and CodeQL.

## Agent

Made by ChatGPT under human maintainer direction.