### PR TITLE
chore: add root editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts,java}]
+indent_size = 4
+max_line_length = 120
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+
+[*.{xml,html,css,scss,json,yml,yaml,md,sh,properties,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf

--- a/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/DiagnosticActivity.kt
@@ -100,9 +100,17 @@ class DiagnosticActivity : Activity() {
         val binder = boundBinder
         if (binder == null) {
             if (serviceBound) {
-                renderServicePlaceholder("CONNECTING", "Waiting for WatchdogService binder callback…", WscanUi.COLOR_WARN)
+                renderServicePlaceholder(
+                    "CONNECTING",
+                    "Waiting for WatchdogService binder callback…",
+                    WscanUi.COLOR_WARN,
+                )
             } else {
-                renderServicePlaceholder("NOT RUNNING", "Start scanning from the main screen, then return here.", WscanUi.COLOR_BAD)
+                renderServicePlaceholder(
+                    "NOT RUNNING",
+                    "Start scanning from the main screen, then return here.",
+                    WscanUi.COLOR_BAD,
+                )
             }
             return
         }
@@ -131,7 +139,12 @@ class DiagnosticActivity : Activity() {
                 "${caps.wifiRtt.toReadyLabel()} · now=${caps.wifiRttAvailableNow}",
                 WscanUi.statusColor(caps.wifiRtt),
             )
-            WscanUi.metricRow(capsCard, "Wi-Fi Aware", caps.wifiAware.toReadyLabel(), WscanUi.statusColor(caps.wifiAware))
+            WscanUi.metricRow(
+                capsCard,
+                "Wi-Fi Aware",
+                caps.wifiAware.toReadyLabel(),
+                WscanUi.statusColor(caps.wifiAware),
+            )
             WscanUi.metricRow(capsCard, "UWB", caps.uwb.toReadyLabel(), WscanUi.statusColor(caps.uwb))
             WscanUi.metricRow(capsCard, "Barometer", caps.barometer.toReadyLabel(), WscanUi.statusColor(caps.barometer))
             WscanUi.metricRow(capsCard, "BLE", caps.bluetoothLe.toReadyLabel(), WscanUi.statusColor(caps.bluetoothLe))
@@ -142,8 +155,18 @@ class DiagnosticActivity : Activity() {
                 if (hasCamera) "READY" else "UNAVAILABLE",
                 if (hasCamera) WscanUi.COLOR_OK else WscanUi.COLOR_BAD,
             )
-            WscanUi.metricRow(capsCard, "Depth camera (ToF)", caps.cameraIrCapable.toDisplayLabel(), caps.cameraIrCapable.statusColor())
-            WscanUi.metricRow(capsCard, "Acoustic", caps.acousticSonarCapable.toDisplayLabel(), caps.acousticSonarCapable.statusColor())
+            WscanUi.metricRow(
+                capsCard,
+                "Depth camera (ToF)",
+                caps.cameraIrCapable.toDisplayLabel(),
+                caps.cameraIrCapable.statusColor(),
+            )
+            WscanUi.metricRow(
+                capsCard,
+                "Acoustic",
+                caps.acousticSonarCapable.toDisplayLabel(),
+                caps.acousticSonarCapable.statusColor(),
+            )
         } else {
             WscanUi.body(capsCard, "Capability probe has not completed yet.", muted = true)
         }
@@ -221,7 +244,8 @@ class DiagnosticActivity : Activity() {
             AcousticStatus.DEVICE_VARIABLE -> "DEVICE VARIABLE"
         }
 
-    private fun formatMs(epochMs: Long): String = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault()).format(Date(epochMs))
+    private fun formatMs(epochMs: Long): String =
+        SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault()).format(Date(epochMs))
 
     companion object {
         @Suppress("unused")

--- a/android/app/src/main/kotlin/com/wscanplus/app/ScanHistoryActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ScanHistoryActivity.kt
@@ -26,7 +26,11 @@ class ScanHistoryActivity : Activity() {
         title = "Scan History"
 
         val root = WscanUi.shell(this)
-        WscanUi.header(root, "Scan History", "Recent scanner sessions, AP observations, threat counts, and narrative availability")
+        WscanUi.header(
+            root,
+            "Scan History",
+            "Recent scanner sessions, AP observations, threat counts, and narrative availability",
+        )
         val scrollView = ScrollView(this).apply { isFillViewport = true }
         contentLayout =
             LinearLayout(this).apply {

--- a/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/ThreatResultsActivity.kt
@@ -38,7 +38,11 @@ class ThreatResultsActivity : Activity() {
         title = "Threat Results"
 
         val root = WscanUi.shell(this)
-        WscanUi.header(root, "Threat Results", "Recent scan sessions with persisted Gemini narratives and local threat context")
+        WscanUi.header(
+            root,
+            "Threat Results",
+            "Recent scan sessions with persisted Gemini narratives and local threat context",
+        )
         val scrollView = ScrollView(this).apply { isFillViewport = true }
         contentLayout =
             LinearLayout(this).apply {
@@ -165,7 +169,9 @@ class ThreatResultsActivity : Activity() {
             card.addView(bodyText(narrative.narrative))
             card.addView(
                 mutedText(
-                    "Generated ${formatTimestamp(narrative.generatedAt)}  •  ${narrative.signalCount} signals  •  ${narrative.modelName}",
+                    "Generated ${formatTimestamp(
+                        narrative.generatedAt,
+                    )}  •  ${narrative.signalCount} signals  •  ${narrative.modelName}",
                 ),
             )
         } else {

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -610,7 +610,8 @@ class WatchdogService : Service() {
         )
     }
 
-    private fun buildDeviceIdentifier(): String = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID) ?: "unknown-device"
+    private fun buildDeviceIdentifier(): String =
+        Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID) ?: "unknown-device"
 
     @Suppress("DEPRECATION")
     private fun buildHelloDeviceId(): String {

--- a/android/app/src/main/kotlin/com/wscanplus/app/db/DbPassphraseProvider.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/db/DbPassphraseProvider.kt
@@ -69,6 +69,9 @@ class DbPassphraseProvider(
 
         private fun bytesToHex(bytes: ByteArray): String = bytes.joinToString("") { "%02x".format(it) }
 
-        private fun hexToBytes(hex: String): ByteArray = ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+        private fun hexToBytes(hex: String): ByteArray =
+            ByteArray(hex.length / 2) {
+                hex.substring(it * 2, it * 2 + 2).toInt(16).toByte()
+            }
     }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/DetectorGateTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/DetectorGateTest.kt
@@ -15,85 +15,211 @@ class DetectorGateTest {
         acoustic: AcousticStatus = AcousticStatus.UNTESTED,
         bluetoothLe: Boolean = false,
         nsd: Boolean = false,
-    ) = DeviceCapabilityManifest(
-        deviceModel = "Test",
-        wifiScan = wifiScan,
-        wifiRtt = wifiRtt,
-        wifiAware = false,
-        uwb = uwb,
-        barometer = barometer,
-        nsd = nsd,
-        bluetoothLe = bluetoothLe,
-        proximity = false,
-        magnetometer = false,
-        accelerometer = false,
-        gyroscope = false,
-        wifiRttAvailableNow = wifiRttAvailableNow,
-        cameraIrCapable = cameraIr,
-        acousticSonarCapable = acoustic,
-    )
+    ) =
+        DeviceCapabilityManifest(
+            deviceModel = "Test",
+            wifiScan = wifiScan,
+            wifiRtt = wifiRtt,
+            wifiAware = false,
+            uwb = uwb,
+            barometer = barometer,
+            nsd = nsd,
+            bluetoothLe = bluetoothLe,
+            proximity = false,
+            magnetometer = false,
+            accelerometer = false,
+            gyroscope = false,
+            wifiRttAvailableNow = wifiRttAvailableNow,
+            cameraIrCapable = cameraIr,
+            acousticSonarCapable = acoustic,
+        )
 
     @Test
     fun wifiScan_requires_wifiScan_true() {
-        assertFalse(DetectorGate.canRun(manifest(wifiScan = false), DetectorGate.DetectorRequirement.WIFI_SCAN))
-        assertTrue(DetectorGate.canRun(manifest(wifiScan = true), DetectorGate.DetectorRequirement.WIFI_SCAN))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(wifiScan = false),
+                DetectorGate.DetectorRequirement.WIFI_SCAN,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(wifiScan = true),
+                DetectorGate.DetectorRequirement.WIFI_SCAN,
+            ),
+        )
     }
 
     @Test
     fun wifiRtt_requires_both_rtt_flags() {
-        assertFalse(DetectorGate.canRun(manifest(wifiRtt = true, wifiRttAvailableNow = false), DetectorGate.DetectorRequirement.WIFI_RTT))
-        assertFalse(DetectorGate.canRun(manifest(wifiRtt = false, wifiRttAvailableNow = true), DetectorGate.DetectorRequirement.WIFI_RTT))
-        assertTrue(DetectorGate.canRun(manifest(wifiRtt = true, wifiRttAvailableNow = true), DetectorGate.DetectorRequirement.WIFI_RTT))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(
+                    wifiRtt = true,
+                    wifiRttAvailableNow = false,
+                ),
+                DetectorGate.DetectorRequirement.WIFI_RTT,
+            ),
+        )
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(
+                    wifiRtt = false,
+                    wifiRttAvailableNow = true,
+                ),
+                DetectorGate.DetectorRequirement.WIFI_RTT,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(
+                    wifiRtt = true,
+                    wifiRttAvailableNow = true,
+                ),
+                DetectorGate.DetectorRequirement.WIFI_RTT,
+            ),
+        )
     }
 
     @Test
     fun uwbRanging_requires_uwb() {
-        assertFalse(DetectorGate.canRun(manifest(uwb = false), DetectorGate.DetectorRequirement.UWB_RANGING))
-        assertTrue(DetectorGate.canRun(manifest(uwb = true), DetectorGate.DetectorRequirement.UWB_RANGING))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(uwb = false),
+                DetectorGate.DetectorRequirement.UWB_RANGING,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(uwb = true),
+                DetectorGate.DetectorRequirement.UWB_RANGING,
+            ),
+        )
     }
 
     @Test
     fun floorInference_requires_barometer() {
-        assertFalse(DetectorGate.canRun(manifest(barometer = false), DetectorGate.DetectorRequirement.FLOOR_INFERENCE))
-        assertTrue(DetectorGate.canRun(manifest(barometer = true), DetectorGate.DetectorRequirement.FLOOR_INFERENCE))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(barometer = false),
+                DetectorGate.DetectorRequirement.FLOOR_INFERENCE,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(barometer = true),
+                DetectorGate.DetectorRequirement.FLOOR_INFERENCE,
+            ),
+        )
     }
 
     @Test
     fun cameraIrSweep_capable_and_partial_allowed() {
-        assertFalse(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.UNTESTED), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
-        assertFalse(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.NOT_CAPABLE), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
-        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.CAPABLE), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
-        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.PARTIAL), DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.UNTESTED),
+                DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP,
+            ),
+        )
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.NOT_CAPABLE),
+                DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.CAPABLE),
+                DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.PARTIAL),
+                DetectorGate.DetectorRequirement.CAMERA_IR_SWEEP,
+            ),
+        )
     }
 
     @Test
     fun glintSweep_same_as_cameraIr() {
-        assertFalse(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.UNTESTED), DetectorGate.DetectorRequirement.GLINT_SWEEP))
-        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.CAPABLE), DetectorGate.DetectorRequirement.GLINT_SWEEP))
-        assertTrue(DetectorGate.canRun(manifest(cameraIr = CameraIrStatus.PARTIAL), DetectorGate.DetectorRequirement.GLINT_SWEEP))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.UNTESTED),
+                DetectorGate.DetectorRequirement.GLINT_SWEEP,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.CAPABLE),
+                DetectorGate.DetectorRequirement.GLINT_SWEEP,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(cameraIr = CameraIrStatus.PARTIAL),
+                DetectorGate.DetectorRequirement.GLINT_SWEEP,
+            ),
+        )
     }
 
     @Test
     fun acousticPresence_requires_capable_only() {
-        assertFalse(DetectorGate.canRun(manifest(acoustic = AcousticStatus.UNTESTED), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE))
         assertFalse(
-            DetectorGate.canRun(manifest(acoustic = AcousticStatus.NOT_CAPABLE), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE),
+            DetectorGate.canRun(
+                manifest(acoustic = AcousticStatus.UNTESTED),
+                DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE,
+            ),
         )
         assertFalse(
-            DetectorGate.canRun(manifest(acoustic = AcousticStatus.DEVICE_VARIABLE), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE),
+            DetectorGate.canRun(
+                manifest(acoustic = AcousticStatus.NOT_CAPABLE),
+                DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE,
+            ),
         )
-        assertTrue(DetectorGate.canRun(manifest(acoustic = AcousticStatus.CAPABLE), DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(acoustic = AcousticStatus.DEVICE_VARIABLE),
+                DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(acoustic = AcousticStatus.CAPABLE),
+                DetectorGate.DetectorRequirement.ACOUSTIC_PRESENCE,
+            ),
+        )
     }
 
     @Test
     fun bleScan_requires_bluetoothLe() {
-        assertFalse(DetectorGate.canRun(manifest(bluetoothLe = false), DetectorGate.DetectorRequirement.BLE_SCAN))
-        assertTrue(DetectorGate.canRun(manifest(bluetoothLe = true), DetectorGate.DetectorRequirement.BLE_SCAN))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(bluetoothLe = false),
+                DetectorGate.DetectorRequirement.BLE_SCAN,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(bluetoothLe = true),
+                DetectorGate.DetectorRequirement.BLE_SCAN,
+            ),
+        )
     }
 
     @Test
     fun nsdDiscovery_requires_nsd() {
-        assertFalse(DetectorGate.canRun(manifest(nsd = false), DetectorGate.DetectorRequirement.NSD_DISCOVERY))
-        assertTrue(DetectorGate.canRun(manifest(nsd = true), DetectorGate.DetectorRequirement.NSD_DISCOVERY))
+        assertFalse(
+            DetectorGate.canRun(
+                manifest(nsd = false),
+                DetectorGate.DetectorRequirement.NSD_DISCOVERY,
+            ),
+        )
+        assertTrue(
+            DetectorGate.canRun(
+                manifest(nsd = true),
+                DetectorGate.DetectorRequirement.NSD_DISCOVERY,
+            ),
+        )
     }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/capabilities/DetectorGateTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/capabilities/DetectorGateTest.kt
@@ -15,24 +15,23 @@ class DetectorGateTest {
         acoustic: AcousticStatus = AcousticStatus.UNTESTED,
         bluetoothLe: Boolean = false,
         nsd: Boolean = false,
-    ) =
-        DeviceCapabilityManifest(
-            deviceModel = "Test",
-            wifiScan = wifiScan,
-            wifiRtt = wifiRtt,
-            wifiAware = false,
-            uwb = uwb,
-            barometer = barometer,
-            nsd = nsd,
-            bluetoothLe = bluetoothLe,
-            proximity = false,
-            magnetometer = false,
-            accelerometer = false,
-            gyroscope = false,
-            wifiRttAvailableNow = wifiRttAvailableNow,
-            cameraIrCapable = cameraIr,
-            acousticSonarCapable = acoustic,
-        )
+    ) = DeviceCapabilityManifest(
+        deviceModel = "Test",
+        wifiScan = wifiScan,
+        wifiRtt = wifiRtt,
+        wifiAware = false,
+        uwb = uwb,
+        barometer = barometer,
+        nsd = nsd,
+        bluetoothLe = bluetoothLe,
+        proximity = false,
+        magnetometer = false,
+        accelerometer = false,
+        gyroscope = false,
+        wifiRttAvailableNow = wifiRttAvailableNow,
+        cameraIrCapable = cameraIr,
+        acousticSonarCapable = acoustic,
+    )
 
     @Test
     fun wifiScan_requires_wifiScan_true() {

--- a/android/core/src/main/kotlin/com/wscanplus/core/db/WscanDatabase.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/db/WscanDatabase.kt
@@ -81,7 +81,11 @@ abstract class WscanDatabase : RoomDatabase() {
                         context.applicationContext,
                         WscanDatabase::class.java,
                         "wscan.db",
-                    ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                    ).addMigrations(
+                        MIGRATION_1_2,
+                        MIGRATION_2_3,
+                        MIGRATION_3_4,
+                    )
             factory?.let { builder.openHelperFactory(it) }
             return builder.build()
         }
@@ -123,8 +127,18 @@ abstract class WscanDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    db.execSQL("CREATE INDEX IF NOT EXISTS index_gemini_narratives_sessionId ON gemini_narratives (sessionId)")
-                    db.execSQL("CREATE INDEX IF NOT EXISTS index_gemini_narratives_generatedAt ON gemini_narratives (generatedAt)")
+                    db.execSQL(
+                        """
+                        CREATE INDEX IF NOT EXISTS index_gemini_narratives_sessionId
+                        ON gemini_narratives (sessionId)
+                        """.trimIndent(),
+                    )
+                    db.execSQL(
+                        """
+                        CREATE INDEX IF NOT EXISTS index_gemini_narratives_generatedAt
+                        ON gemini_narratives (generatedAt)
+                        """.trimIndent(),
+                    )
                 }
             }
     }

--- a/android/core/src/main/kotlin/com/wscanplus/core/db/dao/ScanResultDao.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/db/dao/ScanResultDao.kt
@@ -19,6 +19,13 @@ interface ScanResultDao {
         limit: Int = 100,
     ): List<ScanResultEntity>
 
-    @Query("SELECT * FROM scan_results WHERE latitude IS NOT NULL AND longitude IS NOT NULL ORDER BY timestamp DESC LIMIT :limit")
+    @Query(
+        """
+        SELECT * FROM scan_results
+        WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+        ORDER BY timestamp DESC
+        LIMIT :limit
+        """,
+    )
     fun getGpsTagged(limit: Int = 500): List<ScanResultEntity>
 }


### PR DESCRIPTION
Closes #312

## Summary

Adds a root `.editorconfig` so local editors and IDEs line up with repository formatting expectations.

## Changed

- Adds UTF-8/LF/final newline defaults
- Sets Kotlin/KTS/Java indentation to 4 spaces
- Enables Kotlin official style defaults for IntelliJ-compatible editors
- Sets common data/docs/script formats to 2 spaces
- Keeps Markdown trailing whitespace behavior non-disruptive
- Uses CRLF only for Windows script files

## Scope controls

- Formatting policy only
- No production code changes
- No repository-wide reformat
- No CI workflow changes

## Verification

Expected to be covered by existing checks. Android Core CI should still run if the workflow path rules match this PR; otherwise this PR is safe by inspection because it adds only editor configuration.