### PR TITLE
docs: add Phase 6 WIDS evidence contract fixtures

### DIFF
--- a/docs/contracts/fixtures/wids/phase6-wids-alert-fixtures.json
+++ b/docs/contracts/fixtures/wids/phase6-wids-alert-fixtures.json
@@ -1,0 +1,274 @@
+{
+  "schemaVersion": 1,
+  "detectorVersion": "phase6-wids-v1",
+  "description": "Representative WIDS contract fixtures for Issue #294. Documentation/fixtures only; no runtime behavior implied.",
+  "cases": [
+    {
+      "case": "suspected_evil_twin_android_only",
+      "observations": [
+        {
+          "id": "obs_evil_001",
+          "schemaVersion": 1,
+          "source": "android_wifi",
+          "sourceDeviceId": "android_pixel_001",
+          "timestamp": 1777990200000,
+          "sessionId": "session_evil_001",
+          "ssid": "TrustedNet",
+          "bssid": "de:ad:be:ef:00:02",
+          "frequencyMhz": 2437,
+          "channel": 6,
+          "rssiDbm": -35,
+          "capabilities": "[WPA-PSK-TKIP][ESS]",
+          "oui": "Unknown",
+          "scanAgeMs": 940,
+          "cachedOrThrottled": "unknown",
+          "zoneLabel": "home-office"
+        }
+      ],
+      "alerts": [
+        {
+          "id": "alert_evil_001",
+          "schemaVersion": 1,
+          "type": "suspected_evil_twin",
+          "severity": "high",
+          "confidence": 0.75,
+          "title": "Suspected Evil Twin",
+          "explanation": "Known SSID was observed from an unfamiliar BSSID with changed security capabilities and unexpectedly strong RSSI. Confidence is capped because the source is Android WiFi scan evidence only.",
+          "evidence": [
+            {
+              "kind": "unknown_bssid",
+              "weight": 0.3,
+              "description": "TrustedNet is known, but BSSID de:ad:be:ef:00:02 is not in the trusted baseline.",
+              "observationIds": ["obs_evil_001"]
+            },
+            {
+              "kind": "security_change",
+              "weight": 0.2,
+              "description": "Observed capabilities differ from trusted baseline capabilities.",
+              "observationIds": ["obs_evil_001"]
+            },
+            {
+              "kind": "rssi_anomaly",
+              "weight": 0.15,
+              "description": "RSSI is stronger than expected for this zone baseline.",
+              "observationIds": ["obs_evil_001"]
+            }
+          ],
+          "limitations": [
+            "Android companion mode provides environmental WiFi scan evidence, not monitor-mode packet capture."
+          ],
+          "recommendedAction": "Avoid connecting until the AP is verified against trusted router inventory or monitor-mode evidence is available.",
+          "createdAt": 1777990201000,
+          "sourceDeviceIds": ["android_pixel_001"],
+          "detectorVersion": "phase6-wids-v1"
+        }
+      ]
+    },
+    {
+      "case": "possible_deauth_android_only_capped",
+      "observations": [
+        {
+          "id": "obs_deauth_android_001",
+          "schemaVersion": 1,
+          "source": "android_wifi",
+          "sourceDeviceId": "android_pixel_001",
+          "timestamp": 1777990300000,
+          "sessionId": "session_deauth_001",
+          "ssid": "TrustedNet",
+          "bssid": "aa:bb:cc:dd:ee:ff",
+          "frequencyMhz": 2412,
+          "channel": 1,
+          "rssiDbm": -82,
+          "capabilities": "[WPA2-PSK-CCMP][ESS]",
+          "scanAgeMs": 1300,
+          "cachedOrThrottled": "unknown",
+          "zoneLabel": "home-office"
+        }
+      ],
+      "alerts": [
+        {
+          "id": "alert_deauth_android_001",
+          "schemaVersion": 1,
+          "type": "possible_deauth",
+          "severity": "medium",
+          "confidence": 0.45,
+          "title": "Possible deauth-like disruption",
+          "explanation": "Trusted AP visibility and RSSI changed abruptly during a user-marked disruption window. Confidence is capped because normal Android WiFi APIs do not expose raw management frames.",
+          "evidence": [
+            {
+              "kind": "rssi_anomaly",
+              "weight": 0.2,
+              "description": "Trusted AP RSSI moved outside expected zone baseline during a disruption window.",
+              "observationIds": ["obs_deauth_android_001"]
+            },
+            {
+              "kind": "scan_throttling_possible",
+              "weight": 0.05,
+              "description": "Scan cadence and freshness may be affected by Android platform throttling or cached results.",
+              "observationIds": ["obs_deauth_android_001"]
+            }
+          ],
+          "limitations": [
+            "Normal Android WiFi APIs do not expose raw management frames; this alert is based on indirect scan/connectivity behavior and needs monitor-mode confirmation."
+          ],
+          "recommendedAction": "Correlate with Linux monitor-mode capture before treating this as confirmed management-frame DoS.",
+          "createdAt": 1777990301000,
+          "sourceDeviceIds": ["android_pixel_001"],
+          "detectorVersion": "phase6-wids-v1"
+        }
+      ]
+    },
+    {
+      "case": "management_frame_dos_monitor_mode",
+      "observations": [
+        {
+          "id": "obs_mfdos_001",
+          "schemaVersion": 1,
+          "source": "linux_monitor",
+          "sourceDeviceId": "desktop_adapter_mon0",
+          "timestamp": 1777990400000,
+          "sessionId": "session_mfdos_001",
+          "ssid": "TrustedNet",
+          "bssid": "aa:bb:cc:dd:ee:ff",
+          "frequencyMhz": 2412,
+          "channel": 1,
+          "rssiDbm": -48,
+          "capabilities": "monitor_frame_event:deauth_burst",
+          "scanAgeMs": 0,
+          "cachedOrThrottled": "no",
+          "zoneLabel": "home-office"
+        }
+      ],
+      "alerts": [
+        {
+          "id": "alert_mfdos_001",
+          "schemaVersion": 1,
+          "type": "management_frame_dos",
+          "severity": "critical",
+          "confidence": 0.9,
+          "title": "Management-frame DoS detected",
+          "explanation": "Monitor-mode source observed a repeated deauthentication burst against the trusted AP/channel.",
+          "evidence": [
+            {
+              "kind": "monitor_frame_event",
+              "weight": 0.6,
+              "description": "Linux monitor-mode source observed a deauthentication burst on channel 1 targeting the trusted BSSID.",
+              "observationIds": ["obs_mfdos_001"]
+            }
+          ],
+          "limitations": [],
+          "recommendedAction": "Preserve the capture/session artifact and inspect source/target frame details.",
+          "createdAt": 1777990401000,
+          "sourceDeviceIds": ["desktop_adapter_mon0"],
+          "detectorVersion": "phase6-wids-v1"
+        }
+      ]
+    },
+    {
+      "case": "recurring_radio_signature",
+      "observations": [
+        {
+          "id": "obs_recurring_001",
+          "schemaVersion": 1,
+          "source": "android_ble",
+          "sourceDeviceId": "android_pixel_001",
+          "timestamp": 1777990500000,
+          "sessionId": "session_recurring_001",
+          "bleAddress": "randomized-ble-signature-01",
+          "bleName": null,
+          "bleRssiDbm": -51,
+          "motionState": "still",
+          "scanAgeMs": 600,
+          "cachedOrThrottled": "unknown",
+          "zoneLabel": "home-office"
+        }
+      ],
+      "alerts": [
+        {
+          "id": "alert_recurring_001",
+          "schemaVersion": 1,
+          "type": "recurring_radio_signature",
+          "severity": "medium",
+          "confidence": 0.62,
+          "title": "Recurring nearby radio signature",
+          "explanation": "A nearby BLE/WiFi radio signature recurred near multiple user-marked incident windows. This is correlation evidence only.",
+          "evidence": [
+            {
+              "kind": "recurrence",
+              "weight": 0.35,
+              "description": "The same radio signature was observed across multiple incident windows.",
+              "observationIds": ["obs_recurring_001"]
+            },
+            {
+              "kind": "ble_correlation",
+              "weight": 0.15,
+              "description": "BLE signal appeared near the marked event window with similar RSSI trend.",
+              "observationIds": ["obs_recurring_001"]
+            }
+          ],
+          "limitations": [
+            "This identifies recurring radio observations, not a person, owner, or intent."
+          ],
+          "recommendedAction": "Continue collecting labeled observations before drawing conclusions.",
+          "createdAt": 1777990501000,
+          "sourceDeviceIds": ["android_pixel_001"],
+          "detectorVersion": "phase6-wids-v1"
+        }
+      ]
+    },
+    {
+      "case": "baseline_deviation",
+      "observations": [
+        {
+          "id": "obs_baseline_001",
+          "schemaVersion": 1,
+          "source": "desktop_wifi",
+          "sourceDeviceId": "desktop_iw_wlan0",
+          "timestamp": 1777990600000,
+          "sessionId": "session_baseline_001",
+          "ssid": "TrustedNet",
+          "bssid": "aa:bb:cc:dd:ee:ff",
+          "frequencyMhz": 5180,
+          "channel": 36,
+          "rssiDbm": -88,
+          "capabilities": "[WPA2-PSK-CCMP][ESS]",
+          "scanAgeMs": 300,
+          "cachedOrThrottled": "no",
+          "zoneLabel": "home-office"
+        }
+      ],
+      "alerts": [
+        {
+          "id": "alert_baseline_001",
+          "schemaVersion": 1,
+          "type": "baseline_deviation",
+          "severity": "low",
+          "confidence": 0.48,
+          "title": "Baseline deviation observed",
+          "explanation": "Trusted AP signal profile deviated from the expected zone baseline without enough evidence to classify as a specific attack.",
+          "evidence": [
+            {
+              "kind": "rssi_anomaly",
+              "weight": 0.2,
+              "description": "RSSI is outside the expected median/range for the selected zone.",
+              "observationIds": ["obs_baseline_001"]
+            },
+            {
+              "kind": "channel_change",
+              "weight": 0.1,
+              "description": "Observed channel differs from the most common baseline channel for this AP.",
+              "observationIds": ["obs_baseline_001"]
+            }
+          ],
+          "limitations": [
+            "Baseline deviation is an anomaly signal and does not identify cause by itself."
+          ],
+          "recommendedAction": "Collect additional observations and compare against trusted router inventory.",
+          "createdAt": 1777990601000,
+          "sourceDeviceIds": ["desktop_iw_wlan0"],
+          "detectorVersion": "phase6-wids-v1"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/contracts/fixtures/wids/trusted-network-drift.json
+++ b/docs/contracts/fixtures/wids/trusted-network-drift.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "detectorVersion": "phase6-wids-v1",
+  "case": "trusted_network_drift",
+  "observations": [
+    {
+      "id": "obs_tnd_001",
+      "schemaVersion": 1,
+      "source": "android_wifi",
+      "sourceDeviceId": "android_pixel_001",
+      "timestamp": 1777990100000,
+      "sessionId": "session_tnd_001",
+      "ssid": "TrustedNet",
+      "bssid": "de:ad:be:ef:00:01",
+      "frequencyMhz": 2462,
+      "channel": 11,
+      "rssiDbm": -42,
+      "capabilities": "[WPA2-PSK-CCMP][ESS]",
+      "oui": "Unknown",
+      "scanAgeMs": 720,
+      "cachedOrThrottled": "unknown",
+      "zoneLabel": "home-office"
+    }
+  ],
+  "alerts": [
+    {
+      "id": "alert_tnd_001",
+      "schemaVersion": 1,
+      "type": "trusted_network_drift",
+      "severity": "medium",
+      "confidence": 0.65,
+      "title": "Trusted network drift detected",
+      "explanation": "A known SSID was observed from a BSSID that is not present in the trusted baseline and on an unexpected channel.",
+      "evidence": [
+        {
+          "kind": "unknown_bssid",
+          "weight": 0.3,
+          "description": "TrustedNet is known, but BSSID de:ad:be:ef:00:01 is not in the trusted baseline.",
+          "observationIds": ["obs_tnd_001"]
+        },
+        {
+          "kind": "channel_change",
+          "weight": 0.15,
+          "description": "TrustedNet was observed on channel 11 instead of the expected channel set.",
+          "observationIds": ["obs_tnd_001"]
+        }
+      ],
+      "limitations": [
+        "Android companion mode provides environmental WiFi scan evidence, not monitor-mode packet capture."
+      ],
+      "recommendedAction": "Verify the BSSID against the trusted router inventory before connecting.",
+      "createdAt": 1777990101000,
+      "sourceDeviceIds": ["android_pixel_001"],
+      "detectorVersion": "phase6-wids-v1"
+    }
+  ]
+}

--- a/docs/contracts/wids-evidence-contract.md
+++ b/docs/contracts/wids-evidence-contract.md
@@ -1,0 +1,170 @@
+# wscan+ WIDS Evidence Contract
+
+Issue: #294
+Status: Phase 6 PR 1 scope — documentation and fixtures only
+
+## Purpose
+
+This contract defines the normalized evidence shape used by future wscan+ WIDS work across Android, desktop, and web UI surfaces.
+
+This PR intentionally changes no runtime code. It adds the platform-neutral contract and representative fixtures that later implementation PRs must conform to.
+
+## Principles
+
+- The repo-level contract is the source of truth.
+- Android, desktop, and web UI should adapt to this shape rather than inventing separate alert models.
+- Existing Android heuristics must be wrapped into this model later, not replaced.
+- Desktop detector output must be normalized into this model later, not duplicated.
+- Android normal WiFi scanning is not monitor-mode packet capture.
+- Android-only detections must carry source limitations and confidence caps.
+- Recurring radio signatures are correlation evidence, not attribution evidence.
+
+## Source types
+
+```json
+[
+  "android_wifi",
+  "android_ble",
+  "android_sensor",
+  "desktop_wifi",
+  "linux_monitor",
+  "adb",
+  "manual"
+]
+```
+
+## Observation object
+
+```json
+{
+  "id": "obs_001",
+  "schemaVersion": 1,
+  "source": "android_wifi",
+  "sourceDeviceId": "android_pixel_001",
+  "timestamp": 1777990000000,
+  "sessionId": "session_001",
+  "ssid": "TrustedNet",
+  "bssid": "aa:bb:cc:dd:ee:ff",
+  "frequencyMhz": 2412,
+  "channel": 1,
+  "rssiDbm": -54,
+  "capabilities": "[WPA2-PSK-CCMP][ESS]",
+  "oui": "Example Networks",
+  "bleAddress": null,
+  "bleName": null,
+  "bleRssiDbm": null,
+  "motionState": "still",
+  "magneticMagnitude": null,
+  "floorEstimate": null,
+  "scanAgeMs": 850,
+  "cachedOrThrottled": "unknown",
+  "zoneLabel": "home-office"
+}
+```
+
+## Alert object
+
+```json
+{
+  "id": "alert_001",
+  "schemaVersion": 1,
+  "type": "suspected_evil_twin",
+  "severity": "high",
+  "confidence": 0.75,
+  "title": "Suspected Evil Twin",
+  "explanation": "Known SSID was observed from an unfamiliar BSSID with changed security capabilities and abnormal RSSI behavior.",
+  "evidence": [],
+  "limitations": [],
+  "recommendedAction": "Avoid connecting until the AP is verified against the trusted router inventory.",
+  "createdAt": 1777990001000,
+  "sourceDeviceIds": ["android_pixel_001"],
+  "detectorVersion": "phase6-wids-v1"
+}
+```
+
+## Evidence item
+
+```json
+{
+  "kind": "unknown_bssid",
+  "weight": 0.3,
+  "description": "SSID matches a trusted network, but BSSID is not present in the trusted baseline.",
+  "observationIds": ["obs_001"]
+}
+```
+
+## Alert types
+
+- `trusted_network_drift`
+- `suspected_evil_twin`
+- `suspicious_rogue_ap`
+- `possible_deauth`
+- `management_frame_dos`
+- `recurring_radio_signature`
+- `baseline_deviation`
+- `android_scan_limited`
+
+## Evidence kinds
+
+- `ssid_match`
+- `unknown_bssid`
+- `security_change`
+- `channel_change`
+- `rssi_anomaly`
+- `multi_sensor_match`
+- `monitor_frame_event`
+- `ble_correlation`
+- `walk_test_inconsistency`
+- `baseline_missing`
+- `scan_throttling_possible`
+- `floor_or_zone_mismatch`
+- `recurrence`
+
+## Confidence caps
+
+These are contract rules for later implementation, not runtime code in this PR.
+
+| Scenario | Max confidence without stronger evidence |
+| --- | ---: |
+| Android-only suspected evil twin | 0.75 |
+| Android-only possible deauth-like disruption | 0.45 |
+| Android-only recurring radio signature | 0.65 |
+
+Monitor-mode, hardware-backed, or user-confirmed evidence may lift the cap if the evidence item explicitly records that stronger source.
+
+## Required limitations language
+
+Android-only WiFi alerts should include:
+
+```text
+Android companion mode provides environmental WiFi scan evidence, not monitor-mode packet capture.
+```
+
+Android-only possible deauth alerts should include:
+
+```text
+Normal Android WiFi APIs do not expose raw management frames; this alert is based on indirect scan/connectivity behavior and needs monitor-mode confirmation.
+```
+
+Recurring radio signature alerts should include:
+
+```text
+This identifies recurring radio observations, not a person, owner, or intent.
+```
+
+## Fixture files
+
+Representative fixtures live under:
+
+```text
+docs/contracts/fixtures/wids/
+```
+
+Required fixture coverage:
+
+- trusted network drift;
+- suspected evil twin;
+- Android-only possible deauth capped at 0.45;
+- monitor-mode management-frame DoS;
+- recurring radio signature;
+- baseline deviation.


### PR DESCRIPTION
Closes #294

## Summary

Adds the Phase 6 WIDS evidence contract and representative JSON fixtures.

This PR is intentionally documentation/fixtures only, following the quiz-gated implementation decision:

- shared JSON contract and fixtures first
- repo-level contract as source of truth
- no runtime behavior changes
- existing Android heuristics to be wrapped later, not replaced
- monorepo desktop/web dashboard remains canonical unless a tracked issue says otherwise

## Files added

- `docs/contracts/wids-evidence-contract.md`
- `docs/contracts/fixtures/wids/trusted-network-drift.json`
- `docs/contracts/fixtures/wids/phase6-wids-alert-fixtures.json`

## Fixture coverage

- trusted network drift
- suspected evil twin
- Android-only possible deauth capped at 0.45
- monitor-mode management-frame DoS
- recurring radio signature
- baseline deviation

## Out of scope / intentionally unchanged

- No Android runtime code changes
- No desktop detector changes
- No UI changes
- No scanner, permission, ADB, CTI, Gemini, Room, SQLCipher, or export implementation changes
- No ML or transformer IDS work

## Verification

Docs/fixtures only. No production code changed.