### PR TITLE
ci: add PR enforcement checks (issue-ref, size, WIP, concurrency, simultaneous)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qiE '^\[?WIP\]?[: ]'; then
+          if echo "$PR_TITLE" | grep -qiE '^(\[WIP\]|WIP[: ])'; then
             echo "ERROR: PR title starts with WIP. Mark as draft or rename before review."
             exit 1
           fi
@@ -246,7 +246,7 @@ jobs:
   pr-simultaneous:
     name: Simultaneous PR check (max 2 open)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","ready_for_review"]'), github.event.action)
     timeout-minutes: 5
     steps:
       - name: Check open PR count

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ name: Agent Guarded CI
     branches-ignore:
       - main
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write
+  pull-requests: read
 
 jobs:
   nodejs:
@@ -178,6 +183,85 @@ jobs:
             echo "Allowed prefixes: claude/, copilot/, gpt/, codex/, dvntone/"
             exit 1
           fi
+
+  pr-issue-ref:
+    name: PR issue reference check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    steps:
+      - name: Check for closing keyword
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ -z "$PR_BODY" ]; then
+            echo "ERROR: PR body is empty. Add a description with a closing keyword."
+            exit 1
+          fi
+          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves) #[0-9]+'; then
+            echo "Issue reference found."
+          else
+            echo "ERROR: PR body must reference a GitHub Issue (e.g. 'Closes #123')."
+            exit 1
+          fi
+
+  pr-wip-check:
+    name: WIP title guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    steps:
+      - name: Check for WIP in title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qiE '^\[?WIP\]?[: ]'; then
+            echo "ERROR: PR title starts with WIP. Mark as draft or rename before review."
+            exit 1
+          fi
+          echo "Title OK: $PR_TITLE"
+
+  pr-size:
+    name: PR size check (max 200 LOC, tests excluded)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    steps:
+      - name: Count changed lines via API
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          CHANGED=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --paginate \
+            --jq '[.[] | select(.filename | test("Test|Spec|\\.test\\.|\\.spec\\.") | not) | (.additions + .deletions)] | add // 0')
+          echo "Changed lines (tests excluded): $CHANGED"
+          if [ "$CHANGED" -gt 200 ]; then
+            echo "ERROR: PR changes $CHANGED lines (limit 200 LOC, tests excluded)."
+            echo "Split into smaller PRs or justify the size in the PR description."
+            exit 1
+          fi
+          echo "Size OK: $CHANGED lines"
+
+  pr-simultaneous:
+    name: Simultaneous PR check (max 2 open)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    timeout-minutes: 5
+    steps:
+      - name: Check open PR count
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=10" \
+            --jq 'length')
+          echo "Open PRs: $OPEN"
+          if [ "$OPEN" -gt 2 ]; then
+            echo "ERROR: $OPEN PRs are open simultaneously. Maximum is 2."
+            echo "Close or merge existing PRs before opening another."
+            exit 1
+          fi
+          echo "OK: $OPEN open PR(s)"
 
   secret-scan:
     name: Secret Scan (blocking)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Only these agents may write or modify code, docs, and config in this repo:
 **Coding agents must never remove, replace, or modify the Gemini/Vertex integration in the Android app.** It is intentional and paid for. File an issue if you think something needs changing.
 
 ## PR / Issue Policy
-- MAX 1 open PR at a time (total, across all agents).
+- MAX 2 open PRs at a time (total, across all agents) — enforced by CI on PR open.
 - Every PR must reference exactly one GitHub Issue.
 - If CI is red: fix CI before any new PR or feature work.
 - **Merge strategy: Squash and merge only.** Merge commits and rebase are disabled.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -69,7 +69,7 @@ Every change must be fully traceable back to the agent that made it:
 
 ## Section 1: Single Work Unit at a Time
 
-- Only one open feature or bugfix PR at any time across all agents
+- No more than 2 open PRs at any time across all agents — enforced by CI on PR open
 - Every PR must reference exactly one GitHub Issue
 - Never open a new PR while CI is failing — fix the broken build first
 


### PR DESCRIPTION
## Summary

Closes #331

Turns five discipline-only rules into hard CI gates. Follows from the 2026-05-13 PR audit (55% missing issue refs, [WIP] merged, 8 simultaneous-PR clusters). Also updates the 1-PR limit to 2 per maintainer direction.

## What changed and why

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Concurrency group, `pull-requests: read`, four new jobs |
| `AGENTS.md` | 1-PR limit raised to 2, CI enforcement noted |
| `docs/AGENTS.md` | Same update in Section 1 |

**New CI jobs (all `pull_request` only):**
- `pr-issue-ref` — fails if body lacks `Closes/Fixes/Resolves #N`
- `pr-wip-check` — fails if title starts with `[WIP]` or `WIP:`
- `pr-size` — fails if changed LOC > 200 (tests excluded), uses GitHub API
- `pr-simultaneous` — fails if > 2 PRs open simultaneously (on `opened` event only)
- `concurrency` — cancels redundant runs on rapid push to same ref

All use `env:` blocks for expression values to prevent script injection (same pattern as #330).

## Rules cited

- docs/AGENTS.md Section 0: traceability
- docs/AGENTS.md Section 1: single work unit / PR policy
- CLAUDE.md security invariants: no expression interpolation in shell

## PR checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue (#331)
- [x] CI must be green before marking Ready for Review
- [x] One concern only (CI enforcement)
- [x] < 200 LOC changed (tests excluded)
- [x] No new dependencies
- [x] No runtime code changed — CI workflow + docs only
- [x] `.env` / `local.properties` NOT committed
- [x] No secrets committed
- [x] Gemini/Vertex integration untouched
- [x] Merged via squash only

https://claude.ai/code/session_019CsDaNB5Wm5zVEkdofk1gn

---
_Generated by [Claude Code](https://claude.ai/code/session_019CsDaNB5Wm5zVEkdofk1gn)_