### PR TITLE
Fix code review inconsistencies without bypasses

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanHistoryActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanHistoryActivity.kt
@@ -25,23 +25,24 @@ class ScanHistoryActivity : Activity() {
         super.onCreate(savedInstanceState)
         title = "Scan History"
 
-        val scrollView = ScrollView(this)
+        val root = WscanUi.shell(this)
+        WscanUi.header(root, "Scan History", "Recent scanner sessions, AP observations, threat counts, and narrative availability")
+        val scrollView = ScrollView(this).apply { isFillViewport = true }
         contentLayout =
             LinearLayout(this).apply {
                 orientation = LinearLayout.VERTICAL
-                setPadding(dp(20), dp(20), dp(20), dp(20))
             }
 
-        contentLayout.addView(
-            TextView(this).apply {
-                text = "Scan History"
-                textSize = 24f
-                setTypeface(typeface, Typeface.BOLD)
-            },
-        )
-
         scrollView.addView(contentLayout)
-        setContentView(scrollView)
+        root.addView(
+            scrollView,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                0,
+                1f,
+            ),
+        )
+        setContentView(root)
         loadHistory()
     }
 
@@ -80,13 +81,8 @@ class ScanHistoryActivity : Activity() {
 
     private fun renderHistory(rows: List<SessionHistoryRow>) {
         if (rows.isEmpty()) {
-            contentLayout.addView(
-                TextView(this).apply {
-                    text = "No scan sessions recorded yet."
-                    textSize = 14f
-                    setPadding(0, dp(12), 0, 0)
-                },
-            )
+            val card = WscanUi.card(contentLayout)
+            WscanUi.body(card, "No scan sessions recorded yet.", muted = true)
             return
         }
 
@@ -108,14 +104,9 @@ class ScanHistoryActivity : Activity() {
                 append("$totalAps AP observations  \u2022  $totalThreats threat signals")
             }
 
-        contentLayout.addView(
-            TextView(this).apply {
-                text = summaryText
-                textSize = 13f
-                alpha = 0.85f
-                setPadding(0, dp(8), 0, dp(20))
-            },
-        )
+        val summaryCard = WscanUi.card(contentLayout)
+        WscanUi.sectionTitle(summaryCard, "Summary")
+        WscanUi.body(summaryCard, summaryText)
 
         rows.forEach { row -> contentLayout.addView(buildRow(row)) }
     }
@@ -127,8 +118,8 @@ class ScanHistoryActivity : Activity() {
         val bg = GradientDrawable()
         bg.shape = GradientDrawable.RECTANGLE
         bg.cornerRadius = dp(12).toFloat()
-        bg.setColor(0xFFF6F4EE.toInt())
-        bg.setStroke(dp(1), 0xFFCCBFA3.toInt())
+        bg.setColor(WscanUi.COLOR_CARD)
+        bg.setStroke(dp(1), WscanUi.COLOR_CARD_ALT)
         card.background = bg
 
         val lp =
@@ -147,6 +138,7 @@ class ScanHistoryActivity : Activity() {
             TextView(this).apply {
                 text = formatDateTime(row.session.startedAt)
                 textSize = 15f
+                setTextColor(WscanUi.COLOR_TEXT)
                 setTypeface(typeface, Typeface.BOLD)
             },
         )
@@ -163,7 +155,7 @@ class ScanHistoryActivity : Activity() {
             TextView(this).apply {
                 text = meta
                 textSize = 13f
-                alpha = 0.8f
+                setTextColor(WscanUi.COLOR_MUTED)
                 setPadding(0, dp(4), 0, 0)
             },
         )

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -73,8 +73,8 @@ class ScanMapActivity : Activity() {
         localHeatmapOverlay = findViewById(R.id.local_heatmap_overlay)
 
         setMapStatus(
-            "Google Maps required",
-            "Custom local heatmap rendering is disabled here because Android mapping for this project must remain Google Maps-based until the authoritative docs are updated.",
+            "Loading heatmap",
+            "Loading locally stored GPS-tagged scan data while Google Maps integration remains the authoritative map target.",
         )
     }
 
@@ -82,6 +82,7 @@ class ScanMapActivity : Activity() {
         super.onStart()
         val bindIntent = Intent(this, WatchdogService::class.java)
         isServiceBound = bindService(bindIntent, serviceConnection, 0)
+        loadHeatmap()
     }
 
     override fun onStop() {

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanMapActivity.kt
@@ -73,8 +73,8 @@ class ScanMapActivity : Activity() {
         localHeatmapOverlay = findViewById(R.id.local_heatmap_overlay)
 
         setMapStatus(
-            "Loading heatmap",
-            "Loading locally stored GPS-tagged scan data while Google Maps integration remains the authoritative map target.",
+            "Google Maps required",
+            "Custom local heatmap rendering remains disabled here because Android mapping is locked to Google Maps until the authoritative docs are updated.",
         )
     }
 
@@ -82,7 +82,6 @@ class ScanMapActivity : Activity() {
         super.onStart()
         val bindIntent = Intent(this, WatchdogService::class.java)
         isServiceBound = bindService(bindIntent, serviceConnection, 0)
-        loadHeatmap()
     }
 
     override fun onStop() {

--- a/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
@@ -44,23 +44,25 @@ class ThreatResultsActivity : Activity() {
                 orientation = LinearLayout.VERTICAL
             }
 
-        val exportButton = Button(this).apply {
-            text = "Export JSON"
-            setTextColor(WscanUi.COLOR_TEXT)
-            textSize = 13f
-            typeface = Typeface.DEFAULT_BOLD
-            background = WscanUi.rounded(WscanUi.COLOR_CARD_ALT, dp(14), strokeColor = WscanUi.COLOR_ACCENT)
-            setPadding(dp(12), dp(10), dp(12), dp(10))
-            setOnClickListener { exportJson(this) }
-        }
+        val exportButton =
+            Button(this).apply {
+                text = "Export JSON"
+                setTextColor(WscanUi.COLOR_TEXT)
+                textSize = 13f
+                typeface = Typeface.DEFAULT_BOLD
+                background = WscanUi.rounded(WscanUi.COLOR_CARD_ALT, dp(14), strokeColor = WscanUi.COLOR_ACCENT)
+                setPadding(dp(12), dp(10), dp(12), dp(10))
+                setOnClickListener { exportJson(this) }
+            }
         contentLayout.addView(
             exportButton,
-            LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                dp(52),
-            ).apply {
-                bottomMargin = dp(12)
-            },
+            LinearLayout
+                .LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    dp(52),
+                ).apply {
+                    bottomMargin = dp(12)
+                },
         )
 
         scrollView.addView(contentLayout)

--- a/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors
 class ThreatResultsActivity : Activity() {
     private val executor = Executors.newSingleThreadExecutor()
     private lateinit var contentLayout: LinearLayout
+    private lateinit var exportButton: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,26 +45,7 @@ class ThreatResultsActivity : Activity() {
                 orientation = LinearLayout.VERTICAL
             }
 
-        val exportButton =
-            Button(this).apply {
-                text = "Export JSON"
-                setTextColor(WscanUi.COLOR_TEXT)
-                textSize = 13f
-                typeface = Typeface.DEFAULT_BOLD
-                background = WscanUi.rounded(WscanUi.COLOR_CARD_ALT, dp(14), strokeColor = WscanUi.COLOR_ACCENT)
-                setPadding(dp(12), dp(10), dp(12), dp(10))
-                setOnClickListener { exportJson(this) }
-            }
-        contentLayout.addView(
-            exportButton,
-            LinearLayout
-                .LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    dp(52),
-                ).apply {
-                    bottomMargin = dp(12)
-                },
-        )
+        exportButton = WscanUi.actionButton(contentLayout, "Export JSON") { exportJson() }
 
         scrollView.addView(contentLayout)
         root.addView(
@@ -297,9 +279,9 @@ class ThreatResultsActivity : Activity() {
         }
     }
 
-    private fun exportJson(button: Button) {
-        button.isEnabled = false
-        button.text = "Exporting…"
+    private fun exportJson() {
+        exportButton.isEnabled = false
+        exportButton.text = "Exporting…"
         executor.execute {
             try {
                 val file = ScanDataExporter(applicationContext).export()
@@ -316,16 +298,16 @@ class ThreatResultsActivity : Activity() {
                     intent.putExtra(Intent.EXTRA_STREAM, uri)
                     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     startActivity(Intent.createChooser(intent, "Export scan data"))
-                    button.text = "Export JSON"
-                    button.isEnabled = true
+                    exportButton.text = "Export JSON"
+                    exportButton.isEnabled = true
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Export failed", e)
                 if (isDestroyed) return@execute
                 runOnUiThread {
                     Toast.makeText(this, "Export failed: ${e.message}", Toast.LENGTH_LONG).show()
-                    button.text = "Export JSON"
-                    button.isEnabled = true
+                    exportButton.text = "Export JSON"
+                    exportButton.isEnabled = true
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
@@ -36,35 +36,43 @@ class ThreatResultsActivity : Activity() {
 
         title = "Threat Results"
 
-        val scrollView = ScrollView(this)
+        val root = WscanUi.shell(this)
+        WscanUi.header(root, "Threat Results", "Recent scan sessions with persisted Gemini narratives and local threat context")
+        val scrollView = ScrollView(this).apply { isFillViewport = true }
         contentLayout =
             LinearLayout(this).apply {
                 orientation = LinearLayout.VERTICAL
-                setPadding(dp(20), dp(20), dp(20), dp(20))
             }
 
+        val exportButton = Button(this).apply {
+            text = "Export JSON"
+            setTextColor(WscanUi.COLOR_TEXT)
+            textSize = 13f
+            typeface = Typeface.DEFAULT_BOLD
+            background = WscanUi.rounded(WscanUi.COLOR_CARD_ALT, dp(14), strokeColor = WscanUi.COLOR_ACCENT)
+            setPadding(dp(12), dp(10), dp(12), dp(10))
+            setOnClickListener { exportJson(this) }
+        }
         contentLayout.addView(
-            TextView(this).apply {
-                text = "Threat Results"
-                textSize = 24f
-                setTypeface(typeface, Typeface.BOLD)
+            exportButton,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                dp(52),
+            ).apply {
+                bottomMargin = dp(12)
             },
         )
-        contentLayout.addView(
-            TextView(this).apply {
-                text = "Recent scan sessions with persisted Gemini narratives and local threat context."
-                textSize = 14f
-                setPadding(0, dp(8), 0, dp(16))
-            },
-        )
-
-        val exportButton = Button(this)
-        exportButton.text = "Export JSON"
-        exportButton.setOnClickListener { exportJson(exportButton) }
-        contentLayout.addView(exportButton)
 
         scrollView.addView(contentLayout)
-        setContentView(scrollView)
+        root.addView(
+            scrollView,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                0,
+                1f,
+            ),
+        )
+        setContentView(root)
 
         loadThreatResults()
     }
@@ -106,12 +114,8 @@ class ThreatResultsActivity : Activity() {
 
     private fun renderSummaries(summaries: List<SessionThreatSummary>) {
         if (summaries.isEmpty()) {
-            contentLayout.addView(
-                TextView(this).apply {
-                    text = "No scan sessions found yet."
-                    textSize = 16f
-                },
-            )
+            val card = WscanUi.card(contentLayout)
+            WscanUi.body(card, "No scan sessions found yet.", muted = true)
             return
         }
 
@@ -129,8 +133,8 @@ class ThreatResultsActivity : Activity() {
                     GradientDrawable().apply {
                         shape = GradientDrawable.RECTANGLE
                         cornerRadius = dp(16).toFloat()
-                        setColor(0xFFF6F4EE.toInt())
-                        setStroke(dp(1), 0xFFCCBFA3.toInt())
+                        setColor(WscanUi.COLOR_CARD)
+                        setStroke(dp(1), WscanUi.COLOR_CARD_ALT)
                     }
             }
 
@@ -213,6 +217,7 @@ class ThreatResultsActivity : Activity() {
         TextView(this).apply {
             this.text = text
             textSize = 18f
+            setTextColor(WscanUi.COLOR_TEXT)
             setTypeface(typeface, Typeface.BOLD)
         }
 
@@ -220,6 +225,7 @@ class ThreatResultsActivity : Activity() {
         TextView(this).apply {
             this.text = text
             textSize = 13f
+            setTextColor(WscanUi.COLOR_ACCENT)
             setTypeface(typeface, Typeface.BOLD)
             setPadding(0, dp(12), 0, dp(6))
         }
@@ -228,6 +234,7 @@ class ThreatResultsActivity : Activity() {
         TextView(this).apply {
             this.text = text
             textSize = 14f
+            setTextColor(WscanUi.COLOR_TEXT)
             setLineSpacing(0f, 1.15f)
             setPadding(0, 0, 0, dp(6))
         }
@@ -236,7 +243,7 @@ class ThreatResultsActivity : Activity() {
         TextView(this).apply {
             this.text = text
             textSize = 12f
-            alpha = 0.75f
+            setTextColor(WscanUi.COLOR_MUTED)
             setPadding(0, 0, 0, dp(4))
         }
 
@@ -251,13 +258,14 @@ class ThreatResultsActivity : Activity() {
                 TextView(this).apply {
                     text = label
                     textSize = 12f
+                    setTextColor(WscanUi.COLOR_TEXT)
                     setPadding(dp(10), dp(6), dp(10), dp(6))
                     background =
                         GradientDrawable().apply {
                             shape = GradientDrawable.RECTANGLE
                             cornerRadius = dp(999).toFloat()
-                            setColor(0xFFE3E8D8.toInt())
-                            setStroke(dp(1), 0xFFB6C29A.toInt())
+                            setColor(WscanUi.COLOR_CARD_ALT)
+                            setStroke(dp(1), WscanUi.COLOR_ACCENT)
                         }
                     if (index < labels.lastIndex) {
                         val lp =

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -115,6 +115,8 @@ class WatchdogService : Service() {
     private var latestLocationSample: LocationSample? = null
     private var currentSessionId: Long? = null
     private var lastKismetSendAtMillis: Long = 0L
+
+    @Volatile
     private var degradedMode = false
     private lateinit var database: WscanDatabase
     private lateinit var kismetGpsClient: KismetGpsClient
@@ -133,9 +135,15 @@ class WatchdogService : Service() {
     @Volatile
     var lastDesktopAckSeq: Int = -1
         private set
+
+    @Volatile
     private var helloServerSocket: ServerSocket? = null
+
+    @Volatile
     private var helloClientSocket: Socket? = null
     private var helloServerJob: Job? = null
+
+    @Volatile
     private var lastGeminiAnalysisAtMs: Long = 0L
     private val geminiAnalysisInFlight = AtomicBoolean(false)
     private val engine =

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/WepOpenHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/WepOpenHeuristic.kt
@@ -12,7 +12,7 @@ class WepOpenHeuristic : Heuristic {
             when (security) {
                 SecurityType.OPEN -> 0.4f
                 SecurityType.WEP -> 0.6f
-                SecurityType.WPA -> 0.2f
+                SecurityType.WPA -> 0.3f
                 SecurityType.WPA2, SecurityType.OWE, SecurityType.WPA3 -> return null
             }
         return ThreatSignal(

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/WepOpenHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/WepOpenHeuristicTest.kt
@@ -50,10 +50,10 @@ class WepOpenHeuristicTest {
     }
 
     @Test
-    fun `wpa network returns confidence 0_2`() {
+    fun `wpa network returns confidence 0_3`() {
         val signal: ThreatSignal? = heuristic.evaluate(scanInput("[WPA-PSK-TKIP]"), emptyContext)
         assertNotNull(signal)
-        assertEquals(0.2f, signal!!.confidence)
+        assertEquals(0.3f, signal!!.confidence)
         assertTrue(signal.reasons[0].contains("deprecated"))
     }
 

--- a/desktop/adbPreflight.mjs
+++ b/desktop/adbPreflight.mjs
@@ -132,7 +132,7 @@ export function describeDeviceReadiness(device) {
   };
 }
 
-export const PRELIGHT_CLASSIFICATIONS = {
+export const PREFLIGHT_CLASSIFICATIONS = {
   adbMissing: {
     level: 'adb-missing',
     title: 'ADB unavailable',
@@ -179,28 +179,28 @@ export const PRELIGHT_CLASSIFICATIONS = {
 
 export function classifyPreflight(result) {
   if (result.ok === false) {
-    return result.classification ?? PRELIGHT_CLASSIFICATIONS.adbMissing;
+    return result.classification ?? PREFLIGHT_CLASSIFICATIONS.adbMissing;
   }
 
   const devices = Array.isArray(result.devices) ? result.devices : [];
 
   if (devices.length === 0) {
-    return PRELIGHT_CLASSIFICATIONS.noDevices;
+    return PREFLIGHT_CLASSIFICATIONS.noDevices;
   }
 
   if (devices.some((device) => device.state === 'unauthorized')) {
-    return PRELIGHT_CLASSIFICATIONS.unauthorized;
+    return PREFLIGHT_CLASSIFICATIONS.unauthorized;
   }
 
   if (devices.some((device) => device.state === 'offline')) {
-    return PRELIGHT_CLASSIFICATIONS.offline;
+    return PREFLIGHT_CLASSIFICATIONS.offline;
   }
 
   if (devices.some((device) => device.state === 'device')) {
-    return PRELIGHT_CLASSIFICATIONS.ready;
+    return PREFLIGHT_CLASSIFICATIONS.ready;
   }
 
-  return PRELIGHT_CLASSIFICATIONS.notReady;
+  return PREFLIGHT_CLASSIFICATIONS.notReady;
 }
 
 export function summarizePreflight(versionOutput, devicesOutput) {

--- a/desktop/adbPreflight.mjs
+++ b/desktop/adbPreflight.mjs
@@ -57,7 +57,7 @@ export function parseCompanionPackagePath(output, packageName) {
   return {
     status: 'missing',
     packageName,
-    versionName,
+    versionName: '',
     versionCode: '',
   };
 }

--- a/desktop/adbPreflight.mjs
+++ b/desktop/adbPreflight.mjs
@@ -177,8 +177,6 @@ export const PREFLIGHT_CLASSIFICATIONS = {
   },
 };
 
-export const PRELIGHT_CLASSIFICATIONS = PREFLIGHT_CLASSIFICATIONS;
-
 export function classifyPreflight(result) {
   if (result.ok === false) {
     return result.classification ?? PREFLIGHT_CLASSIFICATIONS.adbMissing;

--- a/desktop/adbPreflight.mjs
+++ b/desktop/adbPreflight.mjs
@@ -57,7 +57,7 @@ export function parseCompanionPackagePath(output, packageName) {
   return {
     status: 'missing',
     packageName,
-    versionName: '',
+    versionName,
     versionCode: '',
   };
 }
@@ -176,6 +176,8 @@ export const PREFLIGHT_CLASSIFICATIONS = {
       'Connected devices are not in a normal ADB session state. Put at least one device into the OS with USB debugging enabled and retry.',
   },
 };
+
+export const PRELIGHT_CLASSIFICATIONS = PREFLIGHT_CLASSIFICATIONS;
 
 export function classifyPreflight(result) {
   if (result.ok === false) {

--- a/desktop/adbPreflight.test.js
+++ b/desktop/adbPreflight.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  PRELIGHT_CLASSIFICATIONS,
+  PREFLIGHT_CLASSIFICATIONS,
   classifyPreflight,
   parseAdbDevices,
   summarizePreflight,
@@ -22,11 +22,11 @@ emulator-5554 device product:sdk_gphone64_x86_64 model:Pixel_8 device:emu64xa tr
 test('classifyPreflight chooses readiness based on device states', () => {
   assert.equal(
     classifyPreflight({ ok: true, devices: [{ state: 'unauthorized' }] }).level,
-    PRELIGHT_CLASSIFICATIONS.unauthorized.level,
+    PREFLIGHT_CLASSIFICATIONS.unauthorized.level,
   );
   assert.equal(
     classifyPreflight({ ok: true, devices: [{ state: 'device' }] }).level,
-    PRELIGHT_CLASSIFICATIONS.ready.level,
+    PREFLIGHT_CLASSIFICATIONS.ready.level,
   );
 });
 
@@ -39,5 +39,5 @@ test('summarizePreflight builds adb version summary and device list', () => {
   assert.equal(summary.ok, true);
   assert.equal(summary.adbVersion, 'Android Debug Bridge version 1.0.41');
   assert.equal(summary.devices[0].serial, 'abc123');
-  assert.equal(summary.classification.level, PRELIGHT_CLASSIFICATIONS.ready.level);
+  assert.equal(summary.classification.level, PREFLIGHT_CLASSIFICATIONS.ready.level);
 });

--- a/desktop/companionServer.mjs
+++ b/desktop/companionServer.mjs
@@ -1,5 +1,5 @@
 import { createServer } from 'node:http';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { WebSocketServer } from 'ws';
 
 const MAX_STALE_MS = 2 * 60 * 1000;
@@ -22,6 +22,28 @@ export function isSequenceMonotonic(deviceId, sequence, sessions) {
 
 function newSession() {
   return { sequence: -1, rateCount: 0, rateWindowStart: Date.now() };
+}
+
+function formatAddress(addressInfo) {
+  if (!addressInfo || typeof addressInfo === 'string') {
+    return addressInfo ?? null;
+  }
+
+  const host = addressInfo.family === 'IPv6'
+    ? `[${addressInfo.address}]`
+    : addressInfo.address;
+  return `${host}:${addressInfo.port}`;
+}
+
+function tokenMatches(candidate, expected) {
+  if (typeof candidate !== 'string' || typeof expected !== 'string') {
+    return false;
+  }
+
+  const candidateBuffer = Buffer.from(candidate);
+  const expectedBuffer = Buffer.from(expected);
+  return candidateBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(candidateBuffer, expectedBuffer);
 }
 
 export class CompanionServer {
@@ -48,7 +70,7 @@ export class CompanionServer {
   }
 
   get address() {
-    return this.#httpServer?.address() ?? null;
+    return formatAddress(this.#httpServer?.address() ?? null);
   }
 
   start(port = 0, host = '127.0.0.1') {
@@ -94,8 +116,7 @@ export class CompanionServer {
         if (
           msg.type !== 'auth' ||
           !this.#token ||
-          typeof msg.token !== 'string' ||
-          msg.token !== this.#token
+          !tokenMatches(msg.token, this.#token)
         ) {
           ws.close(1008, 'Authentication failed');
           return;

--- a/desktop/companionServer.test.js
+++ b/desktop/companionServer.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { WebSocket } from 'ws';
 import {
   CompanionServer,
   isSequenceMonotonic,
@@ -28,4 +29,67 @@ test('CompanionServer generates a pairing token', () => {
 
   assert.match(token, /^[a-f0-9]{32}$/);
   assert.equal(server.token, token);
+});
+
+test('CompanionServer.address returns null before start and a formatted host:port string after start', async () => {
+  const server = new CompanionServer();
+  assert.equal(server.address, null);
+
+  await server.start();
+  try {
+    assert.match(server.address, /^127\.0\.0\.1:\d+$/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test('CompanionServer authenticates successfully with a valid token', async () => {
+  const server = new CompanionServer();
+  const token = server.generateToken();
+  const address = await server.start();
+  try {
+    const response = await new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://${address}`);
+      ws.once('open', () => ws.send(JSON.stringify({ type: 'auth', token })));
+      ws.once('message', (data) => { ws.close(); resolve(JSON.parse(data.toString())); });
+      ws.once('error', reject);
+    });
+    assert.equal(response.type, 'auth_ok');
+  } finally {
+    await server.stop();
+  }
+});
+
+test('CompanionServer closes connection on invalid token', async () => {
+  const server = new CompanionServer();
+  server.generateToken();
+  const address = await server.start();
+  try {
+    const closeCode = await new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://${address}`);
+      ws.once('open', () => ws.send(JSON.stringify({ type: 'auth', token: 'not-the-right-token' })));
+      ws.once('close', (code) => resolve(code));
+      ws.once('error', reject);
+    });
+    assert.equal(closeCode, 1008);
+  } finally {
+    await server.stop();
+  }
+});
+
+test('CompanionServer closes connection on mismatched-length token', async () => {
+  const server = new CompanionServer();
+  server.generateToken();
+  const address = await server.start();
+  try {
+    const closeCode = await new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://${address}`);
+      ws.once('open', () => ws.send(JSON.stringify({ type: 'auth', token: 'short' })));
+      ws.once('close', (code) => resolve(code));
+      ws.once('error', reject);
+    });
+    assert.equal(closeCode, 1008);
+  } finally {
+    await server.stop();
+  }
 });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { AdbTransport } from './adb/AdbTransport.js';
 import {
-  PRELIGHT_CLASSIFICATIONS,
+  PREFLIGHT_CLASSIFICATIONS,
   describeDeviceReadiness,
   parseCompanionPackagePath,
   parseCompanionVersionInfo,
@@ -316,8 +316,8 @@ ipcMain.handle('adb:preflight', async () => {
     return {
       ...failure,
       classification: isAdbMissing
-        ? PRELIGHT_CLASSIFICATIONS.adbMissing
-        : PRELIGHT_CLASSIFICATIONS.preflightFailed,
+        ? PREFLIGHT_CLASSIFICATIONS.adbMissing
+        : PREFLIGHT_CLASSIFICATIONS.preflightFailed,
     };
   }
 });

--- a/desktop/pairing.js
+++ b/desktop/pairing.js
@@ -26,9 +26,20 @@ function logPairingEvent(level, message) {
   }
 }
 
+function asWebSocketUrl(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value.startsWith('ws://') || value.startsWith('wss://')
+    ? value
+    : `ws://${value}`;
+}
+
 function formatAddress(result) {
-  if (typeof result?.endpoint === 'string') return result.endpoint;
-  if (typeof result?.url === 'string') return result.url;
+  const endpoint = asWebSocketUrl(result?.endpoint ?? result?.url);
+  if (endpoint) return endpoint;
+
+  const addressString = asWebSocketUrl(result?.address);
+  if (addressString) return addressString;
+
   if (result?.address?.address && result?.address?.port) {
     return `ws://${result.address.address}:${result.address.port}`;
   }

--- a/desktop/renderer.mjs
+++ b/desktop/renderer.mjs
@@ -85,27 +85,85 @@ function setAps(payload) {
   render();
 }
 
-function addRisk(input) {
-  if (!input || typeof input !== 'object') return;
+function normalizeRiskEntry(input) {
+  if (!input || typeof input !== 'object') return null;
   const bssid = normalizeBssid(input.bssid ?? input.BSSID ?? input.mac);
   const severity = normalizeRisk(input.severity ?? input.risk ?? input.level ?? 'watch');
   const confidenceRaw = Number(input.confidence ?? 0);
   const confidence = Number.isFinite(confidenceRaw) ? Math.max(0, Math.min(100, confidenceRaw <= 1 ? confidenceRaw * 100 : confidenceRaw)) : 0;
-  const risk = {
-    id: String(input.id ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`),
+  const reason = String(input.reason ?? input.message ?? (Array.isArray(input.reasons) ? input.reasons.join('; ') : 'Detector event'));
+  const timestamp = normalizeTimestamp(input.timestamp ?? input.ts ?? Date.now());
+
+  return {
+    id: String(input.id ?? `${bssid || 'risk'}:${severity}:${reason}`),
     bssid,
     ssid: String(input.ssid ?? ''),
     severity,
     confidence,
-    reason: String(input.reason ?? input.message ?? (Array.isArray(input.reasons) ? input.reasons.join('; ') : 'Detector event')),
-    timestamp: normalizeTimestamp(input.timestamp ?? input.ts ?? Date.now()),
+    reason,
+    timestamp,
     status: String(input.status ?? 'open'),
   };
-  state.risks.unshift(risk);
-  state.risks = state.risks.slice(0, 80);
-  const ap = state.aps.get(bssid);
-  if (ap && (severityRank[severity] ?? 0) > (severityRank[ap.risk] ?? 0)) state.aps.set(bssid, { ...ap, risk: severity });
-  addEvent({ level: severity === 'high' ? 'HIGH' : severity === 'watch' ? 'WATCH' : 'INFO', source: 'detector', message: `${risk.reason}${bssid ? ` (${bssid})` : ''}` }, false);
+}
+
+function riskKey(risk) {
+  return `${risk.bssid}:${risk.severity}`;
+}
+
+function applyRiskToAp(risk) {
+  const ap = state.aps.get(risk.bssid);
+  if (ap && (severityRank[risk.severity] ?? 0) > (severityRank[ap.risk] ?? 0)) {
+    state.aps.set(risk.bssid, { ...ap, risk: risk.severity });
+  }
+}
+
+function emitRiskEvent(risk) {
+  addEvent({
+    level: risk.severity === 'high' ? 'HIGH' : risk.severity === 'watch' ? 'WATCH' : 'INFO',
+    source: 'detector',
+    message: `${risk.reason}${risk.bssid ? ` (${risk.bssid})` : ''}`,
+  }, false);
+}
+
+function addRisk(input, rerender = true) {
+  const risk = normalizeRiskEntry(input);
+  if (!risk) return;
+  const key = riskKey(risk);
+  const existingIndex = state.risks.findIndex((item) => riskKey(item) === key);
+  const isNew = existingIndex === -1;
+  if (isNew) {
+    state.risks.unshift(risk);
+  } else {
+    state.risks[existingIndex] = risk;
+  }
+  state.risks = state.risks
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, 80);
+  applyRiskToAp(risk);
+  if (isNew) emitRiskEvent(risk);
+  if (rerender) render();
+}
+
+function setRiskSnapshot(payload) {
+  const list = Array.isArray(payload) ? payload : Array.isArray(payload?.risks) ? payload.risks : Array.isArray(payload?.events) ? payload.events : payload ? [payload] : [];
+  const existingKeys = new Set(state.risks.map(riskKey));
+  const nextRisks = new Map();
+
+  for (const input of list) {
+    const risk = normalizeRiskEntry(input);
+    if (!risk) continue;
+    nextRisks.set(riskKey(risk), risk);
+  }
+
+  state.risks = [...nextRisks.values()]
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, 80);
+
+  for (const risk of state.risks) {
+    applyRiskToAp(risk);
+    if (!existingKeys.has(riskKey(risk))) emitRiskEvent(risk);
+  }
+
   render();
 }
 
@@ -419,10 +477,7 @@ function wireControls() {
 
 function wireSubscriptions() {
   subscribe('onAps', setAps);
-  subscribe('onRiskLog', (payload) => {
-    const risks = Array.isArray(payload) ? payload : Array.isArray(payload?.risks) ? payload.risks : Array.isArray(payload?.events) ? payload.events : [payload];
-    for (const risk of risks) addRisk(risk);
-  });
+  subscribe('onRiskLog', setRiskSnapshot);
   subscribe('onScanState', (payload) => { if (payload && typeof payload === 'object') { state.scanState = { ...state.scanState, ...payload }; render(); } });
   subscribe('onCompanionUpdate', (payload) => { if (payload && typeof payload === 'object') { state.companion = { ...state.companion, ...payload }; addEvent({ level: 'INFO', source: 'companion', message: `update from ${payload.deviceId ?? 'device'}` }, false); render(); } });
   subscribe('onAppError', (payload) => addEvent({ level: 'ERROR', source: 'app', message: payload?.message ?? payload }));

--- a/desktop/scanner.mjs
+++ b/desktop/scanner.mjs
@@ -161,19 +161,25 @@ export function freqToChannel(freqMHz) {
 }
 
 let activeScanPromise = null;
+let activeScanGeneration = null;
+let activeScanRequiresActive = false;
 let scanLoopTimer = null;
 let scanGeneration = 0;
 
-async function runScanAndProcess(generation) {
+async function runScanAndProcess({ generation, requireActive }) {
   const iface = store.state.interface;
   if (!iface) {
     throw new ScanError('No wireless interface configured');
   }
 
+  if (requireActive && (!store.state.scanning || generation !== scanGeneration)) {
+    return [];
+  }
+
   const raw = await runCommand('iw', ['dev', iface, 'scan']);
   const aps = parseScanOutput(raw);
 
-  if (!store.state.scanning || generation !== scanGeneration) {
+  if (requireActive && (!store.state.scanning || generation !== scanGeneration)) {
     return [];
   }
 
@@ -190,11 +196,22 @@ async function runScanAndProcess(generation) {
   return aps;
 }
 
-export async function executeScanCycle() {
-  if (!activeScanPromise) {
-    const generation = scanGeneration;
-    activeScanPromise = runScanAndProcess(generation).finally(() => {
-      activeScanPromise = null;
+export async function executeScanCycle({ requireActive = false } = {}) {
+  const generation = scanGeneration;
+  const canReuseActiveScan =
+    activeScanPromise &&
+    activeScanGeneration === generation &&
+    activeScanRequiresActive === requireActive;
+
+  if (!canReuseActiveScan) {
+    activeScanGeneration = generation;
+    activeScanRequiresActive = requireActive;
+    activeScanPromise = runScanAndProcess({ generation, requireActive }).finally(() => {
+      if (activeScanGeneration === generation && activeScanRequiresActive === requireActive) {
+        activeScanPromise = null;
+        activeScanGeneration = null;
+        activeScanRequiresActive = false;
+      }
     });
   }
   return activeScanPromise;
@@ -211,7 +228,7 @@ function scheduleNextScan() {
 async function scanLoop() {
   if (!store.state.scanning) return;
   try {
-    await executeScanCycle();
+    await executeScanCycle({ requireActive: true });
   } catch (err) {
     store.addError(err);
   } finally {

--- a/desktop/scanner.mjs
+++ b/desktop/scanner.mjs
@@ -216,8 +216,7 @@ export async function executeScanCycle({ requireActive = false } = {}) {
   const generation = scanGeneration;
   const canReuseActiveScan =
     activeScanPromise &&
-    activeScanGeneration === generation &&
-    activeScanRequiresActive === requireActive;
+    activeScanGeneration === generation;
 
   if (!canReuseActiveScan) {
     activeScanGeneration = generation;

--- a/desktop/scanner.mjs
+++ b/desktop/scanner.mjs
@@ -69,6 +69,12 @@ export function runCommand(
   });
 }
 
+let commandRunner = runCommand;
+
+export function setCommandRunnerForTests(runner) {
+  commandRunner = typeof runner === 'function' ? runner : runCommand;
+}
+
 export function parseIwDevOutput(raw) {
   const ifaces = [];
   for (const line of raw.split('\n')) {
@@ -166,6 +172,16 @@ let activeScanRequiresActive = false;
 let scanLoopTimer = null;
 let scanGeneration = 0;
 
+export function resetScannerForTests() {
+  commandRunner = runCommand;
+  activeScanPromise = null;
+  activeScanGeneration = null;
+  activeScanRequiresActive = false;
+  clearTimeout(scanLoopTimer);
+  scanLoopTimer = null;
+  scanGeneration = 0;
+}
+
 async function runScanAndProcess({ generation, requireActive }) {
   const iface = store.state.interface;
   if (!iface) {
@@ -176,7 +192,7 @@ async function runScanAndProcess({ generation, requireActive }) {
     return [];
   }
 
-  const raw = await runCommand('iw', ['dev', iface, 'scan']);
+  const raw = await commandRunner('iw', ['dev', iface, 'scan']);
   const aps = parseScanOutput(raw);
 
   if (requireActive && (!store.state.scanning || generation !== scanGeneration)) {
@@ -239,7 +255,7 @@ async function scanLoop() {
 }
 
 export async function detectInterfaces() {
-  const raw = await runCommand('iw', ['dev']);
+  const raw = await commandRunner('iw', ['dev']);
   return parseIwDevOutput(raw);
 }
 

--- a/desktop/scanner.mjs
+++ b/desktop/scanner.mjs
@@ -162,8 +162,9 @@ export function freqToChannel(freqMHz) {
 
 let activeScanPromise = null;
 let scanLoopTimer = null;
+let scanGeneration = 0;
 
-async function runScanAndProcess() {
+async function runScanAndProcess(generation) {
   const iface = store.state.interface;
   if (!iface) {
     throw new ScanError('No wireless interface configured');
@@ -171,6 +172,10 @@ async function runScanAndProcess() {
 
   const raw = await runCommand('iw', ['dev', iface, 'scan']);
   const aps = parseScanOutput(raw);
+
+  if (!store.state.scanning || generation !== scanGeneration) {
+    return [];
+  }
 
   if (aps.length > 0) {
     store.addAps(aps);
@@ -187,7 +192,8 @@ async function runScanAndProcess() {
 
 export async function executeScanCycle() {
   if (!activeScanPromise) {
-    activeScanPromise = runScanAndProcess().finally(() => {
+    const generation = scanGeneration;
+    activeScanPromise = runScanAndProcess(generation).finally(() => {
       activeScanPromise = null;
     });
   }
@@ -232,11 +238,13 @@ export async function startScanning(iface) {
     resolvedIface = ifaces[0];
   }
 
+  scanGeneration += 1;
   store.update({ scanning: true, interface: resolvedIface });
   void scanLoop();
 }
 
 export function stopScanning() {
+  scanGeneration += 1;
   store.update({ scanning: false });
   clearTimeout(scanLoopTimer);
   scanLoopTimer = null;

--- a/desktop/scanner.test.js
+++ b/desktop/scanner.test.js
@@ -1,6 +1,36 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { freqToChannel, parseIwDevOutput, parseScanOutput } from './scanner.mjs';
+import {
+  executeScanCycle,
+  freqToChannel,
+  parseIwDevOutput,
+  parseScanOutput,
+  resetScannerForTests,
+  setCommandRunnerForTests,
+  startScanning,
+  stopScanning,
+} from './scanner.mjs';
+import { store } from './store.mjs';
+
+const SCAN_OUTPUT = `
+BSS aa:bb:cc:dd:ee:ff(on wlan0)
+	freq: 2412
+	signal: -42.00 dBm
+	SSID: testnet
+	RSN:
+`;
+
+function resetStore() {
+  store.update({ scanning: false, interface: null, scanIntervalMs: 30_000 });
+  store.state.aps.clear();
+  store.state.riskLog = [];
+  store.state.errors = [];
+}
+
+test.afterEach(() => {
+  resetScannerForTests();
+  resetStore();
+});
 
 test('parseIwDevOutput extracts interface names', () => {
   const raw = `
@@ -49,4 +79,57 @@ test('freqToChannel maps common Wi-Fi frequencies', () => {
   assert.equal(freqToChannel(5180), 36);
   assert.equal(freqToChannel(5955), 1);
   assert.equal(freqToChannel(1234), 0);
+});
+
+test('manual scan can mutate store while continuous scanning is stopped', async () => {
+  resetStore();
+  store.update({ scanning: false, interface: 'wlan0' });
+  setCommandRunnerForTests(async () => SCAN_OUTPUT);
+
+  const aps = await executeScanCycle();
+
+  assert.equal(aps.length, 1);
+  assert.equal(store.state.aps.size, 1);
+  assert.equal(store.state.aps.get('aa:bb:cc:dd:ee:ff')?.ssid, 'testnet');
+});
+
+test('active scan discards stale results after stop before store mutation', async () => {
+  resetStore();
+  let resolveScan;
+  const scanPromise = new Promise((resolve) => {
+    resolveScan = resolve;
+  });
+  setCommandRunnerForTests(async () => scanPromise);
+  await startScanning('wlan0');
+
+  stopScanning();
+  resolveScan(SCAN_OUTPUT);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(store.state.scanning, false);
+  assert.equal(store.state.aps.size, 0);
+});
+
+test('restart starts a fresh scan instead of waiting on stale in-flight promise', async () => {
+  resetStore();
+  let firstResolve;
+  let callCount = 0;
+  setCommandRunnerForTests(async () => {
+    callCount += 1;
+    if (callCount === 1) {
+      return new Promise((resolve) => {
+        firstResolve = resolve;
+      });
+    }
+    return SCAN_OUTPUT;
+  });
+
+  await startScanning('wlan0');
+  stopScanning();
+  await startScanning('wlan0');
+  firstResolve(SCAN_OUTPUT);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(callCount, 2);
+  assert.equal(store.state.aps.size, 1);
 });

--- a/desktop/scanner.test.js
+++ b/desktop/scanner.test.js
@@ -115,6 +115,20 @@ test('active scan discards stale results after stop before store mutation', asyn
   assert.equal(store.state.aps.size, 0);
 });
 
+test('manual scan during active continuous scan reuses the in-flight promise', async () => {
+  resetStore();
+  let callCount = 0;
+  setCommandRunnerForTests(async () => {
+    callCount += 1;
+    return SCAN_OUTPUT;
+  });
+
+  await startScanning('wlan0');
+  await executeScanCycle();
+
+  assert.equal(callCount, 1);
+});
+
 test('restart starts a fresh scan instead of waiting on stale in-flight promise', async () => {
   resetStore();
   let firstResolve;

--- a/desktop/scanner.test.js
+++ b/desktop/scanner.test.js
@@ -20,6 +20,11 @@ BSS aa:bb:cc:dd:ee:ff(on wlan0)
 	RSN:
 `;
 
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 function resetStore() {
   store.update({ scanning: false, interface: null, scanIntervalMs: 30_000 });
   store.state.aps.clear();
@@ -104,7 +109,7 @@ test('active scan discards stale results after stop before store mutation', asyn
 
   stopScanning();
   resolveScan(SCAN_OUTPUT);
-  await new Promise((resolve) => setImmediate(resolve));
+  await flushMicrotasks();
 
   assert.equal(store.state.scanning, false);
   assert.equal(store.state.aps.size, 0);
@@ -128,7 +133,7 @@ test('restart starts a fresh scan instead of waiting on stale in-flight promise'
   stopScanning();
   await startScanning('wlan0');
   firstResolve(SCAN_OUTPUT);
-  await new Promise((resolve) => setImmediate(resolve));
+  await flushMicrotasks();
 
   assert.equal(callCount, 2);
   assert.equal(store.state.aps.size, 1);

--- a/docs/HANDOFF_CODE_REVIEW_FIXES.md
+++ b/docs/HANDOFF_CODE_REVIEW_FIXES.md
@@ -16,6 +16,7 @@
 - Fixed `desktop/renderer.mjs` risk-log handling so emitted snapshots replace/dedupe local risk state and render once, instead of appending every snapshot entry repeatedly.
 - Raised WPA heuristic confidence from `0.2f` to `0.3f` so the WPA warning path can actually pass the default `PolicyGate` floor.
 - Wired `ScanMapActivity.loadHeatmap()` from `onStart()` instead of marking implemented code unused.
+- Refactored `ScanHistoryActivity` and `ThreatResultsActivity` onto the shared `WscanUi.shell()` / `WscanUi.header()` path so they inherit the same window preparation and system-inset handling as `DiagnosticActivity`.
 
 ---
 
@@ -48,7 +49,6 @@ If WPA should be a low-priority warning, it must meet the current `PolicyGate` f
   - `helloServerSocket`
   - `helloClientSocket`
   - `lastGeminiAnalysisAtMs`
-- Refactor `ScanHistoryActivity` and `ThreatResultsActivity` to use `WscanUi.shell()`, `WscanUi.header()`, `WscanUi.prepareWindow()`, and `WscanUi.applySystemInsets()` following the `DiagnosticActivity` pattern.
 - Run required checks:
   - `cd desktop && npm test && npm run lint`
   - `cd android && ./gradlew :core:test :app:ktlintCheck :core:ktlintCheck`

--- a/docs/HANDOFF_CODE_REVIEW_FIXES.md
+++ b/docs/HANDOFF_CODE_REVIEW_FIXES.md
@@ -1,0 +1,66 @@
+# Handoff: wscan+ Code Review Fixes
+
+**Repo:** `dvntone/wscanplus`
+**Branch:** `copilot/fix-review-app-code-inconsistencies`
+**Date:** 2026-05-02
+**Prepared by:** ChatGPT code review session
+
+---
+
+## Completed in this branch
+
+- Fixed the misspelled `PRELIGHT_CLASSIFICATIONS` source constant by introducing `PREFLIGHT_CLASSIFICATIONS` in `desktop/adbPreflight.mjs`.
+- Added a temporary compatibility export for the old spelling so existing import sites remain functional until dependent files are safely updated.
+- Added a scan-generation guard in `desktop/scanner.mjs` that discards in-flight scan results **before** store mutation after `stopScanning()`.
+- Hardened `desktop/companionServer.mjs` token auth with length-checked `crypto.timingSafeEqual()`.
+- Formatted `CompanionServer.address` as a displayable string instead of returning raw `AddressInfo` objects.
+- Raised WPA heuristic confidence from `0.2f` to `0.3f` so the WPA warning path can actually pass the default `PolicyGate` floor.
+- Wired `ScanMapActivity.loadHeatmap()` from `onStart()` instead of marking implemented code unused.
+
+---
+
+## Additional review findings appended
+
+These findings were confirmed during independent review and must not be bypassed with suppressions or compatibility shims.
+
+### R-1 · Scanner stop race must be fixed before store mutation
+
+A generation check in `.finally()` is too late because `runScanAndProcess()` mutates `store.addAps()` / `store.addRiskEntries()` before the promise finalizer. The fix in this branch checks `store.state.scanning` and the generation value immediately after parsing scan output and before any store write.
+
+### R-2 · Risk-log renderer path likely duplicates snapshot entries
+
+`store.addRiskEntries()` emits the full `riskLog` snapshot. The renderer currently loops through that snapshot and appends each item through `addRisk()`, which can duplicate existing risk rows and trigger repeated renders. Proper fix: treat the payload as a snapshot, normalize/dedupe into `state.risks`, update AP risk state, emit any new event rows deliberately, and call `render()` once.
+
+### R-3 · `loadHeatmap()` must not be suppressed as unused
+
+The heatmap implementation is functional and backed by stored GPS-tagged scan rows. The proper fix is wiring it into lifecycle. This branch wires it from `onStart()`.
+
+### R-4 · WPA confidence mismatch is a product behavior bug, not only dead code
+
+If WPA should be a low-priority warning, it must meet the current `PolicyGate` floor. This branch raises WPA confidence to `0.3f` rather than adding a comment that hides the unreachable path.
+
+### R-5 · Temporary preflight compatibility alias must be removed in final cleanup
+
+The branch currently keeps `PRELIGHT_CLASSIFICATIONS` as an alias to avoid breaking imports while connector-only edits are limited. Final cleanup should update `desktop/main.js` and `desktop/adbPreflight.test.js` to import/use `PREFLIGHT_CLASSIFICATIONS`, then remove the alias.
+
+---
+
+## Remaining required fixes before ready-for-review
+
+- Update `desktop/main.js` and `desktop/adbPreflight.test.js` to use `PREFLIGHT_CLASSIFICATIONS`; remove the compatibility alias from `desktop/adbPreflight.mjs`.
+- Fix `desktop/renderer.mjs` risk-log snapshot handling without appending duplicates and without N full renders.
+- Add `@Volatile` to `WatchdogService.kt` fields crossing main/executor/IO threads:
+  - `degradedMode`
+  - `helloServerSocket`
+  - `helloClientSocket`
+  - `lastGeminiAnalysisAtMs`
+- Refactor `ScanHistoryActivity` and `ThreatResultsActivity` to use `WscanUi.shell()`, `WscanUi.header()`, `WscanUi.prepareWindow()`, and `WscanUi.applySystemInsets()` following the `DiagnosticActivity` pattern.
+- Run required checks:
+  - `cd desktop && npm test && npm run lint`
+  - `cd android && ./gradlew :core:test :app:ktlintCheck :core:ktlintCheck`
+
+---
+
+## No-bypass rule
+
+Do not mark this PR ready by adding `@Suppress("unused")`, retaining compatibility aliases as final fixes, weakening tests, skipping CI, or documenting unreachable code without a product decision. Every item above needs a real implementation fix.

--- a/docs/HANDOFF_CODE_REVIEW_FIXES.md
+++ b/docs/HANDOFF_CODE_REVIEW_FIXES.md
@@ -9,11 +9,11 @@
 
 ## Completed in this branch
 
-- Fixed the misspelled `PRELIGHT_CLASSIFICATIONS` source constant by introducing `PREFLIGHT_CLASSIFICATIONS` in `desktop/adbPreflight.mjs`.
-- Added a temporary compatibility export for the old spelling so existing import sites remain functional until dependent files are safely updated.
+- Renamed the misspelled `PRELIGHT_CLASSIFICATIONS` constant to `PREFLIGHT_CLASSIFICATIONS` across source, main-process imports, and tests. No compatibility alias remains.
 - Added a scan-generation guard in `desktop/scanner.mjs` that discards in-flight scan results **before** store mutation after `stopScanning()`.
 - Hardened `desktop/companionServer.mjs` token auth with length-checked `crypto.timingSafeEqual()`.
 - Formatted `CompanionServer.address` as a displayable string instead of returning raw `AddressInfo` objects.
+- Fixed `desktop/renderer.mjs` risk-log handling so emitted snapshots replace/dedupe local risk state and render once, instead of appending every snapshot entry repeatedly.
 - Raised WPA heuristic confidence from `0.2f` to `0.3f` so the WPA warning path can actually pass the default `PolicyGate` floor.
 - Wired `ScanMapActivity.loadHeatmap()` from `onStart()` instead of marking implemented code unused.
 
@@ -27,9 +27,9 @@ These findings were confirmed during independent review and must not be bypassed
 
 A generation check in `.finally()` is too late because `runScanAndProcess()` mutates `store.addAps()` / `store.addRiskEntries()` before the promise finalizer. The fix in this branch checks `store.state.scanning` and the generation value immediately after parsing scan output and before any store write.
 
-### R-2 · Risk-log renderer path likely duplicates snapshot entries
+### R-2 · Risk-log renderer path duplicated snapshot entries
 
-`store.addRiskEntries()` emits the full `riskLog` snapshot. The renderer currently loops through that snapshot and appends each item through `addRisk()`, which can duplicate existing risk rows and trigger repeated renders. Proper fix: treat the payload as a snapshot, normalize/dedupe into `state.risks`, update AP risk state, emit any new event rows deliberately, and call `render()` once.
+`store.addRiskEntries()` emits the full `riskLog` snapshot. The renderer previously looped through that snapshot and appended each item through `addRisk()`, duplicating existing risk rows and triggering repeated renders. This branch now treats the payload as a snapshot, normalizes/dedupes into `state.risks`, updates AP risk state, emits new detector events deliberately, and calls `render()` once.
 
 ### R-3 · `loadHeatmap()` must not be suppressed as unused
 
@@ -39,16 +39,10 @@ The heatmap implementation is functional and backed by stored GPS-tagged scan ro
 
 If WPA should be a low-priority warning, it must meet the current `PolicyGate` floor. This branch raises WPA confidence to `0.3f` rather than adding a comment that hides the unreachable path.
 
-### R-5 · Temporary preflight compatibility alias must be removed in final cleanup
-
-The branch currently keeps `PRELIGHT_CLASSIFICATIONS` as an alias to avoid breaking imports while connector-only edits are limited. Final cleanup should update `desktop/main.js` and `desktop/adbPreflight.test.js` to import/use `PREFLIGHT_CLASSIFICATIONS`, then remove the alias.
-
 ---
 
 ## Remaining required fixes before ready-for-review
 
-- Update `desktop/main.js` and `desktop/adbPreflight.test.js` to use `PREFLIGHT_CLASSIFICATIONS`; remove the compatibility alias from `desktop/adbPreflight.mjs`.
-- Fix `desktop/renderer.mjs` risk-log snapshot handling without appending duplicates and without N full renders.
 - Add `@Volatile` to `WatchdogService.kt` fields crossing main/executor/IO threads:
   - `degradedMode`
   - `helloServerSocket`
@@ -63,4 +57,4 @@ The branch currently keeps `PRELIGHT_CLASSIFICATIONS` as an alias to avoid break
 
 ## No-bypass rule
 
-Do not mark this PR ready by adding `@Suppress("unused")`, retaining compatibility aliases as final fixes, weakening tests, skipping CI, or documenting unreachable code without a product decision. Every item above needs a real implementation fix.
+Do not mark this PR ready by adding `@Suppress("unused")`, weakening tests, skipping CI, or documenting unreachable code without a product decision. Every item above needs a real implementation fix.

--- a/docs/HANDOFF_CODE_REVIEW_FIXES.md
+++ b/docs/HANDOFF_CODE_REVIEW_FIXES.md
@@ -44,11 +44,6 @@ If WPA should be a low-priority warning, it must meet the current `PolicyGate` f
 
 ## Remaining required fixes before ready-for-review
 
-- Add `@Volatile` to `WatchdogService.kt` fields crossing main/executor/IO threads:
-  - `degradedMode`
-  - `helloServerSocket`
-  - `helloClientSocket`
-  - `lastGeminiAnalysisAtMs`
 - Run required checks:
   - `cd desktop && npm test && npm run lint`
   - `cd android && ./gradlew :core:test :app:ktlintCheck :core:ktlintCheck`

--- a/docs/HANDOFF_CODE_REVIEW_FIXES.md
+++ b/docs/HANDOFF_CODE_REVIEW_FIXES.md
@@ -3,19 +3,19 @@
 **Repo:** `dvntone/wscanplus`
 **Branch:** `copilot/fix-review-app-code-inconsistencies`
 **Date:** 2026-05-02
-**Prepared by:** ChatGPT code review session
+**Traceability:** PR #280 / issue #279 review-fix handoff for Claude/Copilot continuation
 
 ---
 
 ## Completed in this branch
 
 - Renamed the misspelled `PRELIGHT_CLASSIFICATIONS` constant to `PREFLIGHT_CLASSIFICATIONS` across source, main-process imports, and tests. No compatibility alias remains.
-- Added a scan-generation guard in `desktop/scanner.mjs` that discards in-flight scan results **before** store mutation after `stopScanning()`.
+- Added a scan-generation guard in `desktop/scanner.mjs` that discards stale continuous-loop scan results **before** store mutation after `stopScanning()`, while keeping manual idle scans functional.
 - Hardened `desktop/companionServer.mjs` token auth with length-checked `crypto.timingSafeEqual()`.
-- Formatted `CompanionServer.address` as a displayable string instead of returning raw `AddressInfo` objects.
+- Formatted `CompanionServer.address` as a displayable string and updated the pairing UI to accept formatted address strings.
 - Fixed `desktop/renderer.mjs` risk-log handling so emitted snapshots replace/dedupe local risk state and render once, instead of appending every snapshot entry repeatedly.
-- Raised WPA heuristic confidence from `0.2f` to `0.3f` so the WPA warning path can actually pass the default `PolicyGate` floor.
-- Wired `ScanMapActivity.loadHeatmap()` from `onStart()` instead of marking implemented code unused.
+- Raised WPA heuristic confidence from `0.2f` to `0.3f` so the WPA warning path can actually pass the default `PolicyGate` floor. The matching unit test already expects `0.3f` on this branch.
+- Preserved the locked Android mapping decision: `ScanMapActivity` continues to show the Google Maps-required status instead of re-enabling the custom `LocalHeatmapView` path without a product-doc update.
 - Refactored `ScanHistoryActivity` and `ThreatResultsActivity` onto the shared `WscanUi.shell()` / `WscanUi.header()` path so they inherit the same window preparation and system-inset handling as `DiagnosticActivity`.
 
 ---
@@ -26,15 +26,15 @@ These findings were confirmed during independent review and must not be bypassed
 
 ### R-1 · Scanner stop race must be fixed before store mutation
 
-A generation check in `.finally()` is too late because `runScanAndProcess()` mutates `store.addAps()` / `store.addRiskEntries()` before the promise finalizer. The fix in this branch checks `store.state.scanning` and the generation value immediately after parsing scan output and before any store write.
+A generation check in `.finally()` is too late because `runScanAndProcess()` mutates `store.addAps()` / `store.addRiskEntries()` before the promise finalizer. The fix in this branch checks the scan generation immediately after parsing scan output and before any continuous-loop store write. Manual scans do not require `store.state.scanning`, so the idle-state “Scan Now” path remains usable.
 
 ### R-2 · Risk-log renderer path duplicated snapshot entries
 
 `store.addRiskEntries()` emits the full `riskLog` snapshot. The renderer previously looped through that snapshot and appended each item through `addRisk()`, duplicating existing risk rows and triggering repeated renders. This branch now treats the payload as a snapshot, normalizes/dedupes into `state.risks`, updates AP risk state, emits new detector events deliberately, and calls `render()` once.
 
-### R-3 · `loadHeatmap()` must not be suppressed as unused
+### R-3 · `loadHeatmap()` must not be suppressed or re-enabled against locked docs
 
-The heatmap implementation is functional and backed by stored GPS-tagged scan rows. The proper fix is wiring it into lifecycle. This branch wires it from `onStart()`.
+The local heatmap implementation exists, but Android mapping is currently locked to Google Maps in the authoritative docs. The correct fix for this PR is to keep the custom local heatmap path disabled unless a separate product decision updates the mapping docs.
 
 ### R-4 · WPA confidence mismatch is a product behavior bug, not only dead code
 

--- a/docs/HANDOFF_CODE_REVIEW_FIXES.md
+++ b/docs/HANDOFF_CODE_REVIEW_FIXES.md
@@ -46,7 +46,7 @@ If WPA should be a low-priority warning, it must meet the current `PolicyGate` f
 
 - Run required checks:
   - `cd desktop && npm test && npm run lint`
-  - `cd android && ./gradlew :core:test :app:ktlintCheck :core:ktlintCheck`
+  - `cd android && ./gradlew :core:test :app:assembleDebug :app:ktlintCheck :core:ktlintCheck`
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,7 @@
 
 ## Current State
 - docs/SESSION_STATE.md — architecture decisions, locked choices, current phase + next steps
+- docs/HANDOFF_CODE_REVIEW_FIXES.md — active PR #280 code-review fix handoff, remaining blockers, and no-bypass guidance
 - docs/PRODUCT_SPEC.md — product architecture, evidence/output model, language rules, and capability status labels
 - docs/architecture/android-spatial-baseline-implementation-plan.md — Android-first local spatial baseline MVP implementation handoff
 - [docs/SESSION_STATE.md#2026-03-20-handoff-snapshot](docs/SESSION_STATE.md#2026-03-20-handoff-snapshot) — fastest re-entry point for the next AI session

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 ## Current State
 - docs/SESSION_STATE.md — architecture decisions, locked choices, current phase + next steps
-- docs/HANDOFF_CODE_REVIEW_FIXES.md — active PR #280 code-review fix handoff, remaining blockers, and no-bypass guidance
+- docs/HANDOFF_CODE_REVIEW_FIXES.md — code-review fix handoff (PR #280): completed changes, no-bypass guidance
 - docs/PRODUCT_SPEC.md — product architecture, evidence/output model, language rules, and capability status labels
 - docs/architecture/android-spatial-baseline-implementation-plan.md — Android-first local spatial baseline MVP implementation handoff
 - [docs/SESSION_STATE.md#2026-03-20-handoff-snapshot](docs/SESSION_STATE.md#2026-03-20-handoff-snapshot) — fastest re-entry point for the next AI session


### PR DESCRIPTION
Closes #279

## Summary

This draft PR applies real implementation fixes from the independent code review and follow-up Copilot review without suppressions or comment-only bypasses.

Completed here:
- Discard stale in-flight continuous desktop scan results before mutating the store after stop.
- Preserve manual idle-state Scan Now behavior and avoid restart waiting on stale scan promises.
- Add async desktop scanner tests for manual scans, stale active-scan discard, and restart behavior.
- Format companion server address output as a string and update pairing UI to render formatted strings as usable `ws://` endpoints.
- Replace plain token comparison with length-checked `crypto.timingSafeEqual()`.
- Rename `PRELIGHT_CLASSIFICATIONS` to `PREFLIGHT_CLASSIFICATIONS` across source, main process, and tests with no compatibility alias retained.
- Fix renderer risk-log handling as a snapshot/dedupe update with a single render, instead of repeated append.
- Raise WPA heuristic confidence to the default PolicyGate floor; matching test expectation is `0.3f`.
- Preserve the locked Android Google Maps-only map decision instead of re-enabling custom `LocalHeatmapView` without docs/product approval.
- Wrap `ScanHistoryActivity` and `ThreatResultsActivity` in the shared `WscanUi` shell/header/insets pattern.
- Add required `@Volatile` annotations in `WatchdogService.kt` for cross-thread fields.
- Add `docs/HANDOFF_CODE_REVIEW_FIXES.md` with traceable handoff and link it from `docs/INDEX.md`.

## Remaining before ready

Run required desktop and Android checks:
- `cd desktop && npm test && npm run lint`
- `cd android && ./gradlew :core:test :app:ktlintCheck :core:ktlintCheck`

## Verification

Not run in this connector-only environment. Keep this PR draft until CI/local checks pass.

## No-bypass note

Do not mark ready by adding suppressions, weakening tests, skipping CI, or documenting unreachable code without an explicit product decision.