### PR TITLE
feat(core): add evidence provenance metadata model

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/DetectionEvidenceEvent.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/DetectionEvidenceEvent.kt
@@ -21,12 +21,14 @@ data class DetectionEvidenceEvent(
     val reasons: List<String>,
     val bssid: String,
     val detectedAtMs: Long,
+    val provenance: EvidenceProvenance?,
     val schemaVersion: Int = 1,
 ) {
     init {
         require(confidence in 0.0f..0.95f) {
             "Confidence must be 0.0–0.95, was $confidence"
         }
+
         require(reasons.size <= 3) {
             "Maximum 3 reasons, was ${reasons.size}"
         }

--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceProvenance.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceProvenance.kt
@@ -1,0 +1,44 @@
+package com.wscanplus.core.evidence
+
+/**
+ * Provenance metadata describing where evidence originated.
+ *
+ * Provenance is operational metadata only.
+ * It does not imply attribution, device identity, or actor identification.
+ *
+ * Source provenance remains separate from detector confidence so downstream
+ * aggregation can reason about observation origin independently from threat
+ * assessment severity.
+ */
+data class EvidenceProvenance(
+    val sourceType: EvidenceSourceType,
+    val collectorId: String?,
+    val ingestionPath: String,
+    val observationTimestampMs: Long,
+    val receivedTimestampMs: Long,
+    val schemaVersion: Int = 1,
+) {
+    init {
+        require(ingestionPath.isNotBlank()) {
+            "Ingestion path must not be blank"
+        }
+
+        require(observationTimestampMs >= 0) {
+            "Observation timestamp must be non-negative"
+        }
+
+        require(receivedTimestampMs >= 0) {
+            "Received timestamp must be non-negative"
+        }
+    }
+}
+
+enum class EvidenceSourceType {
+    ANDROID_WIFI_SCAN,
+    ANDROID_BLE_SCAN,
+    ANDROID_CELLULAR,
+    DESKTOP_IMPORT,
+    USB_TETHER,
+    BLE_TETHER,
+    MANUAL_IMPORT,
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceProvenanceTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceProvenanceTest.kt
@@ -1,0 +1,55 @@
+package com.wscanplus.core.evidence
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EvidenceProvenanceTest {
+    @Test
+    fun preserves_valid_provenance_fields() {
+        val provenance =
+            EvidenceProvenance(
+                sourceType = EvidenceSourceType.ANDROID_WIFI_SCAN,
+                collectorId = "collector-a",
+                ingestionPath = "android/wifi",
+                observationTimestampMs = 1000L,
+                receivedTimestampMs = 1200L,
+            )
+
+        assertEquals(EvidenceSourceType.ANDROID_WIFI_SCAN, provenance.sourceType)
+        assertEquals("collector-a", provenance.collectorId)
+        assertEquals("android/wifi", provenance.ingestionPath)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_blank_ingestion_path() {
+        EvidenceProvenance(
+            sourceType = EvidenceSourceType.DESKTOP_IMPORT,
+            collectorId = null,
+            ingestionPath = " ",
+            observationTimestampMs = 1000L,
+            receivedTimestampMs = 1200L,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_negative_observation_timestamp() {
+        EvidenceProvenance(
+            sourceType = EvidenceSourceType.BLE_TETHER,
+            collectorId = null,
+            ingestionPath = "ble/tether",
+            observationTimestampMs = -1L,
+            receivedTimestampMs = 1200L,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_negative_received_timestamp() {
+        EvidenceProvenance(
+            sourceType = EvidenceSourceType.USB_TETHER,
+            collectorId = null,
+            ingestionPath = "usb/tether",
+            observationTimestampMs = 1000L,
+            receivedTimestampMs = -1L,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds deterministic provenance metadata support for normalized evidence records.

## Adds

### `EvidenceProvenance`
Captures:
- source type,
- collector identifier,
- ingestion path,
- observation timestamp,
- receive timestamp.

### `EvidenceSourceType`
Enumerates passive evidence origins including:
- Android WiFi,
- BLE,
- cellular,
- desktop import,
- USB tether,
- BLE tether,
- manual import.

### `DetectionEvidenceEvent`
Extended with optional provenance metadata.

## Why this matters

This separates:
- observation origin,
- ingestion path,
- transport source,

from:
- detector confidence,
- severity,
- heuristic interpretation.

This supports:
- explainable evidence chains,
- future desktop correlation,
- companion ingestion,
- recurring-pattern analysis,
- baseline drift analysis,

without introducing attribution or identity claims.

## Constraints preserved

- No ML.
- No SDR assumptions.
- No monitor-mode assumptions.
- No attribution claims.
- No networking changes.
- No detector inflation.

## Tests

Added validation tests for:
- blank ingestion paths,
- negative timestamps,
- valid provenance preservation.