### PR TITLE
feat(core): add transport-agnostic observation ingestion abstractions

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/ingestion/ObservationIngestionSource.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/ingestion/ObservationIngestionSource.kt
@@ -1,0 +1,79 @@
+package com.wscanplus.core.ingestion
+
+import com.wscanplus.core.evidence.EvidenceSourceType
+
+/**
+ * Transport-agnostic observation ingestion source.
+ *
+ * Ingestion sources normalize how observations enter the pipeline while
+ * remaining separate from:
+ * - detector logic,
+ * - confidence scoring,
+ * - attribution,
+ * - threat assessment.
+ *
+ * These abstractions intentionally avoid transport-specific detector behavior.
+ */
+interface ObservationIngestionSource {
+    val sourceId: String
+    val sourceType: EvidenceSourceType
+    val transport: ObservationTransport
+    val displayName: String
+    val isUserInitiated: Boolean
+}
+
+enum class ObservationTransport {
+    LOCAL_ANDROID,
+    DESKTOP_IMPORT,
+    USB_TETHER,
+    BLE_TETHER,
+    MANUAL_IMPORT,
+}
+
+/**
+ * Local Android observation source.
+ */
+data class AndroidObservationSource(
+    override val sourceId: String,
+    override val sourceType: EvidenceSourceType,
+    override val displayName: String,
+    override val isUserInitiated: Boolean = false,
+) : ObservationIngestionSource {
+    override val transport: ObservationTransport = ObservationTransport.LOCAL_ANDROID
+}
+
+/**
+ * Desktop-imported observation source.
+ */
+data class DesktopImportSource(
+    override val sourceId: String,
+    override val displayName: String,
+    override val isUserInitiated: Boolean = true,
+) : ObservationIngestionSource {
+    override val sourceType: EvidenceSourceType = EvidenceSourceType.DESKTOP_IMPORT
+    override val transport: ObservationTransport = ObservationTransport.DESKTOP_IMPORT
+}
+
+/**
+ * USB-tethered companion ingestion source.
+ */
+data class UsbTetherSource(
+    override val sourceId: String,
+    override val displayName: String,
+    override val isUserInitiated: Boolean = true,
+) : ObservationIngestionSource {
+    override val sourceType: EvidenceSourceType = EvidenceSourceType.USB_TETHER
+    override val transport: ObservationTransport = ObservationTransport.USB_TETHER
+}
+
+/**
+ * BLE-tethered companion ingestion source.
+ */
+data class BleTetherSource(
+    override val sourceId: String,
+    override val displayName: String,
+    override val isUserInitiated: Boolean = true,
+) : ObservationIngestionSource {
+    override val sourceType: EvidenceSourceType = EvidenceSourceType.BLE_TETHER
+    override val transport: ObservationTransport = ObservationTransport.BLE_TETHER
+}

--- a/android/core/src/test/kotlin/com/wscanplus/core/ingestion/ObservationIngestionSourceTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/ingestion/ObservationIngestionSourceTest.kt
@@ -1,0 +1,60 @@
+package com.wscanplus.core.ingestion
+
+import com.wscanplus.core.evidence.EvidenceSourceType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObservationIngestionSourceTest {
+    @Test
+    fun android_source_preserves_transport_metadata() {
+        val source =
+            AndroidObservationSource(
+                sourceId = "android-primary",
+                sourceType = EvidenceSourceType.ANDROID_WIFI_SCAN,
+                displayName = "Primary Android Scanner",
+            )
+
+        assertEquals(ObservationTransport.LOCAL_ANDROID, source.transport)
+        assertEquals(EvidenceSourceType.ANDROID_WIFI_SCAN, source.sourceType)
+        assertFalse(source.isUserInitiated)
+    }
+
+    @Test
+    fun desktop_import_is_user_initiated() {
+        val source =
+            DesktopImportSource(
+                sourceId = "desktop-import",
+                displayName = "Desktop Import",
+            )
+
+        assertEquals(ObservationTransport.DESKTOP_IMPORT, source.transport)
+        assertEquals(EvidenceSourceType.DESKTOP_IMPORT, source.sourceType)
+        assertTrue(source.isUserInitiated)
+    }
+
+    @Test
+    fun usb_tether_source_uses_usb_transport() {
+        val source =
+            UsbTetherSource(
+                sourceId = "usb-source",
+                displayName = "USB Companion",
+            )
+
+        assertEquals(ObservationTransport.USB_TETHER, source.transport)
+        assertEquals(EvidenceSourceType.USB_TETHER, source.sourceType)
+    }
+
+    @Test
+    fun ble_tether_source_uses_ble_transport() {
+        val source =
+            BleTetherSource(
+                sourceId = "ble-source",
+                displayName = "BLE Companion",
+            )
+
+        assertEquals(ObservationTransport.BLE_TETHER, source.transport)
+        assertEquals(EvidenceSourceType.BLE_TETHER, source.sourceType)
+    }
+}


### PR DESCRIPTION
## Summary

Adds transport-agnostic ingestion abstractions for normalized observation intake.

## Adds

### `ObservationIngestionSource`
Defines normalized ingestion metadata separated from:
- detector logic,
- confidence scoring,
- attribution,
- threat assessment.

### `ObservationTransport`
Enumerates ingestion transports:
- local Android,
- desktop import,
- USB tether,
- BLE tether,
- manual import.

### Source implementations
- `AndroidObservationSource`
- `DesktopImportSource`
- `UsbTetherSource`
- `BleTetherSource`

## Why this matters

This establishes a clean ingestion boundary between:
- transport/runtime layers,
- normalized observations,
- explainable detector systems.

This enables future:
- desktop correlation,
- tethered companion ingestion,
- imported evidence replay,
- recurring-pattern analysis,

without coupling detectors to transport origin.

## Constraints preserved

- No networking implementation.
- No detector logic changes.
- No attribution claims.
- No SDR assumptions.
- No monitor-mode assumptions.
- No alert generation.

## Tests

Added transport/source validation coverage for all ingestion source types.