### PR TITLE
fix: mark desktop demo data clearly

### DIFF
--- a/desktop/demoMode.js
+++ b/desktop/demoMode.js
@@ -1,0 +1,108 @@
+/* global window, document, MutationObserver */
+
+const api = window.wscan ?? window.wscanplus ?? window.wscanPlus ?? {};
+const DEMO_BSSIDS = new Set([
+  '9C:3A:AF:22:10:8B',
+  '1E:89:41:77:A0:2C',
+  'F2:1D:02:90:11:FE',
+  '58:EF:68:41:90:7A',
+]);
+
+let liveDataSeen = false;
+
+function createBanner() {
+  if (document.getElementById('demo-data-banner')) return;
+
+  const workspace = document.querySelector('.workspace');
+  const header = document.querySelector('.workspace-header');
+  if (!workspace || !header) return;
+
+  const banner = document.createElement('section');
+  banner.id = 'demo-data-banner';
+  banner.className = 'demo-data-banner';
+  banner.setAttribute('role', 'status');
+  banner.setAttribute('aria-live', 'polite');
+
+  const badge = document.createElement('span');
+  badge.id = 'data-mode-badge';
+  badge.className = 'badge badge-warning';
+  badge.textContent = 'DEMO DATA';
+
+  const text = document.createElement('p');
+  text.id = 'data-mode-message';
+  text.textContent = 'Sample AP rows and threat entries are layout placeholders only, not live evidence.';
+
+  banner.append(badge, text);
+  header.insertAdjacentElement('afterend', banner);
+  workspace.classList.add('workspace-with-demo-banner');
+}
+
+function normalizePayload(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.aps)) return payload.aps;
+  if (Array.isArray(payload?.networks)) return payload.networks;
+  return [];
+}
+
+function markLiveMode() {
+  if (liveDataSeen) return;
+  liveDataSeen = true;
+
+  const badge = document.getElementById('data-mode-badge');
+  if (badge) {
+    badge.className = 'badge badge-success';
+    badge.textContent = 'LIVE DATA';
+  }
+
+  const message = document.getElementById('data-mode-message');
+  if (message) {
+    message.textContent = 'Live scanner or companion AP data has arrived. Seeded demo rows are hidden from the operator view.';
+  }
+
+  hideSeededDemoRows();
+}
+
+function hideSeededDemoRows() {
+  const rows = document.querySelectorAll('#ap-table-body tr');
+  for (const row of rows) {
+    const bssid = row.children?.[1]?.textContent?.trim().toUpperCase();
+    if (bssid && DEMO_BSSIDS.has(bssid)) {
+      row.hidden = liveDataSeen;
+      row.classList.add('demo-seeded-row');
+      row.setAttribute('aria-label', 'Seeded demo row, hidden when live data is present');
+    }
+  }
+
+  const threatItems = document.querySelectorAll('.threat-item');
+  for (const item of threatItems) {
+    const text = item.textContent ?? '';
+    if (text.includes('F2:1D:02:90:11:FE') || text.includes('Unknown AP near trusted SSID pattern')) {
+      item.hidden = liveDataSeen;
+      item.classList.add('demo-seeded-threat');
+    }
+  }
+}
+
+function subscribeToLiveAps() {
+  if (typeof api.onAps !== 'function') return;
+  try {
+    api.onAps((payload) => {
+      const aps = normalizePayload(payload);
+      if (aps.length > 0) markLiveMode();
+    });
+  } catch {
+    // Renderer already reports preload/subscription failures. Keep this guard silent.
+  }
+}
+
+function observeTableRerenders() {
+  const target = document.querySelector('.workspace');
+  if (!target) return;
+  const observer = new MutationObserver(() => hideSeededDemoRows());
+  observer.observe(target, { childList: true, subtree: true });
+}
+
+createBanner();
+hideSeededDemoRows();
+subscribeToLiveAps();
+observeTableRerenders();

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -196,5 +196,6 @@
 
     <script type="module" src="./renderer.mjs"></script>
     <script type="module" src="./pairing.js"></script>
+    <script type="module" src="./demoMode.js"></script>
   </body>
 </html>

--- a/desktop/styles.css
+++ b/desktop/styles.css
@@ -172,6 +172,32 @@ select { width: 100%; min-height: 34px; color: var(--text); border: 1px solid va
   overflow: hidden;
 }
 
+.workspace-with-demo-banner {
+  grid-template-rows: auto auto auto minmax(230px, 0.8fr) minmax(230px, 1fr);
+}
+
+.demo-data-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 44px;
+  padding: 10px 14px;
+  border: 1px solid rgba(249, 168, 37, 0.54);
+  border-radius: 14px;
+  background: rgba(249, 168, 37, 0.1);
+}
+
+.demo-data-banner p {
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.demo-seeded-row,
+.demo-seeded-threat {
+  opacity: 0.72;
+}
+
 .primary-action,
 .secondary-action { min-height: 34px; border-radius: 10px; padding: 0 13px; font-weight: 800; }
 .primary-action { color: var(--text); border: 1px solid rgba(33, 150, 243, 0.7); background: linear-gradient(180deg, var(--primary), var(--primary-deep)); }


### PR DESCRIPTION
## Summary

Fixes #264

Adds a visible desktop UI demo-data indicator so seeded fallback rows cannot be mistaken for live evidence.

## Changes

- Adds `desktop/demoMode.js` as a small UI-only guard.
- Loads the demo-mode guard from `desktop/index.html`.
- Adds a visible `DEMO DATA` banner explaining that sample AP rows and threat entries are layout placeholders only.
- Switches the banner to `LIVE DATA` once live AP data is received through the existing preload `onAps` subscription.
- Hides known seeded demo AP rows and the seeded demo threat item after live AP payloads arrive.
- Adds minimal styling for the banner.

## Scope controls

- Desktop UI only.
- No scanner/detector changes.
- No Android changes.
- No ntfy implementation.
- No Google Maps work.
- No new dependencies.

## Verification

- Branch is current with `main`.
- Diff touches only intended desktop UI files.
- New browser globals are declared at file scope in `demoMode.js`.
- CI should run desktop lint/tests, Android checks, secret scan, and CodeQL.

## Agent

Made by ChatGPT under human maintainer direction.