### PR TITLE
fix(core): restore detection evidence mapper compatibility

### DIFF
--- a/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
+++ b/android/core/src/main/kotlin/com/wscanplus/core/evidence/EvidenceMappers.kt
@@ -42,6 +42,7 @@ fun ThreatSignal.toDetectionEvidenceEvent(
     require(observation.wifi.bssid.equals(bssid, ignoreCase = true)) {
         "Observation BSSID must match threat signal BSSID"
     }
+
     return DetectionEvidenceEvent(
         id = id,
         observationId = observation.id,
@@ -51,6 +52,7 @@ fun ThreatSignal.toDetectionEvidenceEvent(
         reasons = reasons,
         bssid = bssid,
         detectedAtMs = detectedAt,
+        provenance = null,
     )
 }
 

--- a/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
+++ b/android/core/src/test/kotlin/com/wscanplus/core/evidence/EvidenceMappersTest.kt
@@ -167,6 +167,7 @@ class EvidenceMappersTest {
             reasons = listOf("too high"),
             bssid = "AA:BB:CC:DD:EE:FF",
             detectedAtMs = 1L,
+            provenance = null,
         )
     }
 
@@ -181,6 +182,7 @@ class EvidenceMappersTest {
             reasons = listOf("one", "two", "three", "four"),
             bssid = "AA:BB:CC:DD:EE:FF",
             detectedAtMs = 1L,
+            provenance = null,
         )
     }
 }


### PR DESCRIPTION
Closes #324

## Summary

Fixes Android CI failure introduced after adding provenance metadata to \`DetectionEvidenceEvent\`.

## Problem

\`DetectionEvidenceEvent\` gained a required \`provenance\` parameter. \`EvidenceMappers.kt\` still used the old constructor shape, causing a Kotlin compile failure and Android CI failure.

## Fix

Adds explicit \`provenance = null\` in \`EvidenceMappers.kt\` when mapping existing \`ThreatSignal\` instances.

Current detector flows do not yet populate provenance metadata. Using \`null\` preserves backward compatibility, deterministic detector behavior, and existing evidence semantics.

## Agent checklist
- [x] Made by: GPT (gpt/fix-evidence-mapper-provenance)
- [x] References exactly one GitHub Issue: #324
- [x] CI is green
- [x] One bugfix only
- [x] < 200 LOC changed (tests excluded)
- [x] No .env / local.properties committed
- [x] Gemini/Vertex integration untouched