### PR TITLE
chore: enforce branch naming in CI and fix agent prefix list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check agent prefix
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
           if echo "$BRANCH" | grep -qE '^(claude|copilot|gpt|codex|dvntone)/'; then
             echo "Branch name OK: $BRANCH"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,23 @@ jobs:
           name: wscanplus-debug-apk-ci-mock
           path: android/app/build/outputs/apk/debug/app-debug.apk
 
+  branch-name:
+    name: Branch name lint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    steps:
+      - name: Check agent prefix
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if echo "$BRANCH" | grep -qE '^(claude|copilot|gpt|codex|dvntone)/'; then
+            echo "Branch name OK: $BRANCH"
+          else
+            echo "ERROR: Branch '$BRANCH' does not start with an approved agent prefix."
+            echo "Allowed prefixes: claude/, copilot/, gpt/, codex/, dvntone/"
+            exit 1
+          fi
+
   secret-scan:
     name: Secret Scan (blocking)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Only these agents may write or modify code, docs, and config in this repo:
 
 Every change must be traceable. This means:
 
-- Branch names must start with the agent prefix: `claude/`, `copilot/`, or `dvntone/`
+- Branch names must start with an approved agent prefix: `claude/`, `copilot/`, `gpt/`, `codex/`, or `dvntone/`. This is enforced by CI — PRs with non-compliant branch names will fail.
 - Commit messages must be descriptive (what changed and why — not just "update file")
 - Every PR description must state: which agent made it, what was changed and why, and which rules guided the decisions
 - No force-pushes. No amending commits after they are merged.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,5 +1,27 @@
 # Known Issues
 
+## 2026-05-13: PR process audit findings — branch naming and guardrail violations
+
+A review of the last 40 PRs (PRs ~#283–#328) identified the following systemic issues:
+
+### Branch naming violations (9 PRs)
+Branches used non-approved prefixes (`android/`, `ci/`, `docs/`, `feat/`, bare names, `dvntone-` with dash). Both `AGENTS.md` and `docs/AGENTS.md` also had an incomplete prefix list — `gpt/` and `codex/` were missing despite being in active use. **Fixed in PR #330**: CI now enforces the prefix rule as a hard gate; both AGENTS files updated.
+
+### Missing issue references (22/40 PRs — 55%)
+The "every PR must reference exactly one GitHub Issue" rule is not being followed. No automated gate exists for this. Remains a human/agent discipline requirement. Agents must open the issue first, then the PR.
+
+### Simultaneous open PR clusters (8 clusters)
+The "1 open PR at a time" rule was violated in 8 distinct clusters. Worst case: 8 PRs opened within 21 minutes on 2026-05-09 evening (PRs #315–#322). No automated enforcement is possible for this rule — it requires session discipline.
+
+### Other anomalies
+- PR #283 had `[WIP]` in title, was never a draft, and was merged — double violation of the draft PR workflow rule.
+- PR #286 branch name (`claude/figma-code-connect-uzVc9`) had no relation to its content (SessionStart hook).
+- PR #314 title embedded a raw CI run ID.
+
+**Status:** Branch naming CI gate added (PR #330). Other items carry forward as discipline requirements with no automated fix.
+
+---
+
 ## Phase 2: Local Threat Intelligence — COMPLETE (2026-03-20)
 
 All 9 tasks merged (PRs #96–#117). 7 WiFi threat heuristics, HeuristicEngine, PolicyGate, Room database (5 entities, 5 DAOs), OUI vendor lookup, and app-side logging are live.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -58,7 +58,7 @@ This project is built by AI agents under human oversight (review and direction o
 
 Every change must be fully traceable back to the agent that made it:
 
-- Branch names must include the agent prefix (for example, `claude/...`, `copilot/...`, or `dvntone/...`)
+- Branch names must start with an approved agent prefix: `claude/`, `copilot/`, `gpt/`, `codex/`, or `dvntone/`. This is enforced by CI — PRs with non-compliant branch names will fail.
 - Commit messages must describe what changed and why — not just "update file" or "fix"
 - Every PR description must include:
   - Which agent made it


### PR DESCRIPTION
## Summary

Closes #329

Addresses findings from the 2026-05-13 PR audit (last 40 PRs reviewed).

- **CI gate**: new `branch-name` job in `ci.yml` rejects any PR whose head branch does not start with an approved agent prefix (`claude/`, `copilot/`, `gpt/`, `codex/`, `dvntone/`). Turns a guideline into a hard check.
- **Docs fix**: both `AGENTS.md` and `docs/AGENTS.md` listed only `claude/`, `copilot/`, `dvntone/` — `gpt/` and `codex/` were missing despite being in active use. Both files corrected to list all five prefixes and note CI enforcement.
- **Audit record**: `KNOWN_ISSUES.md` updated with the full audit findings (9 branch violations, 22/40 PRs missing issue refs, 8 simultaneous-open clusters, notable anomalies) for traceability.

## What changed and why

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | New `branch-name` job — exits 1 if `github.head_ref` does not match `^(claude\|copilot\|gpt\|codex\|dvntone)/` |
| `AGENTS.md` | Branch prefix list corrected; CI enforcement noted |
| `docs/AGENTS.md` | Same fix |
| `KNOWN_ISSUES.md` | 2026-05-13 audit findings documented |

## Rules that guided decisions

- AGENTS.md Section 0: traceability / branch naming
- CLAUDE.md: docs-only + CI-only change, no code modified
- One concern addressed per PR

## PR checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#329)
- [x] CI must be green before marking Ready for Review
- [x] One concern only (branch naming enforcement + audit docs)
- [x] < 200 LOC changed (tests excluded) — 41 lines net
- [x] No new dependencies
- [x] No runtime code changed — CI workflow + docs only
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets committed
- [x] Gemini/Vertex integration untouched
- [x] Merged via squash only

https://claude.ai/code/session_019CsDaNB5Wm5zVEkdofk1gn

---
_Generated by [Claude Code](https://claude.ai/code/session_019CsDaNB5Wm5zVEkdofk1gn)_