### PR TITLE
ci: add Android core validation workflow

### DIFF
--- a/.github/workflows/android-core.yml
+++ b/.github/workflows/android-core.yml
@@ -1,0 +1,79 @@
+name: Android Core CI
+
+on:
+  pull_request:
+    paths:
+      - "android/**"
+      - ".github/workflows/android-core.yml"
+  push:
+    branches: [main]
+    paths:
+      - "android/**"
+      - ".github/workflows/android-core.yml"
+  workflow_dispatch:
+
+jobs:
+  android-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache Gradle packages
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission to gradlew
+        working-directory: android
+        run: chmod +x ./gradlew
+
+      - name: Write mock google-services.json for CI
+        run: |
+          cat > android/app/google-services.json << 'EOF'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "ci-placeholder",
+              "storage_bucket": "ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": {
+                    "package_name": "com.wscanplus.app"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [{ "current_key": "CI_PLACEHOLDER" }],
+                "services": { "appinvite_service": { "other_platform_oauth_client": [] } }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          EOF
+
+      - name: Run core unit tests
+        working-directory: android
+        run: ./gradlew --no-daemon :core:test
+
+      - name: Run core ktlint
+        working-directory: android
+        run: ./gradlew --no-daemon :core:ktlintCheck


### PR DESCRIPTION
Closes #308

## Summary

Adds a dedicated Android Core CI workflow that validates Android core changes with unit tests and ktlint.

## Changed

- Adds `.github/workflows/android-core.yml`
- Runs on Android-related PRs and pushes to `main`
- Supports manual dispatch
- Sets up JDK 17
- Caches Gradle packages
- Writes the same mock `google-services.json` pattern used by Copilot setup
- Runs:

```bash
cd android
./gradlew --no-daemon :core:test
./gradlew --no-daemon :core:ktlintCheck
```

## Scope controls

- CI only
- No app/runtime code changes
- No desktop/npm checks
- No real Firebase/Gemini secrets required

## Notes

The workflow intentionally focuses on `:core:test` and `:core:ktlintCheck` so Android core model/adapter changes such as PR #306 get automatic validation.