### PR TITLE
docs(ui): add wscan design tokens and attribution notes

### DIFF
--- a/design/tokens/README.md
+++ b/design/tokens/README.md
@@ -1,0 +1,42 @@
+# wscan+ Design Tokens
+
+This directory contains the seed semantic token source for the wscan+ tactical/operator UI language.
+
+## Purpose
+
+The token file is not a decorative palette dump. It defines stable semantic names that can be mapped into:
+
+- desktop Electron CSS variables
+- Android View/Kotlin color constants
+- future Android Material 3 resources
+- web/PWA CSS variables
+- documentation and visual QA checklists
+
+## Current scope
+
+`wscan.tokens.json` is a source-of-truth seed for issue #301. The first implementation goal is consistency and traceability, not a full token build pipeline.
+
+Runtime wiring should happen in small follow-up PRs so desktop, Android, and any web UI can adopt the tokens without broad rewrites.
+
+## Naming rules
+
+Use semantic names tied to product meaning:
+
+- `color.canvas`
+- `color.panel`
+- `color.accentScan`
+- `color.threatCritical`
+- `color.rssiStrong`
+
+Avoid names tied only to appearance:
+
+- `blue500`
+- `redBright`
+- `cardColor2`
+
+## Guardrails
+
+- Do not vendor third-party design-system code into this directory without preserving upstream license notices.
+- Do not use tokens to imply detector certainty. Threat colors are severity/status UI tokens only.
+- Do not introduce paid map, font, icon, or theme dependencies as part of token adoption.
+- Keep Gemini/Vertex Android integration untouched.

--- a/design/tokens/wscan.tokens.json
+++ b/design/tokens/wscan.tokens.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json.schemastore.org/design-tokens.json",
+  "meta": {
+    "name": "wscan+ tactical operator tokens",
+    "status": "source-of-truth seed",
+    "issue": "#301"
+  },
+  "color": {
+    "canvas": { "value": "#0B1220" },
+    "panel": { "value": "#121A2B" },
+    "panelElevated": { "value": "#1A2336" },
+    "panelHover": { "value": "#24324A" },
+    "border": { "value": "#2A3850" },
+    "borderStrong": { "value": "#42526B" },
+    "accentScan": { "value": "#2AC3FF" },
+    "accentFocus": { "value": "#7C5CFF" },
+    "threatLow": { "value": "#2FBF71" },
+    "threatMedium": { "value": "#F2B94B" },
+    "threatHigh": { "value": "#FF8A3D" },
+    "threatCritical": { "value": "#FF5A5F" },
+    "rssiWeak": { "value": "#FF8A3D" },
+    "rssiModerate": { "value": "#F2B94B" },
+    "rssiStrong": { "value": "#2FBF71" },
+    "textStrong": { "value": "#F2F5F9" },
+    "text": { "value": "#D6DCE7" },
+    "textMuted": { "value": "#A4AFBF" },
+    "textDisabled": { "value": "#6B7586" },
+    "console": { "value": "#05070B" }
+  },
+  "radius": {
+    "sm": { "value": "6px" },
+    "md": { "value": "10px" },
+    "lg": { "value": "14px" },
+    "xl": { "value": "18px" },
+    "pill": { "value": "999px" }
+  },
+  "space": {
+    "1": { "value": "4px" },
+    "2": { "value": "8px" },
+    "3": { "value": "12px" },
+    "4": { "value": "16px" },
+    "5": { "value": "20px" },
+    "6": { "value": "24px" },
+    "8": { "value": "32px" }
+  },
+  "motion": {
+    "fast": { "value": "120ms" },
+    "medium": { "value": "200ms" }
+  }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,6 +8,12 @@
 - docs/research/spatial-map-provider-neutral-plan.md — provider-neutral spatial renderer plan (MapLibre primary, local fallback)
 - [docs/SESSION_STATE.md#2026-03-20-handoff-snapshot](docs/SESSION_STATE.md#2026-03-20-handoff-snapshot) — fastest re-entry point for the next AI session
 
+## Design / UI
+- docs/design/wscan_theme_token_strategy.md — shared token strategy for desktop, Android, and future web surfaces
+- docs/third-party-attribution.md — attribution notes for design-system and theme-generation influences
+- design/tokens/README.md — design-token source purpose, naming rules, and guardrails
+- design/tokens/wscan.tokens.json — seed semantic token source for wscan+ UI surfaces
+
 ## Device Testing
 - docs/testing/README.md — testing layout, rules, and per-device organization
 - docs/testing/scan-reliability-matrix.md — required matrix for Wi-Fi/BLE/cell scan behavior across connectivity, FGS, lockscreen, battery, and OEM states

--- a/docs/design/wscan_theme_token_strategy.md
+++ b/docs/design/wscan_theme_token_strategy.md
@@ -1,0 +1,67 @@
+# wscan+ Theme Token Strategy
+
+Issue: #301
+
+## Current state
+
+The active monorepo already contains the desktop Electron tactical shell under `desktop/`. The immediate need is not to re-port the archived desktop UI from scratch; it is to formalize the shared visual language so desktop, Android, and future web surfaces stay consistent.
+
+The first token source lives at:
+
+```text
+design/tokens/wscan.tokens.json
+```
+
+## Strategy
+
+Use one semantic token source and map it into platform-specific outputs over time.
+
+### Desktop Electron
+
+Map token values into CSS variables in `desktop/styles.css`.
+
+Preferred variable shape:
+
+```css
+--ws-color-canvas
+--ws-color-panel
+--ws-color-panel-elevated
+--ws-color-accent-scan
+--ws-color-threat-critical
+--ws-color-rssi-strong
+```
+
+The current short aliases such as `--bg`, `--surface`, and `--primary` can remain temporarily as compatibility aliases while the desktop UI is migrated.
+
+### Android View UI
+
+Map token values into `WscanUi` color constants or a future theme object.
+
+Current Android UI is View-based. Avoid broad Compose or AppCompat rewrites in token-only PRs. Theme preference work should be validated separately from visual-token adoption.
+
+### Future Material 3 path
+
+RikkaApps/MaterialThemeBuilder informed the theme-generation direction: use generated color resources where useful, but do not vendor generator code unless the upstream license notice is preserved.
+
+The initial wscan+ need is semantic mapping, not dynamic-color complexity.
+
+## Current vs planned map wording
+
+Current Android scan map behavior is local/offline heatmap rendering through `LocalHeatmapView` and GPS-tagged scan data.
+
+MapLibre is a planned free-only future migration path and must stay in its own dedicated map-provider issue/PR. Token PRs must not add map-provider dependencies.
+
+## PR sequencing
+
+1. Token source + docs.
+2. Desktop CSS semantic aliases.
+3. Android `WscanUi` token mapping.
+4. Future generated platform outputs only after review.
+
+## Guardrails
+
+- Do not vendor upstream UI repositories in the first implementation PR.
+- Do not copy icons, SVGs, USS/UXML, Kotlin generator code, or runtime helpers without preserving license notices.
+- Do not add fake detector output or claim confirmed threats from demo rows.
+- Do not touch Gemini/Vertex integration.
+- Keep each PR under the repo's one-work-unit rule.

--- a/docs/third-party-attribution.md
+++ b/docs/third-party-attribution.md
@@ -1,0 +1,52 @@
+# Third-Party Attribution Notes
+
+This file records design-system and theme-generation influences for wscan+.
+
+It is not a vendor manifest. If upstream code, assets, icons, SVGs, stylesheets, generators, or runtime helpers are copied or adapted later, the relevant upstream license files must be preserved alongside the copied material.
+
+## Sinan Ata / Leap of Legends — Unity UI Toolkit design-system influence
+
+The wscan+ design-system architecture was informed by the open-source Unity UI Toolkit design-system work by Sinan Ata / Leap of Legends.
+
+Useful adopted concepts:
+
+- tokenized visual language
+- reusable component discipline
+- showcase/test-harness style UI validation
+- mobile/desktop override thinking
+- production UI consistency over one-off screen styling
+
+Original source:
+
+```text
+https://github.com/sinanata/unity-ui-document-design-system
+```
+
+Compliance note:
+
+If any code, USS, UXML, SVG icons, runtime helpers, or assets from that repository are copied or adapted, preserve the upstream MIT license notice.
+
+## RikkaApps MaterialThemeBuilder — Android theme-generation influence
+
+The wscan+ Android theme-token strategy was informed by RikkaApps/MaterialThemeBuilder.
+
+Useful adopted concepts:
+
+- generated theme resources
+- light/dark token derivation
+- semantic color mapping before platform output
+- keeping generated theme artifacts reproducible
+
+Original source:
+
+```text
+https://github.com/RikkaApps/MaterialThemeBuilder
+```
+
+Compliance note:
+
+If generator code, Gradle logic, generated-resource templates, or other implementation code from that repository are copied or adapted, preserve the upstream license notice.
+
+## Current implementation stance
+
+The current #301 token seed does not vendor either upstream repository. It only documents design influence and creates a wscan+ owned token source.


### PR DESCRIPTION
Closes #301

## Summary

Adds the first wscan+ design-token seed and supporting design documentation.

This PR intentionally starts with the shared token source and attribution layer before wiring runtime CSS/Android constants. The monorepo already contains the tactical desktop shell under `desktop/`, so this work formalizes the design-system foundation rather than re-porting the archived shell from scratch.

## Changed

- Adds `design/tokens/wscan.tokens.json`
- Adds `design/tokens/README.md`
- Adds `docs/design/wscan_theme_token_strategy.md`
- Adds `docs/third-party-attribution.md`
- Adds `docs/INDEX.md` links for the new design/token docs

## Why

Issue #301 needs a traceable foundation for shared desktop/Android/web UI semantics:

- canvas/panel/border/text tokens
- scan accent token
- threat severity tokens
- RSSI strength tokens
- spacing/radius/motion tokens
- clear third-party attribution rules

## Guardrails followed

- Made by: GPT-5.5 Thinking via GitHub connector
- References exactly one GitHub Issue: #301
- One work unit: design-token source and docs only
- No new dependencies
- No runtime behavior changes
- No upstream repos vendored
- No copied third-party code/assets
- Gemini/Vertex integration untouched
- No map-provider dependency changes
- No detector logic or fake production alerts added

## Follow-up work

After this lands, smaller PRs can:

1. map token values into `desktop/styles.css` semantic `--ws-*` variables;
2. audit and replace desktop `innerHTML` sinks across renderer/support files with safe DOM construction;
3. map Android `WscanUi` colors to the token names;
4. add generated platform outputs only after review.

## Testing

Docs/token source only. No production code changed.

Checklist:

- [x] Made by: GPT-5.5 Thinking
- [x] References exactly one GitHub Issue
- [x] One feature OR one bugfix (not both)
- [x] No new dependencies mixed in
- [x] Documentation updated
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets of any kind committed
- [x] Gemini/Vertex integration untouched
