### PR TITLE
Add GitHub Actions workflow for labeling PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+# Labeler configuration for automatically applying labels to PRs based on changed paths
+# See: https://github.com/actions/labeler
+
+# Documentation changes
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: ['docs/**/*', '*.md', '.github/**/*.md']
+
+# Android app changes
+android:
+  - changed-files:
+    - any-glob-to-any-file: ['android/**/*']
+
+# Desktop/Electron app changes
+desktop:
+  - changed-files:
+    - any-glob-to-any-file: ['desktop/**/*']
+
+# Dependency updates
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'package*.json'
+      - 'desktop/package*.json'
+      - 'android/build.gradle*'
+      - 'android/app/build.gradle*'
+      - 'android/gradle/**/*'
+
+# CI/CD and GitHub Actions
+ci:
+  - changed-files:
+    - any-glob-to-any-file: ['.github/workflows/**/*', '.github/actions/**/*']
+
+# Architecture and core structure
+architecture:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AGENTS.md'
+      - 'docs/ARCHITECTURE.md'
+      - 'docs/SESSION_STATE.md'
+      - '**/core/**/*'
+
+# Security-related files
+security:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/workflows/codeql.yml'
+      - 'secrets.*.properties'
+      - '.env*'
+      - '**/security/**/*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,22 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request_target]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -22,6 +22,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@eab38f7e4d623ad323b1b8a59c0f2f3a0fef5f5f # v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,12 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request_target]
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   label:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -22,6 +22,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@eab38f7e4d623ad323b1b8a59c0f2f3a0fef5f5f # v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@eab38f7e4d623ad323b1b8a59c0f2f3a0fef5f5f # v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request introduces automated labeling for pull requests by adding configuration and a workflow that applies labels based on the files changed in a PR. This will help triage and categorize pull requests more efficiently, improving project organization and review processes.

**Automated labeling setup:**

* Added `.github/labeler.yml` to define label rules for documentation, Android, desktop, dependencies, CI/CD, architecture, and security based on changed file paths.
* Added `.github/workflows/label.yml` to run the Labeler GitHub Action on pull request events and apply the appropriate labels automatically.