### PR TITLE
Fix deprecated Android 15 edge-to-edge window handling

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -12,6 +12,7 @@ import android.widget.TextView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import java.util.Locale
 
 object WscanUi {
@@ -28,10 +29,14 @@ object WscanUi {
 
     fun prepareWindow(activity: Activity) {
         WindowCompat.setDecorFitsSystemWindows(activity.window, false)
-        activity.window.statusBarColor = COLOR_NAVY
-        activity.window.navigationBarColor = COLOR_BG
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            activity.window.navigationBarDividerColor = COLOR_BG
+
+        WindowInsetsControllerCompat(activity.window, activity.window.decorView).apply {
+            isAppearanceLightStatusBars = false
+            isAppearanceLightNavigationBars = false
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            activity.window.isNavigationBarContrastEnforced = false
         }
     }
 

--- a/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt
@@ -30,6 +30,8 @@ object WscanUi {
     fun prepareWindow(activity: Activity) {
         WindowCompat.setDecorFitsSystemWindows(activity.window, false)
 
+        applyLegacySystemBarColors(activity)
+
         WindowInsetsControllerCompat(activity.window, activity.window.decorView).apply {
             isAppearanceLightStatusBars = false
             isAppearanceLightNavigationBars = false
@@ -37,6 +39,19 @@ object WscanUi {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             activity.window.isNavigationBarContrastEnforced = false
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun applyLegacySystemBarColors(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return
+        }
+
+        activity.window.statusBarColor = COLOR_NAVY
+        activity.window.navigationBarColor = COLOR_BG
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            activity.window.navigationBarDividerColor = COLOR_BG
         }
     }
 


### PR DESCRIPTION
## Summary

- Removes deprecated Android 15 system bar color mutations from `WscanUi.prepareWindow()`
- Keeps the existing View-based UI architecture intact
- Preserves existing inset handling and tactical dark theme behavior
- Replaces deprecated system-bar mutations with supported `WindowInsetsControllerCompat` handling

## Why

A quick audit after PR #293 identified an existing carried-forward issue in `WscanUi.kt`:

- `statusBarColor`
- `navigationBarColor`
- `navigationBarDividerColor`

These APIs are deprecated or ineffective for Android 15+ edge-to-edge behavior.

This PR intentionally stays surgical and does not introduce Compose, Navigation 3, MCP runtime wiring, or broader UI refactors.

## Scope

Changed:
- `android/app/src/main/kotlin/com/wscanplus/app/WscanUi.kt`

Not changed:
- scanner logic
- ADB transport
- detector logic
- desktop runtime
- Compose setup
- MCP runtime

## Test plan

- [ ] `cd android && ./gradlew :app:assembleDebug`
- [ ] `cd android && ./gradlew :core:ktlintCheck :app:ktlintCheck`
- [ ] Manual smoke test on Android 15+ device
- [ ] Verify content remains clear of system bars
- [ ] Verify status/navigation icon contrast remains readable
