### PR TITLE
feat(android): add baseline drift detector

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/baseline/BaselineProfile.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/baseline/BaselineProfile.kt
@@ -1,0 +1,29 @@
+package com.wscanplus.core.baseline
+
+/**
+ * Trusted wireless baseline for a labeled zone.
+ *
+ * This model is intentionally small for the first detector slice. Persistence,
+ * enrollment UX, and multi-source baselines can build on top of it later.
+ */
+data class BaselineProfile(
+    val id: String,
+    val zoneLabel: String,
+    val trustedAccessPoints: List<TrustedApProfile>,
+    val schemaVersion: Int = 1,
+)
+
+data class TrustedApProfile(
+    val ssid: String,
+    val bssid: String,
+    val expectedFrequenciesMhz: Set<Int>,
+    val expectedCapabilities: Set<String>,
+    val rssiMedianDbm: Int? = null,
+    val rssiToleranceDb: Int? = null,
+) {
+    init {
+        require(rssiToleranceDb == null || rssiToleranceDb >= 0) {
+            "RSSI tolerance must be non-negative"
+        }
+    }
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/baseline/BaselineProfile.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/baseline/BaselineProfile.kt
@@ -22,6 +22,9 @@ data class TrustedApProfile(
     val rssiToleranceDb: Int? = null,
 ) {
     init {
+        require((rssiMedianDbm == null) == (rssiToleranceDb == null)) {
+            "RSSI median and tolerance must both be set or both be null"
+        }
         require(rssiToleranceDb == null || rssiToleranceDb >= 0) {
             "RSSI tolerance must be non-negative"
         }

--- a/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
@@ -79,12 +79,18 @@ class TrustedNetworkDriftDetector {
             null
         }
 
-    private fun TrustedApProfile.capabilitiesReason(capabilities: String): TrustedNetworkDriftReason? =
-        if (expectedCapabilities.isNotEmpty() && capabilities !in expectedCapabilities) {
+    private fun TrustedApProfile.capabilitiesReason(capabilities: String): TrustedNetworkDriftReason? {
+        if (expectedCapabilities.isEmpty()) return null
+
+        val observedCapabilities = capabilities.normalizedCapabilityTokens()
+        val expectedCapabilitySets = expectedCapabilities.map { it.normalizedCapabilityTokens() }
+
+        return if (observedCapabilities !in expectedCapabilitySets) {
             TrustedNetworkDriftReason.CAPABILITIES_CHANGED
         } else {
             null
         }
+    }
 
     private fun TrustedApProfile.rssiReason(rssiDbm: Int): TrustedNetworkDriftReason? {
         val median = rssiMedianDbm ?: return null
@@ -103,3 +109,10 @@ class TrustedNetworkDriftDetector {
             else -> 0.45f
         }.coerceAtMost(ANDROID_ONLY_CONFIDENCE_CAP)
 }
+
+private fun String.normalizedCapabilityTokens(): Set<String> =
+    Regex("\\[([^\\]]+)]")
+        .findAll(this)
+        .map { it.groupValues[1].trim().uppercase() }
+        .filter { it.isNotEmpty() }
+        .toSet()

--- a/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
@@ -1,0 +1,98 @@
+package com.wscanplus.core.detector
+
+import com.wscanplus.core.baseline.BaselineProfile
+import com.wscanplus.core.baseline.TrustedApProfile
+import com.wscanplus.core.evidence.ObservationEvent
+
+private const val ANDROID_ONLY_CONFIDENCE_CAP = 0.75f
+
+data class TrustedNetworkDriftResult(
+    val observationId: String,
+    val ssid: String,
+    val bssid: String,
+    val confidence: Float,
+    val reasons: List<String>,
+    val limitations: List<String>,
+) {
+    init {
+        require(confidence in 0.0f..ANDROID_ONLY_CONFIDENCE_CAP) {
+            "Confidence must be 0.0–$ANDROID_ONLY_CONFIDENCE_CAP, was $confidence"
+        }
+        require(reasons.isNotEmpty()) {
+            "Trusted network drift result requires at least one reason"
+        }
+        require(reasons.size <= 3) {
+            "Maximum 3 reasons, was ${reasons.size}"
+        }
+    }
+}
+
+class TrustedNetworkDriftDetector {
+    fun evaluate(
+        observation: ObservationEvent,
+        baseline: BaselineProfile,
+    ): TrustedNetworkDriftResult? {
+        val wifi = observation.wifi
+        val sameSsidProfiles = baseline.trustedAccessPoints.filter { it.ssid == wifi.ssid }
+        if (sameSsidProfiles.isEmpty()) return null
+
+        val matchingBssidProfile =
+            sameSsidProfiles.firstOrNull { it.bssid.equals(wifi.bssid, ignoreCase = true) }
+
+        val reasons = mutableListOf<String>()
+
+        if (matchingBssidProfile == null) {
+            reasons += "Known SSID observed with untrusted BSSID"
+        } else {
+            reasons += matchingBssidProfile.frequencyReason(wifi.frequencyMhz)
+            reasons += matchingBssidProfile.capabilitiesReason(wifi.capabilities)
+            reasons += matchingBssidProfile.rssiReason(wifi.rssiDbm)
+        }
+
+        val filteredReasons = reasons.filterNotNull().take(3)
+        if (filteredReasons.isEmpty()) return null
+
+        return TrustedNetworkDriftResult(
+            observationId = observation.id,
+            ssid = wifi.ssid,
+            bssid = wifi.bssid,
+            confidence = confidenceFor(filteredReasons),
+            reasons = filteredReasons,
+            limitations = listOf(
+                "Android Wi-Fi observations are scan snapshots, not monitor-mode packet captures.",
+                "This detector reports baseline drift only; it does not confirm an evil twin or identify an attacker.",
+            ),
+        )
+    }
+
+    private fun TrustedApProfile.frequencyReason(frequencyMhz: Int): String? =
+        if (expectedFrequenciesMhz.isNotEmpty() && frequencyMhz !in expectedFrequenciesMhz) {
+            "Trusted BSSID observed on unexpected frequency"
+        } else {
+            null
+        }
+
+    private fun TrustedApProfile.capabilitiesReason(capabilities: String): String? =
+        if (expectedCapabilities.isNotEmpty() && capabilities !in expectedCapabilities) {
+            "Trusted BSSID capabilities changed from baseline"
+        } else {
+            null
+        }
+
+    private fun TrustedApProfile.rssiReason(rssiDbm: Int): String? {
+        val median = rssiMedianDbm ?: return null
+        val tolerance = rssiToleranceDb ?: return null
+        return if (kotlin.math.abs(rssiDbm - median) > tolerance) {
+            "Trusted BSSID RSSI outside baseline tolerance"
+        } else {
+            null
+        }
+    }
+
+    private fun confidenceFor(reasons: List<String>): Float =
+        when {
+            reasons.any { it.contains("untrusted BSSID") } -> 0.65f
+            reasons.size >= 2 -> 0.60f
+            else -> 0.45f
+        }.coerceAtMost(ANDROID_ONLY_CONFIDENCE_CAP)
+}

--- a/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
@@ -60,7 +60,7 @@ class TrustedNetworkDriftDetector {
             reasons = filteredReasons,
             limitations = listOf(
                 "Android Wi-Fi observations are scan snapshots, not monitor-mode packet captures.",
-                "This detector reports baseline drift only; it does not confirm an evil twin or identify an attacker.",
+                "This detector reports baseline drift only; it does not confirm an evil twin or identify a responsible person or device owner.",
             ),
         )
     }

--- a/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
@@ -27,7 +27,9 @@ data class TrustedNetworkDriftResult(
     }
 }
 
-private enum class TrustedNetworkDriftReason(val description: String) {
+private enum class TrustedNetworkDriftReason(
+    val description: String,
+) {
     UNTRUSTED_BSSID("Known SSID observed with untrusted BSSID"),
     UNEXPECTED_FREQUENCY("Trusted BSSID observed on unexpected frequency"),
     CAPABILITIES_CHANGED("Trusted BSSID capabilities changed from baseline"),
@@ -65,10 +67,11 @@ class TrustedNetworkDriftDetector {
             bssid = wifi.bssid,
             confidence = confidenceFor(filteredReasons),
             reasons = filteredReasons.map { it.description },
-            limitations = listOf(
-                "Android Wi-Fi observations are scan snapshots, not monitor-mode packet captures.",
-                "This detector reports baseline drift only; it does not confirm an evil twin or identify a responsible person or device owner.",
-            ),
+            limitations =
+                listOf(
+                    "Android Wi-Fi observations are scan snapshots, not monitor-mode packet captures.",
+                    "This detector reports baseline drift only; it does not confirm an evil twin or identify a responsible person or device owner.",
+                ),
         )
     }
 

--- a/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetector.kt
@@ -27,6 +27,13 @@ data class TrustedNetworkDriftResult(
     }
 }
 
+private enum class TrustedNetworkDriftReason(val description: String) {
+    UNTRUSTED_BSSID("Known SSID observed with untrusted BSSID"),
+    UNEXPECTED_FREQUENCY("Trusted BSSID observed on unexpected frequency"),
+    CAPABILITIES_CHANGED("Trusted BSSID capabilities changed from baseline"),
+    RSSI_OUTSIDE_TOLERANCE("Trusted BSSID RSSI outside baseline tolerance"),
+}
+
 class TrustedNetworkDriftDetector {
     fun evaluate(
         observation: ObservationEvent,
@@ -39,17 +46,17 @@ class TrustedNetworkDriftDetector {
         val matchingBssidProfile =
             sameSsidProfiles.firstOrNull { it.bssid.equals(wifi.bssid, ignoreCase = true) }
 
-        val reasons = mutableListOf<String>()
+        val driftReasons = mutableListOf<TrustedNetworkDriftReason>()
 
         if (matchingBssidProfile == null) {
-            reasons += "Known SSID observed with untrusted BSSID"
+            driftReasons += TrustedNetworkDriftReason.UNTRUSTED_BSSID
         } else {
-            reasons += matchingBssidProfile.frequencyReason(wifi.frequencyMhz)
-            reasons += matchingBssidProfile.capabilitiesReason(wifi.capabilities)
-            reasons += matchingBssidProfile.rssiReason(wifi.rssiDbm)
+            matchingBssidProfile.frequencyReason(wifi.frequencyMhz)?.let { driftReasons += it }
+            matchingBssidProfile.capabilitiesReason(wifi.capabilities)?.let { driftReasons += it }
+            matchingBssidProfile.rssiReason(wifi.rssiDbm)?.let { driftReasons += it }
         }
 
-        val filteredReasons = reasons.filterNotNull().take(3)
+        val filteredReasons = driftReasons.take(3)
         if (filteredReasons.isEmpty()) return null
 
         return TrustedNetworkDriftResult(
@@ -57,7 +64,7 @@ class TrustedNetworkDriftDetector {
             ssid = wifi.ssid,
             bssid = wifi.bssid,
             confidence = confidenceFor(filteredReasons),
-            reasons = filteredReasons,
+            reasons = filteredReasons.map { it.description },
             limitations = listOf(
                 "Android Wi-Fi observations are scan snapshots, not monitor-mode packet captures.",
                 "This detector reports baseline drift only; it does not confirm an evil twin or identify a responsible person or device owner.",
@@ -65,33 +72,33 @@ class TrustedNetworkDriftDetector {
         )
     }
 
-    private fun TrustedApProfile.frequencyReason(frequencyMhz: Int): String? =
+    private fun TrustedApProfile.frequencyReason(frequencyMhz: Int): TrustedNetworkDriftReason? =
         if (expectedFrequenciesMhz.isNotEmpty() && frequencyMhz !in expectedFrequenciesMhz) {
-            "Trusted BSSID observed on unexpected frequency"
+            TrustedNetworkDriftReason.UNEXPECTED_FREQUENCY
         } else {
             null
         }
 
-    private fun TrustedApProfile.capabilitiesReason(capabilities: String): String? =
+    private fun TrustedApProfile.capabilitiesReason(capabilities: String): TrustedNetworkDriftReason? =
         if (expectedCapabilities.isNotEmpty() && capabilities !in expectedCapabilities) {
-            "Trusted BSSID capabilities changed from baseline"
+            TrustedNetworkDriftReason.CAPABILITIES_CHANGED
         } else {
             null
         }
 
-    private fun TrustedApProfile.rssiReason(rssiDbm: Int): String? {
+    private fun TrustedApProfile.rssiReason(rssiDbm: Int): TrustedNetworkDriftReason? {
         val median = rssiMedianDbm ?: return null
         val tolerance = rssiToleranceDb ?: return null
         return if (kotlin.math.abs(rssiDbm - median) > tolerance) {
-            "Trusted BSSID RSSI outside baseline tolerance"
+            TrustedNetworkDriftReason.RSSI_OUTSIDE_TOLERANCE
         } else {
             null
         }
     }
 
-    private fun confidenceFor(reasons: List<String>): Float =
+    private fun confidenceFor(reasons: List<TrustedNetworkDriftReason>): Float =
         when {
-            reasons.any { it.contains("untrusted BSSID") } -> 0.65f
+            TrustedNetworkDriftReason.UNTRUSTED_BSSID in reasons -> 0.65f
             reasons.size >= 2 -> 0.60f
             else -> 0.45f
         }.coerceAtMost(ANDROID_ONLY_CONFIDENCE_CAP)

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/ObservationEvent.kt
@@ -19,7 +19,9 @@ data class ObservationEvent(
     val schemaVersion: Int = 1,
 )
 
-enum class ObservationSource(val contractValue: String) {
+enum class ObservationSource(
+    val contractValue: String,
+) {
     ANDROID_WIFI("android_wifi"),
 }
 

--- a/android/core/src/test/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetectorTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetectorTest.kt
@@ -63,6 +63,17 @@ class TrustedNetworkDriftDetectorTest {
     }
 
     @Test
+    fun `does not flag equivalent capability strings with reordered tokens`() {
+        val result =
+            detector.evaluate(
+                observation(capabilities = "[ess][wpa2-psk-ccmp]"),
+                baseline(),
+            )
+
+        assertNull(result)
+    }
+
+    @Test
     fun `detects trusted BSSID RSSI outside baseline tolerance`() {
         val result =
             detector.evaluate(
@@ -122,6 +133,18 @@ class TrustedNetworkDriftDetectorTest {
         val text = (result!!.reasons + result.limitations).joinToString(" ").lowercase()
         assertTrue("should not claim confirmed evil twin", "confirmed evil twin" !in text)
         assertTrue("should not claim attacker identity", "attacker" !in text)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `requires RSSI median and tolerance to be configured together`() {
+        TrustedApProfile(
+            ssid = "HomeNet",
+            bssid = "AA:BB:CC:DD:EE:FF",
+            expectedFrequenciesMhz = setOf(2412),
+            expectedCapabilities = setOf("[WPA2-PSK-CCMP][ESS]"),
+            rssiMedianDbm = -45,
+            rssiToleranceDb = null,
+        )
     }
 
     private fun assertAndroidOnlyLimitations(result: TrustedNetworkDriftResult) {

--- a/android/core/src/test/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetectorTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/detector/TrustedNetworkDriftDetectorTest.kt
@@ -1,0 +1,176 @@
+package com.wscanplus.core.detector
+
+import com.wscanplus.core.baseline.BaselineProfile
+import com.wscanplus.core.baseline.TrustedApProfile
+import com.wscanplus.core.evidence.ObservationEvent
+import com.wscanplus.core.evidence.ObservationSource
+import com.wscanplus.core.evidence.TimeBasis
+import com.wscanplus.core.evidence.WifiObservationEvidence
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrustedNetworkDriftDetectorTest {
+    private val detector = TrustedNetworkDriftDetector()
+
+    @Test
+    fun `returns null for known access point within baseline`() {
+        val result = detector.evaluate(observation(), baseline())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `detects known SSID with unknown BSSID`() {
+        val result =
+            detector.evaluate(
+                observation(bssid = "11:22:33:44:55:66"),
+                baseline(),
+            )
+
+        assertNotNull(result)
+        assertEquals(listOf("Known SSID observed with untrusted BSSID"), result!!.reasons)
+        assertEquals(0.65f, result.confidence)
+        assertAndroidOnlyLimitations(result)
+    }
+
+    @Test
+    fun `detects trusted BSSID on unexpected frequency`() {
+        val result =
+            detector.evaluate(
+                observation(frequencyMhz = 2462),
+                baseline(),
+            )
+
+        assertNotNull(result)
+        assertEquals(listOf("Trusted BSSID observed on unexpected frequency"), result!!.reasons)
+        assertEquals(0.45f, result.confidence)
+    }
+
+    @Test
+    fun `detects trusted BSSID capability drift`() {
+        val result =
+            detector.evaluate(
+                observation(capabilities = "[WPA-PSK-TKIP][ESS]"),
+                baseline(),
+            )
+
+        assertNotNull(result)
+        assertEquals(listOf("Trusted BSSID capabilities changed from baseline"), result!!.reasons)
+        assertEquals(0.45f, result.confidence)
+    }
+
+    @Test
+    fun `detects trusted BSSID RSSI outside baseline tolerance`() {
+        val result =
+            detector.evaluate(
+                observation(rssiDbm = -75),
+                baseline(),
+            )
+
+        assertNotNull(result)
+        assertEquals(listOf("Trusted BSSID RSSI outside baseline tolerance"), result!!.reasons)
+        assertEquals(0.45f, result.confidence)
+    }
+
+    @Test
+    fun `combines multiple trusted BSSID drift reasons without exceeding confidence cap`() {
+        val result =
+            detector.evaluate(
+                observation(
+                    frequencyMhz = 2462,
+                    capabilities = "[WPA-PSK-TKIP][ESS]",
+                    rssiDbm = -75,
+                ),
+                baseline(),
+            )
+
+        assertNotNull(result)
+        assertEquals(
+            listOf(
+                "Trusted BSSID observed on unexpected frequency",
+                "Trusted BSSID capabilities changed from baseline",
+                "Trusted BSSID RSSI outside baseline tolerance",
+            ),
+            result!!.reasons,
+        )
+        assertTrue(result.confidence <= 0.75f)
+    }
+
+    @Test
+    fun `ignores observations for SSIDs not present in baseline`() {
+        val result =
+            detector.evaluate(
+                observation(ssid = "CoffeeShop"),
+                baseline(),
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `does not use confirmed attack or attribution wording`() {
+        val result =
+            detector.evaluate(
+                observation(bssid = "11:22:33:44:55:66"),
+                baseline(),
+            )
+
+        assertNotNull(result)
+        val text = (result!!.reasons + result.limitations).joinToString(" ").lowercase()
+        assertTrue("should not claim confirmed evil twin", "confirmed evil twin" !in text)
+        assertTrue("should not claim attacker identity", "attacker" !in text)
+    }
+
+    private fun assertAndroidOnlyLimitations(result: TrustedNetworkDriftResult) {
+        assertTrue(
+            result.limitations.any { it.contains("scan snapshots") },
+        )
+        assertTrue(
+            result.limitations.any { it.contains("does not confirm") },
+        )
+    }
+
+    private fun baseline(): BaselineProfile =
+        BaselineProfile(
+            id = "home",
+            zoneLabel = "Home",
+            trustedAccessPoints =
+                listOf(
+                    TrustedApProfile(
+                        ssid = "HomeNet",
+                        bssid = "AA:BB:CC:DD:EE:FF",
+                        expectedFrequenciesMhz = setOf(2412),
+                        expectedCapabilities = setOf("[WPA2-PSK-CCMP][ESS]"),
+                        rssiMedianDbm = -45,
+                        rssiToleranceDb = 15,
+                    ),
+                ),
+        )
+
+    private fun observation(
+        ssid: String = "HomeNet",
+        bssid: String = "AA:BB:CC:DD:EE:FF",
+        frequencyMhz: Int = 2412,
+        capabilities: String = "[WPA2-PSK-CCMP][ESS]",
+        rssiDbm: Int = -45,
+    ): ObservationEvent =
+        ObservationEvent(
+            id = "obs-1",
+            source = ObservationSource.ANDROID_WIFI,
+            observedAtMs = 1_000L,
+            observedAtBasis = TimeBasis.ELAPSED_REALTIME,
+            wifi =
+                WifiObservationEvidence(
+                    ssid = ssid,
+                    bssid = bssid,
+                    hiddenSsid = ssid.isBlank(),
+                    rssiDbm = rssiDbm,
+                    frequencyMhz = frequencyMhz,
+                    channelWidth = 0,
+                    capabilities = capabilities,
+                ),
+        )
+}


### PR DESCRIPTION
Closes #310

## Summary

Adds the first baseline comparison detector for Android/core: a trusted-network drift detector that compares `ObservationEvent` Wi-Fi facts against a small trusted AP baseline.

## Changed

- Adds `BaselineProfile` and `TrustedApProfile`
- Adds `TrustedNetworkDriftDetector`
- Adds `TrustedNetworkDriftResult`
- Adds unit tests for:
  - no alert for known AP within baseline
  - known SSID with unknown BSSID
  - unexpected frequency
  - capability drift
  - RSSI outside tolerance
  - combined drift reasons with Android-only confidence cap
  - unknown SSID ignored
  - no confirmed attack / attribution wording

## Scope controls

- Android/core only
- No UI changes
- No database or persistence migration
- No desktop changes
- No Android scanner behavior changes
- No ML
- No SDR
- No monitor-mode assumptions
- No deauth claims
- No broad detector runner yet

## Verification

Expected to be validated by Android Core CI:

```bash
cd android
./gradlew --no-daemon :core:test
./gradlew --no-daemon :core:ktlintCheck
```

## Notes

The detector intentionally reports baseline drift only. It does not claim confirmed evil twin behavior or identify a responsible person/device owner from Android scan snapshots.