### PR TITLE
docs: clarify Phase 6 web UI/dashboard wording

### DIFF
--- a/docs/research/wids_phase6_model_alignment_preflight_addendum.md
+++ b/docs/research/wids_phase6_model_alignment_preflight_addendum.md
@@ -1,0 +1,26 @@
+# Phase 6 Preflight Addendum — Web UI/Dashboard Wording Clarification
+
+Related issue: #299
+
+## Clarification
+
+References in the Phase 6 preflight document to a `web UI/dashboard` surface are architectural planning references only.
+
+They do **not** imply:
+
+- an existing `web/` directory
+- a currently implemented dashboard package
+- a finalized filesystem layout
+- a committed frontend runtime structure
+
+## Canonical Source of Truth
+
+Current repository structure and authoritative monorepo layout decisions remain governed by:
+
+- `docs/SESSION_STATE.md`
+
+Any future dashboard or web UI implementation paths must be introduced explicitly through tracked repository changes and associated implementation issues.
+
+## Intent of the Original Wording
+
+The original wording was intended to communicate ownership and governance alignment inside the monorepo boundary, not to document an already-existing runtime path.


### PR DESCRIPTION
## Summary

Adds an explicit clarification addendum for the Phase 6 preflight documentation to avoid implying that a concrete `web/` dashboard path already exists in the monorepo.

## Changes

- adds `docs/research/wids_phase6_model_alignment_preflight_addendum.md`
- clarifies the wording is architectural/planning guidance only
- points contributors to `docs/SESSION_STATE.md` as the canonical repo structure source
- references follow-up issue #299

## Scope

- docs only
- no runtime changes
- no repo restructuring
- no new implementation paths introduced
