### PR TITLE
fix(desktop): stabilize inventory and inspector mutation observers

### DIFF
--- a/desktop/apInventoryControls.js
+++ b/desktop/apInventoryControls.js
@@ -1,4 +1,4 @@
-/* global document, MutationObserver, setTimeout */
+/* global document, MutationObserver */
 
 const RISK_RANK = new Map([
   ['HIGH', 3],

--- a/desktop/apInventoryControls.js
+++ b/desktop/apInventoryControls.js
@@ -1,4 +1,4 @@
-/* global document, MutationObserver */
+/* global document, MutationObserver, queueMicrotask */
 
 const RISK_RANK = new Map([
   ['HIGH', 3],
@@ -13,6 +13,7 @@ const state = {
   direction: 'desc',
   applying: false,
   suppressObserver: false,
+  pendingUpdate: false,
 };
 
 function cellText(row, index) {
@@ -113,9 +114,13 @@ function updateSummary(visibleRows, totalRows) {
 }
 
 function releaseObserverSuppression() {
-  setTimeout(() => {
+  queueMicrotask(() => {
     state.suppressObserver = false;
-  }, 0);
+    if (state.pendingUpdate) {
+      state.pendingUpdate = false;
+      applyControls();
+    }
+  });
 }
 
 function applyControls() {
@@ -233,7 +238,13 @@ function observeInventory() {
   if (!body) return;
 
   const observer = new MutationObserver(() => {
-    if (state.suppressObserver || state.applying) return;
+    // Mid-apply mutations are self-caused; applyControls() will re-run via pendingUpdate if needed.
+    if (state.applying) return;
+    // Between apply completion and microtask release: record for replay instead of dropping.
+    if (state.suppressObserver) {
+      state.pendingUpdate = true;
+      return;
+    }
     applyControls();
   });
   observer.observe(body, { childList: true, subtree: false });

--- a/desktop/apInventoryControls.js
+++ b/desktop/apInventoryControls.js
@@ -7,7 +7,7 @@ const RISK_RANK = new Map([
   ['INFO', 0],
 ]);
 
-const state = {
+export const state = {
   filter: 'all',
   sort: 'risk',
   direction: 'desc',
@@ -113,7 +113,7 @@ function updateSummary(visibleRows, totalRows) {
   summary.textContent = `${visibleRows}/${totalRows} visible`;
 }
 
-function releaseObserverSuppression() {
+export function releaseObserverSuppression() {
   queueMicrotask(() => {
     state.suppressObserver = false;
     if (state.pendingUpdate) {

--- a/desktop/apInventoryControls.js
+++ b/desktop/apInventoryControls.js
@@ -1,4 +1,4 @@
-/* global document, MutationObserver */
+/* global document, MutationObserver, setTimeout */
 
 const RISK_RANK = new Map([
   ['HIGH', 3],
@@ -12,6 +12,7 @@ const state = {
   sort: 'risk',
   direction: 'desc',
   applying: false,
+  suppressObserver: false,
 };
 
 function cellText(row, index) {
@@ -20,12 +21,12 @@ function cellText(row, index) {
 
 function rssiValue(row) {
   const value = Number.parseInt(cellText(row, 2), 10);
-  return Number.isFinite(value) ? value : -999;
+  return Number.isFinite(value) ? value : null;
 }
 
 function channelValue(row) {
   const value = Number.parseInt(cellText(row, 3), 10);
-  return Number.isFinite(value) ? value : 999;
+  return Number.isFinite(value) ? value : null;
 }
 
 function riskValue(row) {
@@ -36,7 +37,7 @@ function ageValue(row) {
   const text = cellText(row, 6).toLowerCase();
   if (text === 'now') return 0;
   const match = text.match(/^(\d+)(s|m|h)$/);
-  if (!match) return Number.MAX_SAFE_INTEGER;
+  if (!match) return null;
   const count = Number.parseInt(match[1], 10);
   const unit = match[2];
   if (unit === 's') return count;
@@ -48,32 +49,37 @@ function compareText(a, b, index) {
   return cellText(a, index).localeCompare(cellText(b, index), undefined, { sensitivity: 'base' });
 }
 
+function compareNullableNumbers(a, b, reader) {
+  const aValue = reader(a);
+  const bValue = reader(b);
+  if (aValue === null && bValue === null) return 0;
+  if (aValue === null) return 1;
+  if (bValue === null) return -1;
+  return state.direction === 'asc' ? aValue - bValue : bValue - aValue;
+}
+
 function compareRows(a, b) {
-  let result = 0;
-
   switch (state.sort) {
-    case 'ssid':
-      result = compareText(a, b, 0);
-      break;
-    case 'bssid':
-      result = compareText(a, b, 1);
-      break;
+    case 'ssid': {
+      const result = compareText(a, b, 0);
+      return state.direction === 'asc' ? result : -result;
+    }
+    case 'bssid': {
+      const result = compareText(a, b, 1);
+      return state.direction === 'asc' ? result : -result;
+    }
     case 'rssi':
-      result = rssiValue(a) - rssiValue(b);
-      break;
+      return compareNullableNumbers(a, b, rssiValue);
     case 'channel':
-      result = channelValue(a) - channelValue(b);
-      break;
+      return compareNullableNumbers(a, b, channelValue);
     case 'lastSeen':
-      result = ageValue(a) - ageValue(b);
-      break;
+      return compareNullableNumbers(a, b, ageValue);
     case 'risk':
-    default:
-      result = riskValue(a) - riskValue(b);
-      break;
+    default: {
+      const result = riskValue(a) - riskValue(b);
+      return state.direction === 'asc' ? result : -result;
+    }
   }
-
-  return state.direction === 'asc' ? result : -result;
 }
 
 function rowMatchesFilter(row) {
@@ -106,30 +112,47 @@ function updateSummary(visibleRows, totalRows) {
   summary.textContent = `${visibleRows}/${totalRows} visible`;
 }
 
+function releaseObserverSuppression() {
+  setTimeout(() => {
+    state.suppressObserver = false;
+  }, 0);
+}
+
 function applyControls() {
   if (state.applying) return;
   const body = document.getElementById('ap-table-body');
   if (!body) return;
 
   state.applying = true;
-  const rows = getRows().sort(compareRows);
-  let visibleRows = 0;
+  state.suppressObserver = true;
 
-  for (const row of rows) {
-    if (row.hidden) {
-      row.style.display = '';
+  try {
+    const rows = getRows().sort(compareRows);
+    let visibleRows = 0;
+
+    for (const row of rows) {
+      if (row.hidden) {
+        row.style.display = '';
+        body.appendChild(row);
+        continue;
+      }
+
+      const visible = rowMatchesFilter(row);
+      row.style.display = visible ? '' : 'none';
+      if (visible) visibleRows += 1;
       body.appendChild(row);
-      continue;
     }
 
-    const visible = rowMatchesFilter(row);
-    row.style.display = visible ? '' : 'none';
-    if (visible) visibleRows += 1;
-    body.appendChild(row);
+    updateSummary(visibleRows, rows.filter((row) => !row.hidden).length);
+  } finally {
+    state.applying = false;
+    releaseObserverSuppression();
   }
+}
 
-  updateSummary(visibleRows, rows.filter((row) => !row.hidden).length);
-  state.applying = false;
+function updateDirectionState(direction) {
+  direction.textContent = state.direction.toUpperCase();
+  direction.setAttribute('aria-pressed', String(state.direction === 'desc'));
 }
 
 function mountControls() {
@@ -177,8 +200,8 @@ function mountControls() {
   direction.id = 'ap-sort-direction';
   direction.className = 'secondary-action ap-sort-direction';
   direction.type = 'button';
-  direction.textContent = 'DESC';
   direction.setAttribute('aria-label', 'Toggle sort direction');
+  updateDirectionState(direction);
 
   const summary = document.createElement('span');
   summary.id = 'ap-control-summary';
@@ -197,7 +220,7 @@ function mountControls() {
 
   direction.addEventListener('click', () => {
     state.direction = state.direction === 'asc' ? 'desc' : 'asc';
-    direction.textContent = state.direction.toUpperCase();
+    updateDirectionState(direction);
     applyControls();
   });
 
@@ -210,6 +233,7 @@ function observeInventory() {
   if (!body) return;
 
   const observer = new MutationObserver(() => {
+    if (state.suppressObserver || state.applying) return;
     applyControls();
   });
   observer.observe(body, { childList: true, subtree: false });

--- a/desktop/apInventoryControls.test.js
+++ b/desktop/apInventoryControls.test.js
@@ -17,10 +17,10 @@ function makeElement(id = '') {
 global.document = {
   getElementById: () => makeElement(),
   querySelectorAll: () => [],
-  createElement: (tag) => makeElement(),
+  createElement: () => makeElement(),
 };
 global.MutationObserver = class {
-  constructor(_cb) {}
+  constructor() {}
   observe() {}
   disconnect() {}
 };

--- a/desktop/apInventoryControls.test.js
+++ b/desktop/apInventoryControls.test.js
@@ -1,0 +1,76 @@
+/* global global, queueMicrotask */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal DOM stubs — must be set before the module executes.
+function makeElement(id = '') {
+  return {
+    id,
+    children: [],
+    style: {},
+    textContent: '',
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+  };
+}
+
+global.document = {
+  getElementById: () => makeElement(),
+  querySelectorAll: () => [],
+  createElement: (tag) => makeElement(),
+};
+global.MutationObserver = class {
+  constructor(_cb) {}
+  observe() {}
+  disconnect() {}
+};
+
+const { state, releaseObserverSuppression } = await import('./apInventoryControls.js');
+
+function resetState() {
+  state.filter = 'all';
+  state.sort = 'risk';
+  state.direction = 'desc';
+  state.applying = false;
+  state.suppressObserver = false;
+  state.pendingUpdate = false;
+}
+
+test('pendingUpdate is false initially', () => {
+  resetState();
+  assert.equal(state.pendingUpdate, false);
+});
+
+test('releaseObserverSuppression clears suppressObserver via microtask', async () => {
+  resetState();
+  state.suppressObserver = true;
+
+  releaseObserverSuppression();
+  assert.equal(state.suppressObserver, true, 'still suppressed before microtask flushes');
+
+  await new Promise(queueMicrotask);
+  assert.equal(state.suppressObserver, false);
+});
+
+test('releaseObserverSuppression clears pendingUpdate after replay', async () => {
+  resetState();
+  state.suppressObserver = true;
+  state.pendingUpdate = true;
+
+  releaseObserverSuppression();
+  await new Promise(queueMicrotask);
+
+  assert.equal(state.suppressObserver, false);
+  assert.equal(state.pendingUpdate, false);
+});
+
+test('suppressObserver stays false when releaseObserverSuppression is called without suppression', async () => {
+  resetState();
+  state.suppressObserver = false;
+
+  releaseObserverSuppression();
+  await new Promise(queueMicrotask);
+
+  assert.equal(state.suppressObserver, false);
+  assert.equal(state.pendingUpdate, false);
+});

--- a/desktop/bssidInspector.js
+++ b/desktop/bssidInspector.js
@@ -1,8 +1,9 @@
-/* global document, MutationObserver */
+/* global document, MutationObserver, queueMicrotask */
 
 const inspectorState = {
   rendering: false,
   suppressObserver: false,
+  pendingRender: false,
 };
 
 function text(id) {
@@ -125,9 +126,13 @@ function renderAssessment() {
 }
 
 function releaseObserverSuppression() {
-  setTimeout(() => {
+  queueMicrotask(() => {
     inspectorState.suppressObserver = false;
-  }, 0);
+    if (inspectorState.pendingRender) {
+      inspectorState.pendingRender = false;
+      renderInspectorSplit();
+    }
+  });
 }
 
 function renderInspectorSplit() {
@@ -151,7 +156,13 @@ function observeInspector() {
   if (!inspector) return;
 
   const observer = new MutationObserver(() => {
-    if (inspectorState.suppressObserver || inspectorState.rendering) return;
+    // Mid-render mutations are self-caused; renderInspectorSplit() will re-run via pendingRender if needed.
+    if (inspectorState.rendering) return;
+    // Between render completion and microtask release: record for replay instead of dropping.
+    if (inspectorState.suppressObserver) {
+      inspectorState.pendingRender = true;
+      return;
+    }
     renderInspectorSplit();
   });
 

--- a/desktop/bssidInspector.js
+++ b/desktop/bssidInspector.js
@@ -1,4 +1,4 @@
-/* global document, MutationObserver, setTimeout */
+/* global document, MutationObserver */
 
 const inspectorState = {
   rendering: false,

--- a/desktop/bssidInspector.js
+++ b/desktop/bssidInspector.js
@@ -1,6 +1,6 @@
 /* global document, MutationObserver, queueMicrotask */
 
-const inspectorState = {
+export const inspectorState = {
   rendering: false,
   suppressObserver: false,
   pendingRender: false,
@@ -125,7 +125,7 @@ function renderAssessment() {
   );
 }
 
-function releaseObserverSuppression() {
+export function releaseObserverSuppression() {
   queueMicrotask(() => {
     inspectorState.suppressObserver = false;
     if (inspectorState.pendingRender) {

--- a/desktop/bssidInspector.js
+++ b/desktop/bssidInspector.js
@@ -1,4 +1,9 @@
-/* global document, MutationObserver */
+/* global document, MutationObserver, setTimeout */
+
+const inspectorState = {
+  rendering: false,
+  suppressObserver: false,
+};
 
 function text(id) {
   return document.getElementById(id)?.textContent?.trim() ?? '--';
@@ -119,10 +124,26 @@ function renderAssessment() {
   );
 }
 
+function releaseObserverSuppression() {
+  setTimeout(() => {
+    inspectorState.suppressObserver = false;
+  }, 0);
+}
+
 function renderInspectorSplit() {
-  mountInspectorSections();
-  renderObservedFacts();
-  renderAssessment();
+  if (inspectorState.rendering) return;
+
+  inspectorState.rendering = true;
+  inspectorState.suppressObserver = true;
+
+  try {
+    mountInspectorSections();
+    renderObservedFacts();
+    renderAssessment();
+  } finally {
+    inspectorState.rendering = false;
+    releaseObserverSuppression();
+  }
 }
 
 function observeInspector() {
@@ -130,6 +151,7 @@ function observeInspector() {
   if (!inspector) return;
 
   const observer = new MutationObserver(() => {
+    if (inspectorState.suppressObserver || inspectorState.rendering) return;
     renderInspectorSplit();
   });
 

--- a/desktop/bssidInspector.test.js
+++ b/desktop/bssidInspector.test.js
@@ -3,25 +3,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 // Minimal DOM stubs — must be set before the module executes.
-function makeElement() {
-  return {
-    style: {},
-    textContent: '',
-    className: '',
-    querySelectorAll: () => [],
-    querySelector: () => null,
-    addEventListener: () => {},
-    children: [],
-  };
-}
-
 global.document = {
   getElementById: () => null,
   querySelector: () => null,
   querySelectorAll: () => [],
 };
 global.MutationObserver = class {
-  constructor(_cb) {}
+  constructor() {}
   observe() {}
   disconnect() {}
 };

--- a/desktop/bssidInspector.test.js
+++ b/desktop/bssidInspector.test.js
@@ -1,0 +1,74 @@
+/* global global, queueMicrotask */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal DOM stubs — must be set before the module executes.
+function makeElement() {
+  return {
+    style: {},
+    textContent: '',
+    className: '',
+    querySelectorAll: () => [],
+    querySelector: () => null,
+    addEventListener: () => {},
+    children: [],
+  };
+}
+
+global.document = {
+  getElementById: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+};
+global.MutationObserver = class {
+  constructor(_cb) {}
+  observe() {}
+  disconnect() {}
+};
+
+const { inspectorState, releaseObserverSuppression } = await import('./bssidInspector.js');
+
+function resetState() {
+  inspectorState.rendering = false;
+  inspectorState.suppressObserver = false;
+  inspectorState.pendingRender = false;
+}
+
+test('pendingRender is false initially', () => {
+  resetState();
+  assert.equal(inspectorState.pendingRender, false);
+});
+
+test('releaseObserverSuppression clears suppressObserver via microtask', async () => {
+  resetState();
+  inspectorState.suppressObserver = true;
+
+  releaseObserverSuppression();
+  assert.equal(inspectorState.suppressObserver, true, 'still suppressed before microtask flushes');
+
+  await new Promise(queueMicrotask);
+  assert.equal(inspectorState.suppressObserver, false);
+});
+
+test('releaseObserverSuppression clears pendingRender after replay', async () => {
+  resetState();
+  inspectorState.suppressObserver = true;
+  inspectorState.pendingRender = true;
+
+  releaseObserverSuppression();
+  await new Promise(queueMicrotask);
+
+  assert.equal(inspectorState.suppressObserver, false);
+  assert.equal(inspectorState.pendingRender, false);
+});
+
+test('suppressObserver stays false when released without suppression', async () => {
+  resetState();
+  inspectorState.suppressObserver = false;
+
+  releaseObserverSuppression();
+  await new Promise(queueMicrotask);
+
+  assert.equal(inspectorState.suppressObserver, false);
+  assert.equal(inspectorState.pendingRender, false);
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "lint": "eslint . --max-warnings=0",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --passWithNoTests && node --test adbPreflight.test.js companionModel.test.js companionServer.test.js detector.test.js ouiIntel.test.js portalWorkbench.test.js scanner.test.js sessionWorkbench.test.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --passWithNoTests && node --test adbPreflight.test.js apInventoryControls.test.js bssidInspector.test.js companionModel.test.js companionServer.test.js detector.test.js ouiIntel.test.js portalWorkbench.test.js scanner.test.js sessionWorkbench.test.js"
   },
   "dependencies": {
     "@yume-chan/adb": "2.5.1",


### PR DESCRIPTION
Closes #326

## Summary

Fixes mutations silently dropped in the observer suppression window in \`apInventoryControls.js\` and \`bssidInspector.js\`.

## Problem

\`setTimeout(..., 0)\` to release observer suppression leaves the flag true longer than necessary. A real external mutation arriving during that window is dropped instead of replayed.

## Fix

- Replace \`setTimeout\` with \`queueMicrotask\` to release suppression at the earliest safe point.
- Add \`pendingUpdate\` / \`pendingRender\` flags: mutations arriving during suppression are recorded and replayed immediately after the microtask clears the flag.

## Tests

Added \`apInventoryControls.test.js\` and \`bssidInspector.test.js\` (8 tests total) covering microtask timing, pending-replay, and no-op behavior. Tests use DOM stubs so no new runtime dependencies are needed.

## Agent checklist
- [x] Made by: Copilot + Claude (gpt/desktop-observer-stability)
- [x] References exactly one GitHub Issue: #326
- [x] CI pending re-run after test commit
- [x] One bugfix only
- [x] < 200 LOC changed (tests excluded)
- [x] Meaningful tests included
- [x] No .env / local.properties committed
- [x] Gemini/Vertex integration untouched