### PR TITLE
chore: add SessionStart hook for remote web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,4 +6,4 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 cd "$CLAUDE_PROJECT_DIR/desktop"
-npm install
+npm ci

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR/desktop"
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -176,8 +176,10 @@ out/
 # Android Studio IDE files
 android/.idea/
 
-# Claude AI local files
-.claude/
+# Claude AI local files (keep hook and settings tracked; ignore transcripts and cache)
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
 
 # VS Code local settings (not project config)
 .vscode/


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `.claude/hooks/session-start.sh` that runs `npm install` in `desktop/` on remote Claude Code web sessions
- Registers the hook in `.claude/settings.json` under `SessionStart`
- Updates `.gitignore` to track `.claude/settings.json` and `.claude/hooks/` while keeping transcripts/cache local-only

## Test plan

- [ ] Merge into default branch
- [ ] Start a new Claude Code web session on this repo
- [ ] Confirm `desktop/node_modules` is present and `npm test` / `npm run lint` run without errors

https://claude.ai/code/session_01Xq29CR2gFBJojVqYSRuUEM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xq29CR2gFBJojVqYSRuUEM)_