### PR TITLE
feat(android): add NMEA GPS delivery servers (BLE GATT + USB)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,15 +48,17 @@
     <!-- Required for ServerSocket(9000) ADB communication (Phase 3) -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- BLE NMEA tethering: GATT server + advertising for desktop receivers -->
+    <!-- ================================================================
+         BLE NMEA tethering: GATT server + advertising for desktop receivers
+         ================================================================ -->
+
+    <!-- Legacy Bluetooth (API ≤30) -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_CONNECT"
-        tools:targetApi="31" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADVERTISE"
-        tools:targetApi="31" />
+
+    <!-- Runtime permissions required API 31+ for GATT server and advertising -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="31" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" tools:targetApi="31" />
 
     <!-- Required for CameraIrSelfTest (user-triggered capability self-test only) -->
     <uses-permission android:name="android.permission.CAMERA" />

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
@@ -48,6 +48,7 @@ class BleNmeaGattServer(
     private var gattServer: BluetoothGattServer? = null
     private var advertiser: BluetoothLeAdvertiser? = null
     private var characteristic: BluetoothGattCharacteristic? = null
+
     // Saved before we overwrite the adapter name so stop() can restore it.
     private var previousDeviceName: String? = null
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
@@ -1,0 +1,285 @@
+package com.wscanplus.app.nmea
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.ParcelUuid
+import android.util.Log
+import androidx.core.content.ContextCompat
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class BleNmeaGattServer(
+    private val context: Context,
+    private val deviceName: String = DEFAULT_DEVICE_NAME,
+) {
+    @Volatile
+    var isRunning: Boolean = false
+        private set
+
+    @Volatile
+    var isAdvertising: Boolean = false
+        private set
+
+    @Volatile
+    var lastError: String? = null
+        private set
+
+    val subscriberCount: Int
+        get() = subscribers.size
+
+    private val subscribers = ConcurrentHashMap.newKeySet<BluetoothDevice>()
+    private val mtuByAddress = ConcurrentHashMap<String, Int>()
+    private var gattServer: BluetoothGattServer? = null
+    private var advertiser: BluetoothLeAdvertiser? = null
+    private var characteristic: BluetoothGattCharacteristic? = null
+
+    @SuppressLint("MissingPermission")
+    fun start() {
+        if (isRunning) return
+        if (!hasBlePermissions(context)) {
+            lastError = "Missing BLE permissions"
+            return
+        }
+
+        val manager = context.getSystemService(BluetoothManager::class.java)
+        val adapter = manager?.adapter
+        if (manager == null || adapter == null || !adapter.isEnabled) {
+            lastError = "Bluetooth unavailable"
+            return
+        }
+
+        val service =
+            BluetoothGattService(SERVICE_UUID, BluetoothGattService.SERVICE_TYPE_PRIMARY)
+        val nmeaCharacteristic =
+            BluetoothGattCharacteristic(
+                NMEA_CHARACTERISTIC_UUID,
+                BluetoothGattCharacteristic.PROPERTY_NOTIFY or
+                    BluetoothGattCharacteristic.PROPERTY_READ,
+                BluetoothGattCharacteristic.PERMISSION_READ,
+            )
+        val cccd =
+            BluetoothGattDescriptor(
+                CLIENT_CONFIG_UUID,
+                BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE,
+            )
+        nmeaCharacteristic.addDescriptor(cccd)
+        service.addCharacteristic(nmeaCharacteristic)
+
+        val server = manager.openGattServer(context, callback)
+        if (server == null) {
+            lastError = "Unable to open GATT server"
+            return
+        }
+
+        val advertisedName = adapter.name
+        if (advertisedName != deviceName) {
+            adapter.name = deviceName
+        }
+
+        if (!server.addService(service)) {
+            server.close()
+            lastError = "Unable to add BLE NMEA service"
+            return
+        }
+
+        gattServer = server
+        characteristic = nmeaCharacteristic
+        advertiser = adapter.bluetoothLeAdvertiser
+        isRunning = true
+        lastError = null
+        startAdvertising()
+        Log.i(TAG, "BLE NMEA GATT server started")
+    }
+
+    @SuppressLint("MissingPermission")
+    fun stop() {
+        isAdvertising = false
+        isRunning = false
+        subscribers.clear()
+        mtuByAddress.clear()
+        advertiser?.stopAdvertising(advertiseCallback)
+        advertiser = null
+        try {
+            gattServer?.close()
+        } catch (error: Exception) {
+            Log.w(TAG, "Failed to close BLE GATT server", error)
+        }
+        gattServer = null
+        characteristic = null
+    }
+
+    @SuppressLint("MissingPermission")
+    fun broadcast(line: String) {
+        if (!isRunning || subscribers.isEmpty()) return
+        val gatt = gattServer ?: return
+        val target = characteristic ?: return
+        subscribers.forEach { device ->
+            val mtu = mtuByAddress[device.address] ?: DEFAULT_MTU
+            chunkUtf8(line, mtu).forEach { payload ->
+                target.value = payload
+                gatt.notifyCharacteristicChanged(device, target, false)
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startAdvertising() {
+        val bleAdvertiser = advertiser
+        if (bleAdvertiser == null) {
+            lastError = "BLE advertiser unavailable"
+            return
+        }
+
+        val settings =
+            AdvertiseSettings
+                .Builder()
+                .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+                .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM)
+                .setConnectable(true)
+                .build()
+        val data =
+            AdvertiseData
+                .Builder()
+                .setIncludeDeviceName(true)
+                .addServiceUuid(ParcelUuid(SERVICE_UUID))
+                .build()
+        bleAdvertiser.startAdvertising(settings, data, advertiseCallback)
+    }
+
+    private val advertiseCallback =
+        object : AdvertiseCallback() {
+            override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+                isAdvertising = true
+                lastError = null
+                Log.i(TAG, "BLE NMEA advertising started")
+            }
+
+            override fun onStartFailure(errorCode: Int) {
+                isAdvertising = false
+                lastError = "Advertise failure code=$errorCode"
+                Log.e(TAG, "BLE NMEA advertising failed: $errorCode")
+            }
+        }
+
+    private val callback =
+        object : BluetoothGattServerCallback() {
+            override fun onConnectionStateChange(
+                device: BluetoothDevice,
+                status: Int,
+                newState: Int,
+            ) {
+                if (newState != BluetoothGatt.STATE_CONNECTED) {
+                    subscribers.remove(device)
+                    mtuByAddress.remove(device.address)
+                }
+            }
+
+            override fun onMtuChanged(
+                device: BluetoothDevice,
+                mtu: Int,
+            ) {
+                mtuByAddress[device.address] = mtu
+            }
+
+            override fun onCharacteristicReadRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                offset: Int,
+                characteristic: BluetoothGattCharacteristic,
+            ) {
+                val gatt = gattServer ?: return
+                val value = characteristic.value ?: byteArrayOf()
+                val response =
+                    if (offset >= value.size) {
+                        byteArrayOf()
+                    } else {
+                        value.copyOfRange(offset, value.size)
+                    }
+                gatt.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, response)
+            }
+
+            override fun onDescriptorWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                descriptor: BluetoothGattDescriptor,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray?,
+            ) {
+                val gatt = gattServer ?: return
+                val descriptorValue = value ?: byteArrayOf()
+                if (descriptor.uuid == CLIENT_CONFIG_UUID) {
+                    when {
+                        descriptorValue.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) ->
+                            subscribers += device
+                        descriptorValue.contentEquals(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE) ->
+                            subscribers.remove(device)
+                    }
+                }
+                if (responseNeeded) {
+                    gatt.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, descriptorValue)
+                }
+            }
+        }
+
+    companion object {
+        private const val TAG = "BleNmeaGattServer"
+        private const val DEFAULT_MTU = 23
+        private const val DEFAULT_DEVICE_NAME = "wscan+ NMEA"
+        val SERVICE_UUID: UUID = UUID.fromString("f1d5e3f4-2f95-4b30-9c94-0a50327dd201")
+        val NMEA_CHARACTERISTIC_UUID: UUID = UUID.fromString("f1d5e3f4-2f95-4b30-9c94-0a50327dd202")
+        val CLIENT_CONFIG_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+
+        internal fun chunkUtf8(
+            line: String,
+            mtu: Int,
+        ): List<ByteArray> {
+            val bytes = line.toByteArray(StandardCharsets.UTF_8)
+            val chunkSize = (mtu - 3).coerceAtLeast(1)
+            if (bytes.isEmpty()) return listOf(byteArrayOf())
+
+            val chunks = mutableListOf<ByteArray>()
+            var index = 0
+            while (index < bytes.size) {
+                val end = (index + chunkSize).coerceAtMost(bytes.size)
+                chunks += bytes.copyOfRange(index, end)
+                index = end
+            }
+            return chunks
+        }
+
+        fun hasBlePermissions(context: Context): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                return ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.BLUETOOTH,
+                ) == PackageManager.PERMISSION_GRANTED
+            }
+
+            return listOf(
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+            ).all { permission ->
+                ContextCompat.checkSelfPermission(context, permission) ==
+                    PackageManager.PERMISSION_GRANTED
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
@@ -48,6 +48,8 @@ class BleNmeaGattServer(
     private var gattServer: BluetoothGattServer? = null
     private var advertiser: BluetoothLeAdvertiser? = null
     private var characteristic: BluetoothGattCharacteristic? = null
+    // Saved before we overwrite the adapter name so stop() can restore it.
+    private var previousDeviceName: String? = null
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -87,13 +89,15 @@ class BleNmeaGattServer(
             return
         }
 
-        val advertisedName = adapter.name
-        if (advertisedName != deviceName) {
+        val currentName = adapter.name
+        if (currentName != deviceName) {
+            previousDeviceName = currentName
             adapter.name = deviceName
         }
 
         if (!server.addService(service)) {
             server.close()
+            restoreDeviceName()
             lastError = "Unable to add BLE NMEA service"
             return
         }
@@ -101,27 +105,17 @@ class BleNmeaGattServer(
         gattServer = server
         characteristic = nmeaCharacteristic
         advertiser = adapter.bluetoothLeAdvertiser
-        isRunning = true
         lastError = null
+        // isRunning is set to true only in onStartSuccess once advertising is confirmed;
+        // if startAdvertising() fails synchronously (null advertiser) closeResources() resets state.
         startAdvertising()
         Log.i(TAG, "BLE NMEA GATT server started")
     }
 
     @SuppressLint("MissingPermission")
     fun stop() {
-        isAdvertising = false
-        isRunning = false
-        subscribers.clear()
-        mtuByAddress.clear()
         advertiser?.stopAdvertising(advertiseCallback)
-        advertiser = null
-        try {
-            gattServer?.close()
-        } catch (error: Exception) {
-            Log.w(TAG, "Failed to close BLE GATT server", error)
-        }
-        gattServer = null
-        characteristic = null
+        closeResources()
     }
 
     @SuppressLint("MissingPermission")
@@ -143,6 +137,7 @@ class BleNmeaGattServer(
         val bleAdvertiser = advertiser
         if (bleAdvertiser == null) {
             lastError = "BLE advertiser unavailable"
+            closeResources()
             return
         }
 
@@ -162,18 +157,49 @@ class BleNmeaGattServer(
         bleAdvertiser.startAdvertising(settings, data, advertiseCallback)
     }
 
+    // Tears down GATT resources and restores device name without calling stopAdvertising —
+    // used from advertising callbacks where stopAdvertising would be a re-entrant no-op or error.
+    private fun closeResources() {
+        isAdvertising = false
+        isRunning = false
+        subscribers.clear()
+        mtuByAddress.clear()
+        advertiser = null
+        restoreDeviceName()
+        try {
+            gattServer?.close()
+        } catch (error: Exception) {
+            Log.w(TAG, "Failed to close BLE GATT server", error)
+        }
+        gattServer = null
+        characteristic = null
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun restoreDeviceName() {
+        val name = previousDeviceName ?: return
+        previousDeviceName = null
+        try {
+            context.getSystemService(BluetoothManager::class.java)?.adapter?.name = name
+        } catch (error: Exception) {
+            Log.w(TAG, "Failed to restore Bluetooth device name", error)
+        }
+    }
+
     private val advertiseCallback =
         object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
                 isAdvertising = true
+                isRunning = true
                 lastError = null
                 Log.i(TAG, "BLE NMEA advertising started")
             }
 
             override fun onStartFailure(errorCode: Int) {
-                isAdvertising = false
                 lastError = "Advertise failure code=$errorCode"
                 Log.e(TAG, "BLE NMEA advertising failed: $errorCode")
+                // Advertising never started — tear down GATT without calling stopAdvertising.
+                closeResources()
             }
         }
 
@@ -267,10 +293,15 @@ class BleNmeaGattServer(
 
         fun hasBlePermissions(context: Context): Boolean {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                return ContextCompat.checkSelfPermission(
-                    context,
+                // Both BLUETOOTH and BLUETOOTH_ADMIN are required pre-API 31:
+                // BLUETOOTH for connection and BLUETOOTH_ADMIN for scanning/advertising.
+                return listOf(
                     Manifest.permission.BLUETOOTH,
-                ) == PackageManager.PERMISSION_GRANTED
+                    Manifest.permission.BLUETOOTH_ADMIN,
+                ).all { permission ->
+                    ContextCompat.checkSelfPermission(context, permission) ==
+                        PackageManager.PERMISSION_GRANTED
+                }
             }
 
             return listOf(

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/BleNmeaGattServer.kt
@@ -190,6 +190,9 @@ class BleNmeaGattServer(
     private val advertiseCallback =
         object : AdvertiseCallback() {
             override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+                // Guard against a stale callback arriving after stop() or a rapid
+                // stop/start cycle has already torn down the GATT server.
+                if (gattServer == null) return
                 isAdvertising = true
                 isRunning = true
                 lastError = null

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
@@ -31,6 +31,10 @@ object NmeaFormatter {
         val utcTime = UTC_TIME_FORMAT.get()!!.format(Date(sample.capturedAt))
         val (lat, latHemisphere) = toNmeaCoordinate(sample.latitude, isLatitude = true)
         val (lon, lonHemisphere) = toNmeaCoordinate(sample.longitude, isLatitude = false)
+        // Android's Location.getAltitude() is WGS84 ellipsoidal height, not MSL.
+        // NMEA GGA field 9 is nominally MSL; field 11 should carry the geoid separation.
+        // Android exposes neither MSL altitude nor EGM96 geoid height, so we emit the
+        // WGS84 value with a blank geoid-separation field — the best available approximation.
         val altitude = sample.altitudeMeters?.let { formatDecimal(it, 1) } ?: ""
         val body =
             listOf(

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
@@ -86,8 +86,15 @@ object NmeaFormatter {
         isLatitude: Boolean,
     ): Pair<String, String> {
         val absValue = abs(coordinate)
-        val degrees = absValue.toInt()
-        val minutes = (absValue - degrees) * 60.0
+        var degrees = absValue.toInt()
+        // Round to output precision first so carry is detected before formatting;
+        // without this, values like 47.9999999 produce "xx60.000" which is rejected
+        // by NMEA parsers (valid range is 00.000–59.999).
+        var minutes = Math.round((absValue - degrees) * 60.0 * 1000.0).toDouble() / 1000.0
+        if (minutes >= 60.0) {
+            degrees += 1
+            minutes = 0.0
+        }
         val degreeWidth = if (isLatitude) 2 else 3
         val formatted =
             String.format(

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
@@ -7,25 +7,31 @@ import java.util.Locale
 import java.util.TimeZone
 import kotlin.math.abs
 
+// ThreadLocal wrappers make SimpleDateFormat safe for concurrent callers on any API level.
 private val UTC_TIME_FORMAT =
-    SimpleDateFormat("HHmmss.SSS", Locale.US).apply {
-        timeZone = TimeZone.getTimeZone("UTC")
+    object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue() =
+            SimpleDateFormat("HHmmss.SSS", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
     }
 
 private val UTC_DATE_FORMAT =
-    SimpleDateFormat("ddMMyy", Locale.US).apply {
-        timeZone = TimeZone.getTimeZone("UTC")
+    object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue() =
+            SimpleDateFormat("ddMMyy", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
     }
 
 object NmeaFormatter {
     fun toSentences(sample: LocationSample): List<String> = listOf(toGga(sample), toRmc(sample))
 
     fun toGga(sample: LocationSample): String {
-        val utcTime = UTC_TIME_FORMAT.format(Date(sample.capturedAt))
+        val utcTime = UTC_TIME_FORMAT.get()!!.format(Date(sample.capturedAt))
         val (lat, latHemisphere) = toNmeaCoordinate(sample.latitude, isLatitude = true)
         val (lon, lonHemisphere) = toNmeaCoordinate(sample.longitude, isLatitude = false)
         val altitude = sample.altitudeMeters?.let { formatDecimal(it, 1) } ?: ""
-        val hdop = sample.accuracyMeters?.takeIf { it > 0f }?.let { formatDecimal(it.toDouble(), 1) } ?: ""
         val body =
             listOf(
                 "GPGGA",
@@ -36,7 +42,10 @@ object NmeaFormatter {
                 lonHemisphere,
                 "1",
                 "",
-                hdop,
+                // Android exposes horizontal accuracy in metres, not HDOP (a dimensionless ratio).
+                // Writing metres into the HDOP field misleads consumers that interpret it as a
+                // quality indicator — leave it blank rather than emit a semantically wrong value.
+                "",
                 altitude,
                 "M",
                 "",
@@ -48,8 +57,8 @@ object NmeaFormatter {
     }
 
     fun toRmc(sample: LocationSample): String {
-        val utcTime = UTC_TIME_FORMAT.format(Date(sample.capturedAt))
-        val utcDate = UTC_DATE_FORMAT.format(Date(sample.capturedAt))
+        val utcTime = UTC_TIME_FORMAT.get()!!.format(Date(sample.capturedAt))
+        val utcDate = UTC_DATE_FORMAT.get()!!.format(Date(sample.capturedAt))
         val (lat, latHemisphere) = toNmeaCoordinate(sample.latitude, isLatitude = true)
         val (lon, lonHemisphere) = toNmeaCoordinate(sample.longitude, isLatitude = false)
         val speedKnots = sample.speedKph?.let { formatDecimal(it / 1.852, 1) } ?: ""

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/NmeaFormatter.kt
@@ -1,0 +1,112 @@
+package com.wscanplus.app.nmea
+
+import com.wscanplus.app.location.LocationSample
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.math.abs
+
+private val UTC_TIME_FORMAT =
+    SimpleDateFormat("HHmmss.SSS", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+private val UTC_DATE_FORMAT =
+    SimpleDateFormat("ddMMyy", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+object NmeaFormatter {
+    fun toSentences(sample: LocationSample): List<String> = listOf(toGga(sample), toRmc(sample))
+
+    fun toGga(sample: LocationSample): String {
+        val utcTime = UTC_TIME_FORMAT.format(Date(sample.capturedAt))
+        val (lat, latHemisphere) = toNmeaCoordinate(sample.latitude, isLatitude = true)
+        val (lon, lonHemisphere) = toNmeaCoordinate(sample.longitude, isLatitude = false)
+        val altitude = sample.altitudeMeters?.let { formatDecimal(it, 1) } ?: ""
+        val hdop = sample.accuracyMeters?.takeIf { it > 0f }?.let { formatDecimal(it.toDouble(), 1) } ?: ""
+        val body =
+            listOf(
+                "GPGGA",
+                utcTime,
+                lat,
+                latHemisphere,
+                lon,
+                lonHemisphere,
+                "1",
+                "",
+                hdop,
+                altitude,
+                "M",
+                "",
+                "M",
+                "",
+                "",
+            ).joinToString(",")
+        return sentence(body)
+    }
+
+    fun toRmc(sample: LocationSample): String {
+        val utcTime = UTC_TIME_FORMAT.format(Date(sample.capturedAt))
+        val utcDate = UTC_DATE_FORMAT.format(Date(sample.capturedAt))
+        val (lat, latHemisphere) = toNmeaCoordinate(sample.latitude, isLatitude = true)
+        val (lon, lonHemisphere) = toNmeaCoordinate(sample.longitude, isLatitude = false)
+        val speedKnots = sample.speedKph?.let { formatDecimal(it / 1.852, 1) } ?: ""
+        val body =
+            listOf(
+                "GPRMC",
+                utcTime,
+                "A",
+                lat,
+                latHemisphere,
+                lon,
+                lonHemisphere,
+                speedKnots,
+                "",
+                utcDate,
+                "",
+                "",
+            ).joinToString(",")
+        return sentence(body)
+    }
+
+    internal fun sentence(body: String): String = "\$$body*${checksum(body)}\r\n"
+
+    internal fun checksum(body: String): String {
+        var value = 0
+        for (ch in body) {
+            value = value xor ch.code
+        }
+        return value.toString(16).uppercase(Locale.US).padStart(2, '0')
+    }
+
+    internal fun toNmeaCoordinate(
+        coordinate: Double,
+        isLatitude: Boolean,
+    ): Pair<String, String> {
+        val absValue = abs(coordinate)
+        val degrees = absValue.toInt()
+        val minutes = (absValue - degrees) * 60.0
+        val degreeWidth = if (isLatitude) 2 else 3
+        val formatted =
+            String.format(
+                Locale.US,
+                "%0${degreeWidth}d%06.3f",
+                degrees,
+                minutes,
+            )
+        val hemisphere =
+            if (isLatitude) {
+                if (coordinate >= 0.0) "N" else "S"
+            } else {
+                if (coordinate >= 0.0) "E" else "W"
+            }
+        return formatted to hemisphere
+    }
+
+    private fun formatDecimal(
+        value: Double,
+        fractionDigits: Int,
+    ): String = String.format(Locale.US, "%.${fractionDigits}f", value)
+}

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/UsbNmeaServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/UsbNmeaServer.kt
@@ -23,6 +23,9 @@ class UsbNmeaServer(
     val clientCount: Int
         get() = clients.size
 
+    val boundPort: Int
+        get() = serverSocket?.localPort ?: -1
+
     private val clients = CopyOnWriteArrayList<Socket>()
     private var serverSocket: ServerSocket? = null
     private var acceptThread: Thread? = null

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/UsbNmeaServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/UsbNmeaServer.kt
@@ -125,7 +125,12 @@ class UsbNmeaServer(
                 Log.e(TAG, "USB NMEA accept loop failed", error)
             }
         } finally {
-            isRunning = false
+            // Only reset the running flag when this thread still owns the server socket.
+            // A rapid stop()+start() may have already bound a new socket; clearing
+            // isRunning in that case would silently kill the new server's healthy state.
+            if (serverSocket === socket) {
+                isRunning = false
+            }
             try {
                 socket.close()
             } catch (_: Exception) {

--- a/android/app/src/main/kotlin/com/wscanplus/app/nmea/UsbNmeaServer.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/nmea/UsbNmeaServer.kt
@@ -1,0 +1,146 @@
+package com.wscanplus.app.nmea
+
+import android.util.Log
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CopyOnWriteArrayList
+
+class UsbNmeaServer(
+    private val host: String = DEFAULT_HOST,
+    private val port: Int = DEFAULT_PORT,
+) {
+    @Volatile
+    var isRunning: Boolean = false
+        private set
+
+    @Volatile
+    var lastError: String? = null
+        private set
+
+    val clientCount: Int
+        get() = clients.size
+
+    private val clients = CopyOnWriteArrayList<Socket>()
+    private var serverSocket: ServerSocket? = null
+    private var acceptThread: Thread? = null
+
+    fun start() {
+        if (isRunning) return
+        try {
+            val socket =
+                ServerSocket(
+                    port,
+                    4,
+                    InetAddress.getByName(host),
+                )
+            serverSocket = socket
+            isRunning = true
+            lastError = null
+            acceptThread =
+                Thread(
+                    { acceptLoop(socket) },
+                    "wscanplus-usb-nmea",
+                ).apply {
+                    isDaemon = true
+                    start()
+                }
+            Log.i(TAG, "USB NMEA server listening on $host:$port")
+        } catch (error: Exception) {
+            lastError = error.message ?: error.javaClass.simpleName
+            Log.e(TAG, "Failed to start USB NMEA server", error)
+            stop()
+        }
+    }
+
+    fun stop() {
+        isRunning = false
+        acceptThread?.interrupt()
+        acceptThread = null
+
+        try {
+            serverSocket?.close()
+        } catch (error: Exception) {
+            Log.w(TAG, "Failed to close USB NMEA server socket", error)
+        }
+        serverSocket = null
+
+        clients.forEach { socket ->
+            try {
+                socket.close()
+            } catch (error: Exception) {
+                Log.w(TAG, "Failed to close USB NMEA client socket", error)
+            }
+        }
+        clients.clear()
+    }
+
+    fun broadcast(line: String) {
+        if (!isRunning || clients.isEmpty()) return
+        val payload = line.toByteArray(StandardCharsets.UTF_8)
+        val deadClients = mutableListOf<Socket>()
+        clients.forEach { socket ->
+            try {
+                socket.getOutputStream().write(payload)
+                socket.getOutputStream().flush()
+            } catch (error: Exception) {
+                Log.w(TAG, "USB NMEA client write failed", error)
+                deadClients += socket
+            }
+        }
+        deadClients.forEach { socket ->
+            clients.remove(socket)
+            try {
+                socket.close()
+            } catch (_: Exception) {
+                // Ignore repeated close on dead client.
+            }
+        }
+    }
+
+    private fun acceptLoop(socket: ServerSocket) {
+        try {
+            while (!socket.isClosed) {
+                val client =
+                    try {
+                        socket.accept()
+                    } catch (error: SocketException) {
+                        if (socket.isClosed) {
+                            break
+                        }
+                        throw error
+                    }
+                client.tcpNoDelay = true
+                clients += client
+                Log.i(TAG, "USB NMEA client connected (${clients.size} total)")
+            }
+        } catch (error: Exception) {
+            if (!isExpectedShutdown(error)) {
+                lastError = error.message ?: error.javaClass.simpleName
+                Log.e(TAG, "USB NMEA accept loop failed", error)
+            }
+        } finally {
+            isRunning = false
+            try {
+                socket.close()
+            } catch (_: Exception) {
+                // Ignore shutdown close failures.
+            }
+        }
+    }
+
+    private fun isExpectedShutdown(error: Exception): Boolean =
+        error is SocketException &&
+            (
+                error.message?.contains("Socket closed", ignoreCase = true) == true ||
+                    error.message?.contains("closed", ignoreCase = true) == true
+            )
+
+    companion object {
+        private const val TAG = "UsbNmeaServer"
+        const val DEFAULT_HOST = "127.0.0.1"
+        const val DEFAULT_PORT = 47393
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/nmea/BleNmeaGattServerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/nmea/BleNmeaGattServerTest.kt
@@ -1,0 +1,29 @@
+package com.wscanplus.app.nmea
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+class BleNmeaGattServerTest {
+    @Test
+    fun `chunkUtf8 keeps whole payload when it fits mtu`() {
+        val chunks = BleNmeaGattServer.chunkUtf8("\$GPRMC,test*00\r\n", 32)
+
+        assertEquals(1, chunks.size)
+        assertArrayEquals("\$GPRMC,test*00\r\n".toByteArray(StandardCharsets.UTF_8), chunks.single())
+    }
+
+    @Test
+    fun `chunkUtf8 splits payload by mtu minus overhead`() {
+        val payload = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+        val chunks = BleNmeaGattServer.chunkUtf8(payload, 10)
+
+        assertEquals(4, chunks.size)
+        assertEquals("ABCDEFG", String(chunks[0], StandardCharsets.UTF_8))
+        assertEquals("HIJKLMN", String(chunks[1], StandardCharsets.UTF_8))
+        assertEquals("OPQRSTU", String(chunks[2], StandardCharsets.UTF_8))
+        assertEquals("VWXYZ", String(chunks[3], StandardCharsets.UTF_8))
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/nmea/NmeaFormatterTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/nmea/NmeaFormatterTest.kt
@@ -1,0 +1,76 @@
+package com.wscanplus.app.nmea
+
+import com.wscanplus.app.location.LocationSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NmeaFormatterTest {
+    @Test
+    fun `toSentences emits GGA and RMC with checksums`() {
+        val sample =
+            LocationSample(
+                latitude = 47.6205,
+                longitude = -122.3493,
+                accuracyMeters = 4.4f,
+                altitudeMeters = 52.7,
+                speedKph = 18.5f,
+                capturedAt = 1_714_600_000_000L,
+                provider = "fused",
+                isMock = false,
+            )
+
+        val sentences = NmeaFormatter.toSentences(sample)
+
+        assertEquals(2, sentences.size)
+        assertTrue(sentences[0].startsWith("\$GPGGA,"))
+        assertTrue(sentences[0].endsWith("\r\n"))
+        assertTrue(sentences[1].startsWith("\$GPRMC,"))
+        assertTrue(sentences[1].endsWith("\r\n"))
+        assertTrue(sentences.all { it.contains('*') })
+    }
+
+    @Test
+    fun `toGga formats coordinates and altitude`() {
+        val sample =
+            LocationSample(
+                latitude = 37.7749,
+                longitude = -122.4194,
+                accuracyMeters = 5.2f,
+                altitudeMeters = 16.4,
+                speedKph = null,
+                capturedAt = 1_714_600_000_000L,
+                provider = "gps",
+                isMock = false,
+            )
+
+        val sentence = NmeaFormatter.toGga(sample)
+
+        assertTrue(sentence.contains(",3746.494,N,12225.164,W,"))
+        assertTrue(sentence.contains(",5.2,16.4,M,,M,,"))
+    }
+
+    @Test
+    fun `toRmc converts speed to knots`() {
+        val sample =
+            LocationSample(
+                latitude = 37.7749,
+                longitude = -122.4194,
+                accuracyMeters = null,
+                altitudeMeters = null,
+                speedKph = 18.52f,
+                capturedAt = 1_714_600_000_000L,
+                provider = "gps",
+                isMock = false,
+            )
+
+        val sentence = NmeaFormatter.toRmc(sample)
+
+        assertTrue(sentence.contains(",A,3746.494,N,12225.164,W,10.0,"))
+    }
+
+    @Test
+    fun `checksum matches known sample`() {
+        assertEquals("47", NmeaFormatter.checksum("GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,"))
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/nmea/NmeaFormatterTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/nmea/NmeaFormatterTest.kt
@@ -73,4 +73,12 @@ class NmeaFormatterTest {
     fun `checksum matches known sample`() {
         assertEquals("47", NmeaFormatter.checksum("GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,"))
     }
+
+    @Test
+    fun `toNmeaCoordinate carries minute rollover at degree boundary`() {
+        // 47.9999999 raw minutes = 59.99999... → rounds to 60.000 without carry fix
+        val (coord, hemi) = NmeaFormatter.toNmeaCoordinate(47.9999999, isLatitude = true)
+        assertTrue("minutes field must not be 60.000, got: $coord", !coord.contains("60.000"))
+        assertEquals("N", hemi)
+    }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/nmea/NmeaFormatterTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/nmea/NmeaFormatterTest.kt
@@ -47,7 +47,8 @@ class NmeaFormatterTest {
         val sentence = NmeaFormatter.toGga(sample)
 
         assertTrue(sentence.contains(",3746.494,N,12225.164,W,"))
-        assertTrue(sentence.contains(",5.2,16.4,M,,M,,"))
+        // HDOP field is blank (Android accuracy metres ≠ HDOP); altitude and units present.
+        assertTrue(sentence.contains(",,,16.4,M,,M,,"))
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/wscanplus/app/nmea/UsbNmeaServerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/nmea/UsbNmeaServerTest.kt
@@ -1,0 +1,124 @@
+package com.wscanplus.app.nmea
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+class UsbNmeaServerTest {
+    // port = 0 lets the OS pick a free port, avoiding conflicts in CI.
+    private var server = UsbNmeaServer(port = 0)
+
+    @After
+    fun tearDown() {
+        server.stop()
+    }
+
+    @Test
+    fun `start sets isRunning and exposes a valid bound port`() {
+        server.start()
+
+        assertTrue(server.isRunning)
+        assertTrue(server.boundPort > 0)
+        assertNull(server.lastError)
+    }
+
+    @Test
+    fun `start is idempotent when already running`() {
+        server.start()
+        val port = server.boundPort
+
+        server.start()
+
+        assertTrue(server.isRunning)
+        assertEquals(port, server.boundPort)
+    }
+
+    @Test
+    fun `stop clears isRunning`() {
+        server.start()
+        server.stop()
+
+        assertFalse(server.isRunning)
+    }
+
+    @Test
+    fun `stop is safe when never started`() {
+        server.stop() // must not throw
+        assertFalse(server.isRunning)
+    }
+
+    @Test
+    fun `start fails gracefully on unresolvable host`() {
+        server = UsbNmeaServer(host = "invalid.host.xyz.invalid")
+        server.start()
+
+        assertFalse(server.isRunning)
+        assertNotNull(server.lastError)
+    }
+
+    @Test
+    fun `broadcast delivers payload to a connected client`() {
+        server.start()
+        val socket = Socket("127.0.0.1", server.boundPort)
+        awaitCondition { server.clientCount == 1 }
+
+        server.broadcast("\$GPRMC,test*00\r\n")
+
+        val buf = ByteArray(32)
+        socket.soTimeout = 2_000
+        val n = socket.getInputStream().read(buf)
+        assertTrue(n > 0)
+        assertTrue(String(buf, 0, n, StandardCharsets.UTF_8).contains("GPRMC"))
+        socket.close()
+    }
+
+    @Test
+    fun `broadcast delivers to all connected clients`() {
+        server.start()
+        val port = server.boundPort
+        val s1 = Socket("127.0.0.1", port)
+        val s2 = Socket("127.0.0.1", port)
+        awaitCondition { server.clientCount == 2 }
+
+        server.broadcast("HELLO\r\n")
+
+        for (s in listOf(s1, s2)) {
+            s.soTimeout = 2_000
+            val buf = ByteArray(16)
+            val n = s.getInputStream().read(buf)
+            assertEquals("HELLO\r\n", String(buf, 0, n, StandardCharsets.UTF_8))
+            s.close()
+        }
+    }
+
+    @Test
+    fun `broadcast removes dead clients after write failure`() {
+        server.start()
+        val socket = Socket("127.0.0.1", server.boundPort)
+        awaitCondition { server.clientCount == 1 }
+
+        socket.close()
+        // A broadcast attempt triggers the dead-client sweep.
+        awaitCondition {
+            server.broadcast("probe\r\n")
+            server.clientCount == 0
+        }
+
+        assertEquals(0, server.clientCount)
+    }
+
+    private fun awaitCondition(timeoutMs: Long = 3_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(20)
+        }
+        error("Timed out waiting for condition")
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/nmea/UsbNmeaServerTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/nmea/UsbNmeaServerTest.kt
@@ -113,7 +113,10 @@ class UsbNmeaServerTest {
         assertEquals(0, server.clientCount)
     }
 
-    private fun awaitCondition(timeoutMs: Long = 3_000, condition: () -> Boolean) {
+    private fun awaitCondition(
+        timeoutMs: Long = 3_000,
+        condition: () -> Boolean,
+    ) {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {
             if (condition()) return


### PR DESCRIPTION
## Summary

Adds a NMEA 0183 GPS delivery layer to the Android app, enabling the desktop companion to ingest live GPS from the device over BLE or USB — with zero paid API dependency.

### New components

| File | Purpose |
|------|---------|
| `nmea/NmeaFormatter.kt` | Pure formatter: converts `LocationSample` → GPGGA + GPRMC sentences with XOR checksum per NMEA 0183 spec |
| `nmea/BleNmeaGattServer.kt` | BLE GATT peripheral server — advertises a custom NMEA service UUID, accepts central subscriptions, and streams sentences with MTU-aware chunking |
| `nmea/UsbNmeaServer.kt` | TCP server on `localhost:47393` — accepts connections from ADB-forwarded or USB-tethered desktop clients, broadcasts NMEA to all open sockets |

All three classes are plain Kotlin classes (not `Service` subclasses), so no `<service>` entries are required in `AndroidManifest.xml`.

### Integration

Both servers consume `LocationSample` (existing model) and write formatted NMEA to subscribed clients. `UsbNmeaServer` reuses the existing `INTERNET` permission already declared for the ADB socket.

### Unit tests

- `NmeaFormatterTest` — validates GPGGA/GPRMC sentence structure and XOR checksum
- `BleNmeaGattServerTest` — validates the `chunkUtf8` helper for MTU-aware splitting

---

## ⚠️ TODO — manifest + gradle changes required before merge

`BleNmeaGattServer` calls `Manifest.permission.BLUETOOTH_CONNECT` and `Manifest.permission.BLUETOOTH_ADVERTISE` at runtime, but **none of the following permissions are declared in `AndroidManifest.xml`**:

```xml
<!-- Legacy BLE (API < 31) -->
<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />

<!-- API 31+ BLE advertising + connection -->
<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="31" />
<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" tools:targetApi="31" />
```

Without these declarations the BLE server will silently fail the permission check on every device. A follow-up commit should add these four `<uses-permission>` entries before the BLE path is wired up in `WatchdogService`.

No `build.gradle.kts` changes are needed — `BleNmeaGattServer` relies only on Android framework BLE APIs (no additional dependencies).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)