### PR TITLE
fix(android): align BLE readiness permissions with capability surveyor

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,14 +49,18 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <!-- ================================================================
-         BLE NMEA tethering: GATT server + advertising for desktop receivers
+         BLE readiness and NMEA tethering support
          ================================================================ -->
 
     <!-- Legacy Bluetooth (API ≤30) -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
 
-    <!-- Runtime permissions required API 31+ for GATT server and advertising -->
+    <!-- Runtime permissions required API 31+ for BLE readiness, GATT server, and advertising -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="31" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="31" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" tools:targetApi="31" />
 


### PR DESCRIPTION
Closes #323

## Summary

Aligns Android BLE manifest permissions with the existing capability readiness model and tests.

## Problem

\`CapabilityReadinessSurveyor\` and associated tests already model:
- \`BLUETOOTH_SCAN\`
- \`BLUETOOTH_CONNECT\`

as distinct Android 12+ readiness requirements.

However, the Android manifest only declared:
- \`BLUETOOTH_CONNECT\`
- \`BLUETOOTH_ADVERTISE\`

This could leave BLE readiness permanently degraded on Android 12+ despite the app's readiness model expecting scan permission support.

## Changes

Added \`android.permission.BLUETOOTH_SCAN\` with \`neverForLocation\` and \`tools:targetApi="31"\`.

## Scope

Manifest alignment only — no BLE scanning implementation, no runtime behavior changes, no detector changes.

## Agent checklist
- [x] Made by: GPT (gpt/ble-scan-permission-alignment)
- [x] References exactly one GitHub Issue: #323
- [x] CI is green
- [x] One bugfix only
- [x] < 200 LOC changed (tests excluded)
- [x] No .env / local.properties committed
- [x] Gemini/Vertex integration untouched