### PR TITLE
feat(android): add canonical evidence adapter layer

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/DetectionEvidenceEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/DetectionEvidenceEvent.kt
@@ -8,6 +8,9 @@ import com.wscanplus.core.threat.ThreatSource
  *
  * This model preserves existing detector confidence and reasons. It does not
  * upgrade confidence or imply attribution beyond the source signal.
+ *
+ * `detectedAtMs` is wall-clock epoch milliseconds from `ThreatSignal.detectedAt`.
+ * It does not necessarily share the same time basis as the linked observation.
  */
 data class DetectionEvidenceEvent(
     val id: String,
@@ -22,7 +25,7 @@ data class DetectionEvidenceEvent(
 ) {
     init {
         require(confidence in 0.0f..0.95f) {
-            "Confidence must be 0.0-0.95, was $confidence"
+            "Confidence must be 0.0–0.95, was $confidence"
         }
         require(reasons.size <= 3) {
             "Maximum 3 reasons, was ${reasons.size}"

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/DetectionEvidenceEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/DetectionEvidenceEvent.kt
@@ -1,0 +1,31 @@
+package com.wscanplus.core.evidence
+
+import com.wscanplus.core.threat.HeuristicType
+import com.wscanplus.core.threat.ThreatSource
+
+/**
+ * Canonical detector evidence derived from existing threat signals.
+ *
+ * This model preserves existing detector confidence and reasons. It does not
+ * upgrade confidence or imply attribution beyond the source signal.
+ */
+data class DetectionEvidenceEvent(
+    val id: String,
+    val observationId: String,
+    val source: ThreatSource,
+    val heuristicType: HeuristicType?,
+    val confidence: Float,
+    val reasons: List<String>,
+    val bssid: String,
+    val detectedAtMs: Long,
+    val schemaVersion: Int = 1,
+) {
+    init {
+        require(confidence in 0.0f..0.95f) {
+            "Confidence must be 0.0-0.95, was $confidence"
+        }
+        require(reasons.size <= 3) {
+            "Maximum 3 reasons, was ${reasons.size}"
+        }
+    }
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -8,14 +8,21 @@ import com.wscanplus.core.threat.ThreatSignal
 fun WifiScanResult.toObservationEvent(id: String? = null): ObservationEvent {
     val scanInput = toScanInput()
     val observationId = id ?: wifiObservationId(scanInput.bssid, scanInput.timestamp)
-    return scanInput.toObservationEvent(id = observationId)
+    return scanInput.toObservationEvent(
+        id = observationId,
+        observedAtBasis = TimeBasis.ELAPSED_REALTIME,
+    )
 }
 
-fun ScanInput.toObservationEvent(id: String = wifiObservationId(bssid, timestamp)): ObservationEvent =
+fun ScanInput.toObservationEvent(
+    id: String = wifiObservationId(bssid, timestamp),
+    observedAtBasis: TimeBasis = TimeBasis.EPOCH,
+): ObservationEvent =
     ObservationEvent(
         id = id,
-        source = ObservationSource.ANDROID_WIFI_SCAN,
+        source = ObservationSource.ANDROID_WIFI,
         observedAtMs = timestamp,
+        observedAtBasis = observedAtBasis,
         wifi =
             WifiObservationEvidence(
                 ssid = ssid,

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -5,7 +5,7 @@ import com.wscanplus.core.scanner.toScanInput
 import com.wscanplus.core.threat.ScanInput
 import com.wscanplus.core.threat.ThreatSignal
 
-fun WifiScanResult.toObservationEvent(id: String = wifiObservationId(bssid, timestamp)): ObservationEvent =
+fun WifiScanResult.toObservationEvent(id: String = wifiObservationId(bssid, timestamp / 1000)): ObservationEvent =
     toScanInput().toObservationEvent(id = id)
 
 fun ScanInput.toObservationEvent(id: String = wifiObservationId(bssid, timestamp)): ObservationEvent =

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -5,8 +5,11 @@ import com.wscanplus.core.scanner.toScanInput
 import com.wscanplus.core.threat.ScanInput
 import com.wscanplus.core.threat.ThreatSignal
 
-fun WifiScanResult.toObservationEvent(id: String = wifiObservationId(bssid, timestamp / 1000)): ObservationEvent =
-    toScanInput().toObservationEvent(id = id)
+fun WifiScanResult.toObservationEvent(id: String? = null): ObservationEvent {
+    val scanInput = toScanInput()
+    val observationId = id ?: wifiObservationId(scanInput.bssid, scanInput.timestamp)
+    return scanInput.toObservationEvent(id = observationId)
+}
 
 fun ScanInput.toObservationEvent(id: String = wifiObservationId(bssid, timestamp)): ObservationEvent =
     ObservationEvent(

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -1,0 +1,52 @@
+package com.wscanplus.core.evidence
+
+import com.wscanplus.core.scanner.WifiScanResult
+import com.wscanplus.core.scanner.toScanInput
+import com.wscanplus.core.threat.ScanInput
+import com.wscanplus.core.threat.ThreatSignal
+
+fun WifiScanResult.toObservationEvent(id: String = wifiObservationId(bssid, timestamp)): ObservationEvent =
+    toScanInput().toObservationEvent(id = id)
+
+fun ScanInput.toObservationEvent(id: String = wifiObservationId(bssid, timestamp)): ObservationEvent =
+    ObservationEvent(
+        id = id,
+        source = ObservationSource.ANDROID_WIFI_SCAN,
+        observedAtMs = timestamp,
+        wifi =
+            WifiObservationEvidence(
+                ssid = ssid,
+                bssid = bssid,
+                hiddenSsid = isHidden,
+                rssiDbm = rssiDbm,
+                frequencyMhz = frequencyMhz,
+                channelWidth = channelWidth,
+                capabilities = capabilities,
+            ),
+    )
+
+fun ThreatSignal.toDetectionEvidenceEvent(
+    observation: ObservationEvent,
+    id: String = detectionEvidenceId(bssid, detectedAt, heuristicType?.name),
+): DetectionEvidenceEvent =
+    DetectionEvidenceEvent(
+        id = id,
+        observationId = observation.id,
+        source = source,
+        heuristicType = heuristicType,
+        confidence = confidence,
+        reasons = reasons,
+        bssid = bssid,
+        detectedAtMs = detectedAt,
+    )
+
+private fun wifiObservationId(
+    bssid: String,
+    observedAtMs: Long,
+): String = "android-wifi:${bssid.lowercase()}:$observedAtMs"
+
+private fun detectionEvidenceId(
+    bssid: String,
+    detectedAtMs: Long,
+    heuristicType: String?,
+): String = "detection:${bssid.lowercase()}:${heuristicType ?: "unknown"}:$detectedAtMs"

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -16,7 +16,7 @@ fun WifiScanResult.toObservationEvent(id: String? = null): ObservationEvent {
 
 fun ScanInput.toObservationEvent(
     id: String = wifiObservationId(bssid, timestamp),
-    observedAtBasis: TimeBasis = TimeBasis.EPOCH,
+    observedAtBasis: TimeBasis = TimeBasis.ELAPSED_REALTIME,
 ): ObservationEvent =
     ObservationEvent(
         id = id,

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -15,8 +15,8 @@ fun WifiScanResult.toObservationEvent(id: String? = null): ObservationEvent {
 }
 
 fun ScanInput.toObservationEvent(
+    observedAtBasis: TimeBasis,
     id: String = wifiObservationId(bssid, timestamp),
-    observedAtBasis: TimeBasis = TimeBasis.ELAPSED_REALTIME,
 ): ObservationEvent =
     ObservationEvent(
         id = id,
@@ -38,8 +38,11 @@ fun ScanInput.toObservationEvent(
 fun ThreatSignal.toDetectionEvidenceEvent(
     observation: ObservationEvent,
     id: String = detectionEvidenceId(bssid, detectedAt, heuristicType?.name),
-): DetectionEvidenceEvent =
-    DetectionEvidenceEvent(
+): DetectionEvidenceEvent {
+    require(observation.wifi.bssid.equals(bssid, ignoreCase = true)) {
+        "Observation BSSID must match threat signal BSSID"
+    }
+    return DetectionEvidenceEvent(
         id = id,
         observationId = observation.id,
         source = source,
@@ -49,11 +52,12 @@ fun ThreatSignal.toDetectionEvidenceEvent(
         bssid = bssid,
         detectedAtMs = detectedAt,
     )
+}
 
 private fun wifiObservationId(
     bssid: String,
     observedAtMs: Long,
-): String = "android-wifi:${bssid.lowercase()}:$observedAtMs"
+): String = "${ObservationSource.ANDROID_WIFI.contractValue}:${bssid.lowercase()}:$observedAtMs"
 
 private fun detectionEvidenceId(
     bssid: String,

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
@@ -1,0 +1,29 @@
+package com.wscanplus.core.evidence
+
+/**
+ * Canonical factual observation captured by wscan+.
+ *
+ * Observation events are facts only. They do not imply malicious activity,
+ * attribution, or detector confidence by themselves.
+ */
+data class ObservationEvent(
+    val id: String,
+    val source: ObservationSource,
+    val observedAtMs: Long,
+    val wifi: WifiObservationEvidence,
+    val schemaVersion: Int = 1,
+)
+
+enum class ObservationSource {
+    ANDROID_WIFI_SCAN,
+}
+
+data class WifiObservationEvidence(
+    val ssid: String,
+    val bssid: String,
+    val hiddenSsid: Boolean,
+    val rssiDbm: Int,
+    val frequencyMhz: Int,
+    val channelWidth: Int,
+    val capabilities: String,
+)

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
@@ -6,19 +6,26 @@ package com.wscanplus.core.evidence
  * Observation events are facts only. They do not imply malicious activity,
  * attribution, or detector confidence by themselves.
  *
- * `observedAtMs` uses the Android Wi-Fi scan elapsed-realtime basis converted
- * to milliseconds, not wall-clock epoch milliseconds.
+ * `observedAtMs` preserves the timestamp supplied by the source adapter. Use
+ * `observedAtBasis` to determine whether that value is elapsed realtime or
+ * wall-clock epoch milliseconds.
  */
 data class ObservationEvent(
     val id: String,
     val source: ObservationSource,
     val observedAtMs: Long,
+    val observedAtBasis: TimeBasis,
     val wifi: WifiObservationEvidence,
     val schemaVersion: Int = 1,
 )
 
-enum class ObservationSource {
-    ANDROID_WIFI_SCAN,
+enum class ObservationSource(val contractValue: String) {
+    ANDROID_WIFI("android_wifi"),
+}
+
+enum class TimeBasis {
+    ELAPSED_REALTIME,
+    EPOCH,
 }
 
 data class WifiObservationEvidence(

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
@@ -5,6 +5,9 @@ package com.wscanplus.core.evidence
  *
  * Observation events are facts only. They do not imply malicious activity,
  * attribution, or detector confidence by themselves.
+ *
+ * `observedAtMs` uses the Android Wi-Fi scan elapsed-realtime basis converted
+ * to milliseconds, not wall-clock epoch milliseconds.
  */
 data class ObservationEvent(
     val id: String,

--- a/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
@@ -41,6 +41,27 @@ class EvidenceMappersTest {
     }
 
     @Test
+    fun `WifiScanResult default ID uses same millisecond timestamp as observation`() {
+        val result =
+            WifiScanResult(
+                ssid = "LabNet",
+                bssid = "AA:BB:CC:DD:EE:FF",
+                signalLevel = -42,
+                frequencyMhz = 2412,
+                capabilities = "[WPA2-PSK-CCMP][ESS]",
+                timestamp = 123_456_000L,
+                channelWidth = 0,
+                centerFreq0 = 0,
+                centerFreq1 = 0,
+            )
+
+        val event = result.toObservationEvent()
+
+        assertEquals(123_456L, event.observedAtMs)
+        assertEquals("android-wifi:aa:bb:cc:dd:ee:ff:123456", event.id)
+    }
+
+    @Test
     fun `hidden SSID remains an observed fact only`() {
         val input =
             ScanInput(

--- a/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
@@ -29,8 +29,10 @@ class EvidenceMappersTest {
         val event = result.toObservationEvent(id = "obs-1")
 
         assertEquals("obs-1", event.id)
-        assertEquals(ObservationSource.ANDROID_WIFI_SCAN, event.source)
+        assertEquals(ObservationSource.ANDROID_WIFI, event.source)
+        assertEquals("android_wifi", event.source.contractValue)
         assertEquals(123_456L, event.observedAtMs)
+        assertEquals(TimeBasis.ELAPSED_REALTIME, event.observedAtBasis)
         assertEquals("LabNet", event.wifi.ssid)
         assertEquals("AA:BB:CC:DD:EE:FF", event.wifi.bssid)
         assertFalse(event.wifi.hiddenSsid)
@@ -58,6 +60,7 @@ class EvidenceMappersTest {
         val event = result.toObservationEvent()
 
         assertEquals(123_456L, event.observedAtMs)
+        assertEquals(TimeBasis.ELAPSED_REALTIME, event.observedAtBasis)
         assertEquals("android-wifi:aa:bb:cc:dd:ee:ff:123456", event.id)
     }
 
@@ -79,7 +82,8 @@ class EvidenceMappersTest {
 
         assertEquals("", event.wifi.ssid)
         assertTrue(event.wifi.hiddenSsid)
-        assertEquals(ObservationSource.ANDROID_WIFI_SCAN, event.source)
+        assertEquals(ObservationSource.ANDROID_WIFI, event.source)
+        assertEquals(TimeBasis.EPOCH, event.observedAtBasis)
     }
 
     @Test
@@ -127,6 +131,20 @@ class EvidenceMappersTest {
             heuristicType = HeuristicType.EVIL_TWIN,
             confidence = 0.96f,
             reasons = listOf("too high"),
+            bssid = "AA:BB:CC:DD:EE:FF",
+            detectedAtMs = 1L,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `DetectionEvidenceEvent enforces reason count cap`() {
+        DetectionEvidenceEvent(
+            id = "bad-reasons",
+            observationId = "obs",
+            source = ThreatSource.LOCAL_HEURISTIC,
+            heuristicType = HeuristicType.EVIL_TWIN,
+            confidence = 0.45f,
+            reasons = listOf("one", "two", "three", "four"),
             bssid = "AA:BB:CC:DD:EE:FF",
             detectedAtMs = 1L,
         )

--- a/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
@@ -43,7 +43,7 @@ class EvidenceMappersTest {
     }
 
     @Test
-    fun `WifiScanResult default ID uses same millisecond timestamp as observation`() {
+    fun `WifiScanResult default ID uses contract source and observation timestamp`() {
         val result =
             WifiScanResult(
                 ssid = "LabNet",
@@ -61,7 +61,7 @@ class EvidenceMappersTest {
 
         assertEquals(123_456L, event.observedAtMs)
         assertEquals(TimeBasis.ELAPSED_REALTIME, event.observedAtBasis)
-        assertEquals("android-wifi:aa:bb:cc:dd:ee:ff:123456", event.id)
+        assertEquals("android_wifi:aa:bb:cc:dd:ee:ff:123456", event.id)
     }
 
     @Test
@@ -78,7 +78,11 @@ class EvidenceMappersTest {
                 timestamp = 321L,
             )
 
-        val event = input.toObservationEvent(id = "obs-hidden")
+        val event =
+            input.toObservationEvent(
+                id = "obs-hidden",
+                observedAtBasis = TimeBasis.EPOCH,
+            )
 
         assertEquals("", event.wifi.ssid)
         assertTrue(event.wifi.hiddenSsid)
@@ -98,7 +102,10 @@ class EvidenceMappersTest {
                 frequencyMhz = 2412,
                 channelWidth = 0,
                 timestamp = 1_000L,
-            ).toObservationEvent(id = "obs-1")
+            ).toObservationEvent(
+                id = "obs-1",
+                observedAtBasis = TimeBasis.ELAPSED_REALTIME,
+            )
 
         val signal =
             ThreatSignal(
@@ -120,6 +127,33 @@ class EvidenceMappersTest {
         assertEquals(listOf("Observed RSSI anomaly"), evidence.reasons)
         assertEquals("AA:BB:CC:DD:EE:FF", evidence.bssid)
         assertEquals(2_000L, evidence.detectedAtMs)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `ThreatSignal evidence requires matching observation bssid`() {
+        val observation =
+            ScanInput(
+                bssid = "11:22:33:44:55:66",
+                ssid = "OtherNet",
+                isHidden = false,
+                capabilities = "[WPA2-PSK-CCMP][ESS]",
+                rssiDbm = -50,
+                frequencyMhz = 2412,
+                channelWidth = 0,
+                timestamp = 1_000L,
+            ).toObservationEvent(
+                id = "obs-other",
+                observedAtBasis = TimeBasis.ELAPSED_REALTIME,
+            )
+
+        ThreatSignal(
+            confidence = 0.45f,
+            source = ThreatSource.LOCAL_HEURISTIC,
+            reasons = listOf("Observed RSSI anomaly"),
+            heuristicType = HeuristicType.RSSI_ANOMALY,
+            bssid = "AA:BB:CC:DD:EE:FF",
+            detectedAt = 2_000L,
+        ).toDetectionEvidenceEvent(observation = observation, id = "bad-link")
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
@@ -1,0 +1,113 @@
+package com.wscanplus.core.evidence
+
+import com.wscanplus.core.scanner.WifiScanResult
+import com.wscanplus.core.threat.HeuristicType
+import com.wscanplus.core.threat.ScanInput
+import com.wscanplus.core.threat.ThreatSignal
+import com.wscanplus.core.threat.ThreatSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EvidenceMappersTest {
+    @Test
+    fun `WifiScanResult maps factual fields into observation event`() {
+        val result =
+            WifiScanResult(
+                ssid = "LabNet",
+                bssid = "AA:BB:CC:DD:EE:FF",
+                signalLevel = -42,
+                frequencyMhz = 2412,
+                capabilities = "[WPA2-PSK-CCMP][ESS]",
+                timestamp = 123_456_000L,
+                channelWidth = 0,
+                centerFreq0 = 0,
+                centerFreq1 = 0,
+            )
+
+        val event = result.toObservationEvent(id = "obs-1")
+
+        assertEquals("obs-1", event.id)
+        assertEquals(ObservationSource.ANDROID_WIFI_SCAN, event.source)
+        assertEquals(123_456L, event.observedAtMs)
+        assertEquals("LabNet", event.wifi.ssid)
+        assertEquals("AA:BB:CC:DD:EE:FF", event.wifi.bssid)
+        assertFalse(event.wifi.hiddenSsid)
+        assertEquals(-42, event.wifi.rssiDbm)
+        assertEquals(2412, event.wifi.frequencyMhz)
+        assertEquals(0, event.wifi.channelWidth)
+        assertEquals("[WPA2-PSK-CCMP][ESS]", event.wifi.capabilities)
+    }
+
+    @Test
+    fun `hidden SSID remains an observed fact only`() {
+        val input =
+            ScanInput(
+                bssid = "11:22:33:44:55:66",
+                ssid = "",
+                isHidden = true,
+                capabilities = "[ESS]",
+                rssiDbm = -65,
+                frequencyMhz = 5180,
+                channelWidth = 1,
+                timestamp = 321L,
+            )
+
+        val event = input.toObservationEvent(id = "obs-hidden")
+
+        assertEquals("", event.wifi.ssid)
+        assertTrue(event.wifi.hiddenSsid)
+        assertEquals(ObservationSource.ANDROID_WIFI_SCAN, event.source)
+    }
+
+    @Test
+    fun `ThreatSignal maps to detection evidence without changing confidence or reasons`() {
+        val observation =
+            ScanInput(
+                bssid = "AA:BB:CC:DD:EE:FF",
+                ssid = "LabNet",
+                isHidden = false,
+                capabilities = "[WPA2-PSK-CCMP][ESS]",
+                rssiDbm = -31,
+                frequencyMhz = 2412,
+                channelWidth = 0,
+                timestamp = 1_000L,
+            ).toObservationEvent(id = "obs-1")
+
+        val signal =
+            ThreatSignal(
+                confidence = 0.45f,
+                source = ThreatSource.LOCAL_HEURISTIC,
+                reasons = listOf("Observed RSSI anomaly"),
+                heuristicType = HeuristicType.RSSI_ANOMALY,
+                bssid = "AA:BB:CC:DD:EE:FF",
+                detectedAt = 2_000L,
+            )
+
+        val evidence = signal.toDetectionEvidenceEvent(observation = observation, id = "ev-1")
+
+        assertEquals("ev-1", evidence.id)
+        assertEquals("obs-1", evidence.observationId)
+        assertEquals(ThreatSource.LOCAL_HEURISTIC, evidence.source)
+        assertEquals(HeuristicType.RSSI_ANOMALY, evidence.heuristicType)
+        assertEquals(0.45f, evidence.confidence)
+        assertEquals(listOf("Observed RSSI anomaly"), evidence.reasons)
+        assertEquals("AA:BB:CC:DD:EE:FF", evidence.bssid)
+        assertEquals(2_000L, evidence.detectedAtMs)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `DetectionEvidenceEvent enforces existing confidence cap`() {
+        DetectionEvidenceEvent(
+            id = "bad",
+            observationId = "obs",
+            source = ThreatSource.LOCAL_HEURISTIC,
+            heuristicType = HeuristicType.EVIL_TWIN,
+            confidence = 0.96f,
+            reasons = listOf("too high"),
+            bssid = "AA:BB:CC:DD:EE:FF",
+            detectedAtMs = 1L,
+        )
+    }
+}


### PR DESCRIPTION
Closes #305

## Summary

Adds the first Android/core runtime bridge between existing scan/heuristic objects and canonical evidence-style events.

This is intentionally adapter-first and behavior-preserving.

## Changed

- Adds `ObservationEvent` and `WifiObservationEvidence`
- Adds `DetectionEvidenceEvent`
- Adds mapper functions:
  - `WifiScanResult -> ObservationEvent`
  - `ScanInput -> ObservationEvent`
  - `ThreatSignal + ObservationEvent -> DetectionEvidenceEvent`
- Adds focused unit tests for factual WiFi mapping, hidden SSID handling, confidence preservation, reason preservation, and confidence cap enforcement

## Scope controls

- Android/core only
- No detector behavior changes
- No new heuristics
- No database migration
- No UI changes
- No desktop changes
- No SDR work
- No MapLibre/osmdroid work
- No ntfy work
- No AI/Gemini changes
- No attack attribution claims

## Verification

Not run in connector environment.

Required before merge:

```bash
cd android && ./gradlew :core:test :core:ktlintCheck
```

## Note

The branch was created from the latest merged commit available through connector search, then compared against current `main`. The PR diff against current `main` is limited to the four intended Android/core evidence files, but the branch may require updating from `main` before merge if GitHub marks it out of date.

Checklist:

- [x] Made by: GPT-5.5 Thinking via GitHub connector
- [x] References exactly one GitHub Issue
- [x] One feature OR one bugfix, not both
- [x] No new dependencies
- [x] Documentation contract already exists; implementation references existing model direction
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets of any kind committed
- [x] Gemini/Vertex integration untouched