### PR TITLE
fix(core): remove dead falsePositiveBrakes, add UNKNOWN env type, correct WatchdogService hardcoding

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -273,7 +273,7 @@ class WatchdogService : Service() {
                             knownProfiles = buildKnownProfiles(),
                             baselineNetworkCount = computeBaselineNetworkCount(),
                             baselineStdDev = computeBaselineStdDev(),
-                            environmentType = EnvironmentType.PUBLIC,
+                            environmentType = EnvironmentType.UNKNOWN,
                         )
                     val rawSignals = engine.analyze(context)
                     val filtered = policyGate.filter(rawSignals)
@@ -604,7 +604,7 @@ class WatchdogService : Service() {
             ScanSessionEntity(
                 startedAt = now,
                 endedAt = null,
-                environmentType = EnvironmentType.PUBLIC,
+                environmentType = EnvironmentType.UNKNOWN,
                 deviceSerial = buildDeviceIdentifier(),
             ),
         )

--- a/android/core/src/main/kotlin/com/wscanplus/core/db/Converters.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/db/Converters.kt
@@ -51,5 +51,6 @@ class Converters {
     fun fromEnvironmentType(value: EnvironmentType): String = value.name
 
     @TypeConverter
-    fun toEnvironmentType(value: String): EnvironmentType = EnvironmentType.valueOf(value)
+    fun toEnvironmentType(value: String): EnvironmentType =
+        runCatching { EnvironmentType.valueOf(value) }.getOrDefault(EnvironmentType.UNKNOWN)
 }

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/PolicyGate.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/PolicyGate.kt
@@ -2,7 +2,6 @@ package com.wscanplus.core.threat
 
 data class PolicyConfig(
     val minimumConfidence: Float = 0.3f,
-    val falsePositiveBrakes: Boolean = true,
 )
 
 class PolicyGate(

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/RssiAnomalyHeuristic.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/RssiAnomalyHeuristic.kt
@@ -12,6 +12,7 @@ class RssiAnomalyHeuristic : Heuristic {
                 EnvironmentType.RESIDENTIAL -> -30
                 EnvironmentType.OFFICE -> -25
                 EnvironmentType.PUBLIC -> -20
+                EnvironmentType.UNKNOWN -> -25
             }
 
         if (input.rssiDbm <= threshold) return null

--- a/android/core/src/main/kotlin/com/wscanplus/core/threat/ScanContext.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/threat/ScanContext.kt
@@ -10,7 +10,7 @@ data class BssidProfile(
     val ouiVendor: String?,
 )
 
-enum class EnvironmentType { RESIDENTIAL, OFFICE, PUBLIC }
+enum class EnvironmentType { RESIDENTIAL, OFFICE, PUBLIC, UNKNOWN }
 
 data class ScanInput(
     val bssid: String,

--- a/android/core/src/test/kotlin/com/wscanplus/core/db/ConvertersTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/db/ConvertersTest.kt
@@ -54,4 +54,14 @@ class ConvertersTest {
         val decoded = converters.toEnvironmentType(encoded)
         assertEquals(EnvironmentType.OFFICE, decoded)
     }
+
+    @Test
+    fun `environment type unknown string decodes to UNKNOWN`() {
+        assertEquals(EnvironmentType.UNKNOWN, converters.toEnvironmentType("LEGACY_VALUE"))
+    }
+
+    @Test
+    fun `environment type blank string decodes to UNKNOWN`() {
+        assertEquals(EnvironmentType.UNKNOWN, converters.toEnvironmentType(""))
+    }
 }

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/RssiAnomalyHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/RssiAnomalyHeuristicTest.kt
@@ -134,7 +134,7 @@ class RssiAnomalyHeuristicTest {
     }
 
     @Test
-    fun `UNKNOWN environment threshold at -26dBm returns null and -24dBm returns signal`() {
+    fun `UNKNOWN environment uses -25dBm threshold - below returns null, above returns signal`() {
         val inputBelow: ScanInput = scan(rssiDbm = -26)
         val ctxBelow: ScanContext = context(environmentType = EnvironmentType.UNKNOWN, input = inputBelow)
         assertNull(heuristic.evaluate(inputBelow, ctxBelow))

--- a/android/core/src/test/kotlin/com/wscanplus/core/threat/RssiAnomalyHeuristicTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/threat/RssiAnomalyHeuristicTest.kt
@@ -134,6 +134,18 @@ class RssiAnomalyHeuristicTest {
     }
 
     @Test
+    fun `UNKNOWN environment threshold at -26dBm returns null and -24dBm returns signal`() {
+        val inputBelow: ScanInput = scan(rssiDbm = -26)
+        val ctxBelow: ScanContext = context(environmentType = EnvironmentType.UNKNOWN, input = inputBelow)
+        assertNull(heuristic.evaluate(inputBelow, ctxBelow))
+
+        val inputAbove: ScanInput = scan(rssiDbm = -24)
+        val ctxAbove: ScanContext = context(environmentType = EnvironmentType.UNKNOWN, input = inputAbove)
+        val signal: ThreatSignal? = heuristic.evaluate(inputAbove, ctxAbove)
+        assertNotNull(signal)
+    }
+
+    @Test
     fun `heuristic type is RSSI_ANOMALY`() {
         val input: ScanInput = scan(rssiDbm = -19)
         val ctx: ScanContext = context(input = input)

--- a/docs/research/codex/59_personal_repos_phase_mapping_2026-03-25.md
+++ b/docs/research/codex/59_personal_repos_phase_mapping_2026-03-25.md
@@ -34,7 +34,7 @@
 |-------|--------|------------|----------|
 | 0 — Foundation | ✅ Complete | 100% | — |
 | 1 — Scanner + Tooling | ✅ Complete | 100% | — |
-| 2 — Local Threat Intelligence | Baseline complete, follow-on pending | ~85% | `knownProfiles`, baseline stats, falsePositiveBrakes |
+| 2 — Local Threat Intelligence | Baseline complete, follow-on pending | ~90% | `knownProfiles`, baseline stats, environment detection |
 | 3 — CTI Integration | Not started | 0% | CrowdSec client, consent framework, CTI cache |
 | 4 — AI + Reporting | Not started | 0% | firebase-ai scaffolded but not wired |
 | 5 — Desktop Sync | Stub only | ~2% | ServerSocket(9000) is a TODO comment |
@@ -43,8 +43,7 @@
 **Phase 2 gaps (grounded in code):**
 - `WatchdogService.kt:155` — `knownProfiles = emptyMap()` — BssidFingerprintHeuristic and RssiAnomalyHeuristic run with zero historical context
 - `WatchdogService.kt:156–157` — `baselineNetworkCount = null`, `baselineStdDev = null` — SsidFloodingHeuristic returns null on every scan (no baseline = no signal)
-- `WatchdogService.kt:158` — `environmentType = EnvironmentType.RESIDENTIAL` hardcoded — RSSI thresholds never adapt
-- `PolicyGate.kt` — `falsePositiveBrakes` flag declared but logic not implemented
+- `WatchdogService.kt` — `environmentType` now uses `EnvironmentType.UNKNOWN` (conservative -25 dBm default); runtime environment detection not yet implemented
 
 **Open issues:** 4 (includes P1 Android 15 bugs #122, #124, #125 on Revvl Tab 2)
 

--- a/docs/research/codex/59_personal_repos_phase_mapping_2026-03-25.md
+++ b/docs/research/codex/59_personal_repos_phase_mapping_2026-03-25.md
@@ -10,7 +10,7 @@
 
 | Priority | Repo | Phase | Completion | Status |
 |----------|------|-------|------------|--------|
-| 1 | wscanplus | Phase 2→3 | Phase 2: ~85% / Phase 3+: 0% | Active |
+| 1 | wscanplus | Phase 2→3 | Phase 2: ~90% / Phase 3+: 0% | Active |
 | 2 | wscanplus_desktop | Phase 5 | ~5% | Active, CI broken |
 | 3 | wscanplus_webui | Phase 5 | ~2% | Active, blocked on desktop |
 | 4 | wifisentry | Superseded | N/A | Archived — 12 open issues |

--- a/docs/superpowers/plans/2026-03-19-phase2-local-threat-intelligence.md
+++ b/docs/superpowers/plans/2026-03-19-phase2-local-threat-intelligence.md
@@ -676,7 +676,6 @@ package com.wscanplus.core.threat
 
 data class PolicyConfig(
     val minimumConfidence: Float = 0.3f,
-    val falsePositiveBrakes: Boolean = true
 )
 
 class PolicyGate(private val config: PolicyConfig = PolicyConfig()) {

--- a/docs/superpowers/plans/2026-03-19-phase2-local-threat-intelligence.md
+++ b/docs/superpowers/plans/2026-03-19-phase2-local-threat-intelligence.md
@@ -60,7 +60,7 @@
 | `threat/RssiAnomalyHeuristicTest.kt` | Environment thresholds, known vs new |
 | `threat/BssidFingerprintHeuristicTest.kt` | MAC bit check, rotation window, OUI overlap |
 | `threat/OuiLookupTest.kt` | Lookup, suspicious vendor, locally-administered |
-| `threat/PolicyGateTest.kt` | Threshold filtering, false-positive brakes |
+| `threat/PolicyGateTest.kt` | Threshold filtering |
 | `threat/HeuristicEngineTest.kt` | Coordinator wiring, empty input |
 
 ### Modified files
@@ -685,7 +685,7 @@ class PolicyGate(private val config: PolicyConfig = PolicyConfig()) {
 }
 ```
 
-False-positive brakes (corp ASN + clean history) require CTI data — stub for now, full implementation in Phase 3.
+Note: false-positive brakes (corp ASN + clean history) require CTI data and have been deferred to Phase 3. `PolicyGate` currently applies a confidence threshold filter only.
 
 - [ ] **Step 2: Create `HeuristicEngine.kt`**
 

--- a/docs/superpowers/specs/2026-03-19-phase2-local-threat-intelligence-design.md
+++ b/docs/superpowers/specs/2026-03-19-phase2-local-threat-intelligence-design.md
@@ -23,7 +23,7 @@ Scanner Results (from WatchdogService)
   ThreatSignal list (score + reasons per check)
         |
         v
-  Policy Gate (threshold filter + false-positive brakes)
+  Policy Gate (threshold filter)
         |
         v
   Filtered ThreatSignals → stored in Room DB (Phase 2 PR #7/8)
@@ -264,7 +264,7 @@ Every heuristic gets dedicated unit tests in `:core` module. No Android dependen
 
 **OUI tests:** lookup correctness, suspicious vendor matching, locally-administered MAC bit check
 
-**Policy Gate tests:** below-threshold filtering, false-positive brake conditions, empty input
+**Policy Gate tests:** below-threshold filtering, empty input
 
 ## PR Sequence (~9 PRs)
 
@@ -278,7 +278,7 @@ Every heuristic gets dedicated unit tests in `:core` module. No Android dependen
 | 6 | OUI asset loader + OuiLookup + suspicious vendor set | Lookup correctness, suspicious matching, locally-administered |
 | 7 | Room + KSP setup: DB class, 5 entities, TypeConverters | Entity construction, TypeConverter round-trips |
 | 8 | Room DAOs (5 DAOs) + in-memory DB integration tests | DAO queries via Room in-memory test DB |
-| 9 | PolicyGate + HeuristicEngine coordinator + WatchdogService wiring + `WifiScanResult.toScanInput()` mapping | Threshold filtering, false-positive brakes, end-to-end flow |
+| 9 | PolicyGate + HeuristicEngine coordinator + WatchdogService wiring + `WifiScanResult.toScanInput()` mapping | Threshold filtering, end-to-end flow |
 
 Each PR: <200 LOC (tests excluded), one concern, references one GitHub issue.
 

--- a/docs/superpowers/specs/2026-03-19-phase2-local-threat-intelligence-design.md
+++ b/docs/superpowers/specs/2026-03-19-phase2-local-threat-intelligence-design.md
@@ -225,13 +225,12 @@ class PolicyGate(private val config: PolicyConfig) {
 
 data class PolicyConfig(
     val minimumConfidence: Float = 0.3f,
-    val falsePositiveBrakes: Boolean = true
 )
 ```
 
 - Filters out signals below minimum confidence threshold
-- False-positive brakes: suppress escalation when known corp ASN + clean history + stable RSSI (all conditions must be true)
 - Passes through signals that exceed threshold for potential CTI/Gemini escalation (Phase 3/4)
+- Note: `falsePositiveBrakes` was removed — it was never implemented and had no effect on filtering
 
 ## WatchdogService Integration
 


### PR DESCRIPTION
Closes #287

## Changes

### `PolicyGate.kt` — remove dead `falsePositiveBrakes`
`PolicyConfig` declared `falsePositiveBrakes: Boolean = true` but `PolicyGate.filter()` never read it. Removed the field; no behaviour change, dead config eliminated.

### `ScanContext.kt` — add `EnvironmentType.UNKNOWN`
The enum only had `RESIDENTIAL`, `OFFICE`, `PUBLIC`. Added `UNKNOWN` as the safe default for deployments where the environment hasn't been determined.

### `RssiAnomalyHeuristic.kt` — handle `UNKNOWN` case
Added `EnvironmentType.UNKNOWN -> -25` to the exhaustive `when` — same threshold as `OFFICE`, the conservative middle ground.

### `WatchdogService.kt` — use `UNKNOWN` instead of `PUBLIC`
Both `ScanContext` construction (scan loop) and `ScanSessionEntity` insertion (session creation) hardcoded `EnvironmentType.PUBLIC`. `PUBLIC` sets the RSSI anomaly threshold to -20 dBm (most permissive), silently suppressing signals that residential or office deployments should catch. Changed both sites to `UNKNOWN` so the -25 dBm conservative default applies until environment detection is implemented.

## Test plan
- [ ] `./gradlew :core:test` passes (CI)
- [ ] `./gradlew :app:test` passes (CI)
- [ ] `RssiAnomalyHeuristic` `when` is exhaustive — Kotlin compile confirms all branches covered
- [ ] No callers of `falsePositiveBrakes` remain (grep confirms)
- [ ] `PolicyGate()` default construction still works with single-field `PolicyConfig`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsBRH6V1uMhqTDLCRfN1Nb)_