### PR TITLE
feat(core): add passive cellular observation normalization model

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/cellular/CellObservation.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/cellular/CellObservation.kt
@@ -1,0 +1,67 @@
+package com.wscanplus.core.cellular
+
+import com.wscanplus.core.evidence.EvidenceProvenance
+
+/**
+ * Passive normalized cellular observation.
+ *
+ * This model represents locally observed radio metadata only.
+ *
+ * It does not:
+ * - identify devices,
+ * - attribute actors,
+ * - imply IMSI catcher detection,
+ * - imply Stingray detection,
+ * - imply lawful/intercept capability.
+ *
+ * The model is intentionally transport-agnostic so future desktop,
+ * tethered, and imported observations can normalize into the same
+ * deterministic aggregation pipeline.
+ */
+data class CellObservation(
+    val observationId: String,
+    val radioType: CellularRadioType,
+    val mcc: String?,
+    val mnc: String?,
+    val trackingAreaCode: Int?,
+    val cellId: Long?,
+    val physicalCellId: Int?,
+    val arfcn: Int?,
+    val bandwidthKhz: Int?,
+    val signalDbm: Int?,
+    val timestampMs: Long,
+    val provenance: EvidenceProvenance?,
+    val schemaVersion: Int = 1,
+) {
+    init {
+        require(observationId.isNotBlank()) {
+            "Observation id must not be blank"
+        }
+
+        require(timestampMs >= 0) {
+            "Timestamp must be non-negative"
+        }
+
+        require(mcc == null || MCC_REGEX.matches(mcc)) {
+            "MCC must contain exactly 3 digits"
+        }
+
+        require(mnc == null || MNC_REGEX.matches(mnc)) {
+            "MNC must contain 2 or 3 digits"
+        }
+    }
+
+    companion object {
+        private val MCC_REGEX = Regex("^[0-9]{3}$")
+        private val MNC_REGEX = Regex("^[0-9]{2,3}$")
+    }
+}
+
+enum class CellularRadioType {
+    GSM,
+    WCDMA,
+    LTE,
+    NR,
+    CDMA,
+    UNKNOWN,
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/cellular/CellObservationTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/cellular/CellObservationTest.kt
@@ -1,0 +1,111 @@
+package com.wscanplus.core.cellular
+
+import com.wscanplus.core.evidence.EvidenceProvenance
+import com.wscanplus.core.evidence.EvidenceSourceType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CellObservationTest {
+    @Test
+    fun preserves_valid_observation() {
+        val observation =
+            CellObservation(
+                observationId = "cell-1",
+                radioType = CellularRadioType.LTE,
+                mcc = "310",
+                mnc = "260",
+                trackingAreaCode = 123,
+                cellId = 456L,
+                physicalCellId = 22,
+                arfcn = 5230,
+                bandwidthKhz = 15000,
+                signalDbm = -91,
+                timestampMs = 1000L,
+                provenance =
+                    EvidenceProvenance(
+                        sourceType = EvidenceSourceType.ANDROID_CELLULAR,
+                        collectorId = "android-primary",
+                        ingestionPath = "android/cellular",
+                        observationTimestampMs = 1000L,
+                        receivedTimestampMs = 1010L,
+                    ),
+            )
+
+        assertEquals(CellularRadioType.LTE, observation.radioType)
+        assertEquals("310", observation.mcc)
+        assertEquals("260", observation.mnc)
+        assertEquals(-91, observation.signalDbm)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_blank_observation_id() {
+        CellObservation(
+            observationId = " ",
+            radioType = CellularRadioType.UNKNOWN,
+            mcc = null,
+            mnc = null,
+            trackingAreaCode = null,
+            cellId = null,
+            physicalCellId = null,
+            arfcn = null,
+            bandwidthKhz = null,
+            signalDbm = null,
+            timestampMs = 1000L,
+            provenance = null,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_invalid_mcc() {
+        CellObservation(
+            observationId = "cell-2",
+            radioType = CellularRadioType.GSM,
+            mcc = "31",
+            mnc = "260",
+            trackingAreaCode = null,
+            cellId = null,
+            physicalCellId = null,
+            arfcn = null,
+            bandwidthKhz = null,
+            signalDbm = null,
+            timestampMs = 1000L,
+            provenance = null,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_invalid_mnc() {
+        CellObservation(
+            observationId = "cell-3",
+            radioType = CellularRadioType.GSM,
+            mcc = "310",
+            mnc = "2",
+            trackingAreaCode = null,
+            cellId = null,
+            physicalCellId = null,
+            arfcn = null,
+            bandwidthKhz = null,
+            signalDbm = null,
+            timestampMs = 1000L,
+            provenance = null,
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejects_negative_timestamp() {
+        CellObservation(
+            observationId = "cell-4",
+            radioType = CellularRadioType.NR,
+            mcc = null,
+            mnc = null,
+            trackingAreaCode = null,
+            cellId = null,
+            physicalCellId = null,
+            arfcn = null,
+            bandwidthKhz = null,
+            signalDbm = null,
+            timestampMs = -1L,
+            provenance = null,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a deterministic passive cellular observation model for future explainable evidence aggregation.

## Adds

### `CellObservation`
Normalized passive observation metadata including:
- radio type,
- MCC/MNC,
- TAC,
- PCI,
- ARFCN,
- bandwidth,
- signal level,
- timestamps,
- provenance metadata.

### `CellularRadioType`
Enumerates normalized radio families:
- GSM,
- WCDMA,
- LTE,
- NR,
- CDMA,
- UNKNOWN.

## Architecture goals

This establishes:
- transport-agnostic observation normalization,
- future desktop/USB/BLE ingestion compatibility,
- deterministic aggregation support,
- provenance-aware evidence pipelines.

## Explicit constraints

This model does NOT:
- identify users,
- attribute actors,
- imply IMSI catcher detection,
- imply Stingray detection,
- imply lawful intercept capability.

No detector logic or alerting was added.

## Tests

Added validation coverage for:
- blank IDs,
- invalid MCC/MNC values,
- negative timestamps,
- valid observation preservation.