### PR TITLE
feat(desktop): functional handoff prototype — seeded data, anomaly modal, live-mode hiding

### DIFF
--- a/desktop/demoMode.js
+++ b/desktop/demoMode.js
@@ -3,7 +3,6 @@
 const api = window.wscan ?? window.wscanplus ?? window.wscanPlus ?? {};
 
 let liveDataSeen = false;
-let domObserver = null;
 
 function createBanner() {
   if (document.getElementById('demo-data-banner')) return;
@@ -95,8 +94,8 @@ function subscribeToLiveAps() {
 function observeTableRerenders() {
   const target = document.querySelector('.workspace');
   if (!target) return;
-  domObserver = new MutationObserver(() => hideSeededDemoRows());
-  domObserver.observe(target, { childList: true, subtree: true });
+  const observer = new MutationObserver(() => hideSeededDemoRows());
+  observer.observe(target, { childList: true, subtree: true });
 }
 
 createBanner();

--- a/desktop/demoMode.js
+++ b/desktop/demoMode.js
@@ -1,14 +1,9 @@
 /* global window, document, MutationObserver */
 
 const api = window.wscan ?? window.wscanplus ?? window.wscanPlus ?? {};
-const DEMO_BSSIDS = new Set([
-  '9C:3A:AF:22:10:8B',
-  '1E:89:41:77:A0:2C',
-  'F2:1D:02:90:11:FE',
-  '58:EF:68:41:90:7A',
-]);
 
 let liveDataSeen = false;
+let domObserver = null;
 
 function createBanner() {
   if (document.getElementById('demo-data-banner')) return;
@@ -26,11 +21,11 @@ function createBanner() {
   const badge = document.createElement('span');
   badge.id = 'data-mode-badge';
   badge.className = 'badge badge-warning';
-  badge.textContent = 'DEMO DATA';
+  badge.textContent = 'HANDOFF DATA';
 
   const text = document.createElement('p');
   text.id = 'data-mode-message';
-  text.textContent = 'Sample AP rows and threat entries are layout placeholders only, not live evidence.';
+  text.textContent = 'Prototype AP rows and anomaly entries are seeded from the implementation handoff, not live evidence.';
 
   banner.append(badge, text);
   header.insertAdjacentElement('afterend', banner);
@@ -56,27 +51,29 @@ function markLiveMode() {
 
   const message = document.getElementById('data-mode-message');
   if (message) {
-    message.textContent = 'Live scanner or companion AP data has arrived. Seeded demo rows are hidden from the operator view.';
+    message.textContent = 'Live scanner or companion AP data has arrived. Seeded handoff rows are hidden from the operator view.';
   }
 
   hideSeededDemoRows();
 }
 
+function isHandoffThreatItem(item) {
+  return item.dataset.source === 'handoff';
+}
+
 function hideSeededDemoRows() {
   const rows = document.querySelectorAll('#ap-table-body tr');
   for (const row of rows) {
-    const bssid = row.children?.[1]?.textContent?.trim().toUpperCase();
-    if (bssid && DEMO_BSSIDS.has(bssid)) {
+    if (row.dataset.source === 'handoff') {
       row.hidden = liveDataSeen;
       row.classList.add('demo-seeded-row');
-      row.setAttribute('aria-label', 'Seeded demo row, hidden when live data is present');
+      row.setAttribute('aria-label', 'Seeded handoff row, hidden when live data is present');
     }
   }
 
   const threatItems = document.querySelectorAll('.threat-item');
   for (const item of threatItems) {
-    const text = item.textContent ?? '';
-    if (text.includes('F2:1D:02:90:11:FE') || text.includes('Unknown AP near trusted SSID pattern')) {
+    if (isHandoffThreatItem(item)) {
       item.hidden = liveDataSeen;
       item.classList.add('demo-seeded-threat');
     }
@@ -98,8 +95,8 @@ function subscribeToLiveAps() {
 function observeTableRerenders() {
   const target = document.querySelector('.workspace');
   if (!target) return;
-  const observer = new MutationObserver(() => hideSeededDemoRows());
-  observer.observe(target, { childList: true, subtree: true });
+  domObserver = new MutationObserver(() => hideSeededDemoRows());
+  domObserver.observe(target, { childList: true, subtree: true });
 }
 
 createBanner();

--- a/desktop/handoffPrototypeModel.js
+++ b/desktop/handoffPrototypeModel.js
@@ -1,0 +1,237 @@
+export const ANOMALY_CONFIDENCE = { low: 34, medium: 61, high: 82, critical: 95 };
+
+export const SESSION = {
+  id: 'sess-7c41a',
+  name: 'Apt 4-W · Tuesday evening sweep',
+  duration: '00:18:42',
+  location: 'home · indoor',
+};
+
+export const WIFI = [
+  {
+    bssid: '4C:5E:0C:91:8A:42',
+    ssid: 'PRIVATE-HOME-5G',
+    ch: 36,
+    sec: 'WPA3',
+    rssi: -42,
+    vendor: 'Cisco Meraki',
+    lastSeen: '2026-05-15T19:59:48Z',
+  },
+  {
+    bssid: '78:8A:20:11:E8:0A',
+    ssid: 'PRIVATE-HOME-2G',
+    ch: 6,
+    sec: 'WPA2',
+    rssi: -54,
+    vendor: 'Cisco Meraki',
+    lastSeen: '2026-05-15T19:59:48Z',
+  },
+  {
+    bssid: 'AE:4F:91:CC:31:F0',
+    ssid: 'xfinitywifi',
+    ch: 11,
+    sec: 'open',
+    rssi: -68,
+    vendor: 'Comcast (Xfinity)',
+    lastSeen: '2026-05-15T19:59:48Z',
+    anomaly: 'high',
+  },
+  {
+    bssid: 'AE:4F:91:CC:31:F1',
+    ssid: 'xfinitywifi',
+    ch: 36,
+    sec: 'open',
+    rssi: -71,
+    vendor: 'Comcast (Xfinity)',
+    lastSeen: '2026-05-15T19:59:48Z',
+    anomaly: 'high',
+  },
+  {
+    bssid: '02:8C:5D:7F:11:01',
+    ssid: 'Setup-7A11',
+    ch: 1,
+    sec: 'open',
+    rssi: -77,
+    vendor: 'unknown (locally-administered)',
+    lastSeen: '2026-05-15T19:48:30Z',
+    anomaly: 'medium',
+  },
+  {
+    bssid: '88:AC:C1:0E:5B:22',
+    ssid: 'NETGEAR55',
+    ch: 6,
+    sec: 'WPA2',
+    rssi: -83,
+    vendor: 'Netgear',
+    lastSeen: '2026-05-15T19:59:48Z',
+  },
+  {
+    bssid: '00:1B:11:9A:03:CC',
+    ssid: 'TP-LINK_C3',
+    ch: 11,
+    sec: 'WPA2',
+    rssi: -85,
+    vendor: 'TP-Link',
+    lastSeen: '2026-05-15T19:59:48Z',
+  },
+  {
+    bssid: '50:C7:BF:01:22:81',
+    ssid: '<hidden>',
+    ch: 149,
+    sec: 'WPA2',
+    rssi: -76,
+    vendor: 'unknown',
+    lastSeen: '2026-05-15T19:59:48Z',
+  },
+];
+
+export const ANOMALIES = [
+  {
+    id: 'wifi-open-portal',
+    sourceId: 'a-019',
+    bssid: 'AE:4F:91:CC:31:F0',
+    title: 'Suspicious captive portal',
+    level: 'high',
+    t: '2026-05-15T19:47:11Z',
+    summary:
+      'Open WiFi captive portal for xfinitywifi does not match known-good baseline.',
+    reasons: [
+      'TLS certificate issuer differs from baseline',
+      'Redirect chain has one extra hop through an unfamiliar host',
+      'Form action URL does not match baseline form host',
+    ],
+    signals: ['wifi', 'portal'],
+    recurrence: 'first-seen at this location',
+    investigation: 'Avoid auto-connect until the portal is confirmed.',
+  },
+  {
+    id: 'ble-rotating-burst',
+    sourceId: 'a-018',
+    title: 'BLE advertisement burst - rotating identifier',
+    level: 'medium',
+    t: '2026-05-15T19:45:08Z',
+    summary:
+      'Rotating BLE advertisement pattern with sub-second cadence recurred across recent sessions.',
+    reasons: [
+      'Advertisement interval at or below 220ms sustained for 2+ minutes',
+      'Random-resolvable address rotation rate above baseline',
+      'Similar pattern observed in 4 prior sessions at this location',
+    ],
+    signals: ['ble'],
+    recurrence: 'recurring - 5 sessions - same approximate location',
+    investigation: 'Pattern alone does not confirm a device class.',
+  },
+  {
+    id: 'wifi-new-open-cluster',
+    sourceId: 'a-017',
+    bssid: '02:8C:5D:7F:11:01',
+    title: 'New AP cluster on busy channel',
+    level: 'medium',
+    t: '2026-05-15T19:44:32Z',
+    summary:
+      'Short-lived BSSIDs broadcast open networks within the same scan window.',
+    reasons: [
+      'BSSIDs not in baseline and using open security',
+      'Co-occurrent appearance pattern',
+      'High RSSI variance suggests mobility',
+    ],
+    signals: ['wifi'],
+    recurrence: 'first-seen',
+    investigation: 'Watch and re-correlate if the pattern repeats.',
+  },
+  {
+    id: 'wifi-baseline-rssi-drift',
+    sourceId: 'a-016',
+    bssid: '4C:5E:0C:91:8A:42',
+    title: 'Baseline RSSI drift - PRIVATE-HOME-5G',
+    level: 'low',
+    t: '2026-05-15T19:43:50Z',
+    summary:
+      'Trusted AP RSSI is 8 dB below the 7-day median for this hour.',
+    reasons: ['RSSI median delta is -8 dB within the urban damping band'],
+    signals: ['wifi'],
+    recurrence: 'occasional - environmental',
+    investigation: 'No action recommended.',
+  },
+];
+
+function riskForWifi(row) {
+  if (row.anomaly === 'high') return 'high';
+  if (row.anomaly === 'medium') return 'watch';
+  return 'low';
+}
+
+export function handoffWifiAps() {
+  return WIFI.map((row) => ({
+    ssid: row.ssid,
+    bssid: row.bssid,
+    rssi: row.rssi,
+    channel: row.ch,
+    security: row.sec,
+    risk: riskForWifi(row),
+    lastSeen: row.lastSeen,
+    source: 'handoff',
+    vendor: row.vendor,
+  }));
+}
+
+export function handoffRisks() {
+  return ANOMALIES.map((anomaly) => ({
+    id: anomaly.id,
+    bssid: anomaly.bssid ?? '',
+    ssid: WIFI.find((row) => row.bssid === anomaly.bssid)?.ssid ?? '',
+    severity: anomaly.level === 'medium' ? 'watch' : anomaly.level,
+    confidence: ANOMALY_CONFIDENCE[anomaly.level] ?? 50,
+    reason: `${anomaly.title}: ${anomaly.summary}`,
+    timestamp: anomaly.t,
+    status: 'open',
+    source: 'handoff',
+  }));
+}
+
+export function findAnomaly(value) {
+  const normalized = String(value ?? '').toUpperCase();
+  return (
+    ANOMALIES.find(
+      (anomaly) =>
+        anomaly.id === value ||
+        anomaly.sourceId === value ||
+        anomaly.bssid?.toUpperCase() === normalized,
+    ) ?? null
+  );
+}
+
+export function summarizeHandoffSession() {
+  const levels = ['low', 'medium', 'high', 'critical'];
+  const highest = ANOMALIES.reduce((max, anomaly) => {
+    return levels.indexOf(anomaly.level) > levels.indexOf(max)
+      ? anomaly.level
+      : max;
+  }, 'low');
+
+  return {
+    id: SESSION.id,
+    title: SESSION.name,
+    duration: SESSION.duration,
+    location: SESSION.location,
+    totalWifi: WIFI.length,
+    anomalousWifi: WIFI.filter((row) => row.anomaly).length,
+    totalAnomalies: ANOMALIES.length,
+    highestLevel: highest,
+  };
+}
+
+export function buildAnomalyReport(anomaly) {
+  if (!anomaly) return '';
+  return [
+    `Anomaly: ${anomaly.title}`,
+    `ID: ${anomaly.id} (${anomaly.sourceId})`,
+    `Level: ${anomaly.level}`,
+    `Signals: ${anomaly.signals.join(', ')}`,
+    `Summary: ${anomaly.summary}`,
+    `Reasons: ${anomaly.reasons.join('; ')}`,
+    `Recurrence: ${anomaly.recurrence}`,
+    `Recommendation: ${anomaly.investigation}`,
+    'Boundary: no actor identification; no intent attribution.',
+  ].join('\n');
+}

--- a/desktop/handoffPrototypeModel.test.js
+++ b/desktop/handoffPrototypeModel.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  ANOMALIES,
+  SESSION,
+  WIFI,
+  buildAnomalyReport,
+  findAnomaly,
+  handoffRisks,
+  handoffWifiAps,
+  summarizeHandoffSession,
+} from './handoffPrototypeModel.js';
+
+test('handoff WiFi rows map to desktop AP rows', () => {
+  const aps = handoffWifiAps();
+
+  assert.equal(aps.length, WIFI.length);
+  assert.deepEqual(aps[2], {
+    ssid: 'xfinitywifi',
+    bssid: 'AE:4F:91:CC:31:F0',
+    rssi: -68,
+    channel: 11,
+    security: 'open',
+    risk: 'high',
+    lastSeen: '2026-05-15T19:59:48Z',
+    source: 'handoff',
+    vendor: 'Comcast (Xfinity)',
+  });
+});
+
+test('handoff anomalies map to risk entries with confidence levels', () => {
+  const risks = handoffRisks();
+
+  assert.equal(risks.length, ANOMALIES.length);
+  assert.equal(risks[0].severity, 'high');
+  assert.equal(risks[0].confidence, 82);
+  assert.match(risks[0].reason, /suspicious captive portal/i);
+  assert.equal(risks[0].source, 'handoff');
+});
+
+test('findAnomaly resolves by id and by BSSID', () => {
+  assert.equal(findAnomaly('wifi-open-portal')?.id, 'wifi-open-portal');
+  assert.equal(findAnomaly('AE:4F:91:CC:31:F0')?.id, 'wifi-open-portal');
+});
+
+test('summarizeHandoffSession returns operator metrics', () => {
+  assert.deepEqual(summarizeHandoffSession(), {
+    id: SESSION.id,
+    title: SESSION.name,
+    duration: SESSION.duration,
+    location: SESSION.location,
+    totalWifi: 8,
+    anomalousWifi: 3,
+    totalAnomalies: 4,
+    highestLevel: 'high',
+  });
+});
+
+test('buildAnomalyReport preserves evidence boundaries', () => {
+  const report = buildAnomalyReport(ANOMALIES[0]);
+
+  assert.match(report, /wifi-open-portal/);
+  assert.match(report, /no actor identification/i);
+  assert.match(report, /no intent attribution/i);
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "electron .",
     "lint": "eslint . --max-warnings=0",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --passWithNoTests && node --test adbPreflight.test.js apInventoryControls.test.js bssidInspector.test.js companionModel.test.js companionServer.test.js detector.test.js ouiIntel.test.js portalWorkbench.test.js scanner.test.js sessionWorkbench.test.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --passWithNoTests && node --test adbPreflight.test.js apInventoryControls.test.js bssidInspector.test.js companionModel.test.js companionServer.test.js detector.test.js handoffPrototypeModel.test.js ouiIntel.test.js portalWorkbench.test.js scanner.test.js sessionWorkbench.test.js"
   },
   "dependencies": {
     "@yume-chan/adb": "2.5.1",

--- a/desktop/renderer.mjs
+++ b/desktop/renderer.mjs
@@ -91,6 +91,11 @@ function upsertAp(input) {
 
 function setAps(payload) {
   const list = Array.isArray(payload) ? payload : Array.isArray(payload?.aps) ? payload.aps : Array.isArray(payload?.networks) ? payload.networks : [];
+  if (list.some((ap) => String(ap?.source ?? 'desktop') !== 'handoff')) {
+    state.aps = new Map([...state.aps].filter(([, ap]) => ap.source !== 'handoff'));
+    state.risks = state.risks.filter((risk) => risk.source !== 'handoff');
+    if (!state.aps.has(state.selectedBssid)) state.selectedBssid = state.aps.keys().next().value ?? null;
+  }
   for (const ap of list) upsertAp(ap);
   render();
 }
@@ -341,9 +346,17 @@ function openAnomalyDetail(identifier, returnFocusTo = document.activeElement) {
   const sheet = document.createElement('article');
   sheet.className = 'anomaly-detail-sheet';
   sheet.addEventListener('click', (event) => event.stopPropagation());
+  const restoreBackground = [...document.body.children]
+    .filter((element) => element !== overlay)
+    .map((element) => [element, element.inert, element.getAttribute('aria-hidden')]);
+  restoreBackground.forEach(([element]) => { element.inert = true; element.setAttribute('aria-hidden', 'true'); });
 
   const closeModal = ({ rerender = false, restoreFocus = true } = {}) => {
     overlay.remove();
+    restoreBackground.forEach(([element, inert, ariaHidden]) => {
+      element.inert = inert;
+      ariaHidden === null ? element.removeAttribute('aria-hidden') : element.setAttribute('aria-hidden', ariaHidden);
+    });
     anomalyModalCleanup?.();
     anomalyModalCleanup = null;
     if (rerender) render();
@@ -351,9 +364,16 @@ function openAnomalyDetail(identifier, returnFocusTo = document.activeElement) {
   };
 
   const onKeydown = (event) => {
-    if (event.key !== 'Escape') return;
-    event.preventDefault();
-    closeModal();
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeModal();
+      return;
+    }
+    if (event.key === 'Tab') {
+      const buttons = [...sheet.querySelectorAll('button:not([disabled])')];
+      const edge = buttons[event.shiftKey ? 0 : buttons.length - 1];
+      if (document.activeElement === edge) { event.preventDefault(); buttons[event.shiftKey ? buttons.length - 1 : 0]?.focus(); }
+    }
   };
   document.addEventListener('keydown', onKeydown);
   anomalyModalCleanup = () => document.removeEventListener('keydown', onKeydown);

--- a/desktop/renderer.mjs
+++ b/desktop/renderer.mjs
@@ -1,3 +1,11 @@
+import {
+  buildAnomalyReport,
+  findAnomaly,
+  handoffRisks,
+  handoffWifiAps,
+  summarizeHandoffSession,
+} from './handoffPrototypeModel.js';
+
 const api = window.wscan ?? window.wscanplus ?? window.wscanPlus ?? {};
 
 const state = {
@@ -5,6 +13,7 @@ const state = {
   risks: [],
   events: [],
   selectedBssid: null,
+  reviewedAnomalies: new Set(),
   scanState: { running: false, scanning: false },
   companion: null,
   adb: { status: 'unknown' },
@@ -13,6 +22,7 @@ const state = {
 
 const severityRank = { high: 3, critical: 3, threat: 3, watch: 2, medium: 2, warning: 2, low: 1, info: 0 };
 const $ = (id) => document.getElementById(id);
+let anomalyModalCleanup = null;
 
 function normalizeBssid(value) {
   return typeof value === 'string' ? value.trim().toUpperCase() : '';
@@ -103,6 +113,7 @@ function normalizeRiskEntry(input) {
     reason,
     timestamp,
     status: String(input.status ?? 'open'),
+    source: String(input.source ?? ''),
   };
 }
 
@@ -241,6 +252,7 @@ function renderApTable(aps) {
     tr.className = `${ap.risk === 'high' ? 'high' : ap.risk === 'watch' ? 'watch' : ''} ${state.selectedBssid === ap.bssid ? 'selected' : ''}`;
     tr.tabIndex = 0;
     tr.dataset.bssid = ap.bssid;
+    if (ap.source) tr.dataset.source = ap.source;
     const cells = [ap.ssid, ap.bssid, Number.isFinite(ap.rssi) ? `${ap.rssi}` : '--', Number.isFinite(ap.channel) ? `${ap.channel}` : '--', summarizeSecurity(ap.security), ap.risk.toUpperCase(), formatAge(ap.lastSeen)];
     for (const cell of cells) {
       const td = document.createElement('td');
@@ -277,11 +289,27 @@ function renderThreats() {
   for (const risk of risks) {
     const li = document.createElement('li');
     li.className = 'threat-item';
+    if (risk.source) li.dataset.source = risk.source;
+    const anomaly = findAnomaly(risk.id) ?? findAnomaly(risk.bssid);
+    const reviewed = anomaly && state.reviewedAnomalies.has(anomaly.id);
+    if (anomaly) {
+      li.tabIndex = 0;
+      li.setAttribute('role', 'button');
+      li.setAttribute('aria-label', `Open anomaly detail for ${anomaly.title}`);
+      li.classList.toggle('reviewed', Boolean(reviewed));
+      li.addEventListener('click', () => openAnomalyDetail(anomaly.id, li));
+      li.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openAnomalyDetail(anomaly.id, li);
+        }
+      });
+    }
     const badge = document.createElement('span');
     badge.className = `badge ${risk.severity === 'high' ? 'badge-threat' : risk.severity === 'watch' ? 'badge-warning' : 'badge-neutral'}`;
-    badge.textContent = `${risk.severity.toUpperCase()} ${risk.confidence ? `${Math.round(risk.confidence)}%` : ''}`.trim();
+    badge.textContent = reviewed ? 'REVIEWED' : `${risk.severity.toUpperCase()} ${risk.confidence ? `${Math.round(risk.confidence)}%` : ''}`.trim();
     const title = document.createElement('strong');
-    title.textContent = risk.bssid || risk.ssid || 'Detector event';
+    title.textContent = anomaly?.title ?? (risk.bssid || risk.ssid || 'Detector event');
     const body = document.createElement('p');
     body.textContent = `${risk.reason} • ${formatAge(risk.timestamp)} ago`;
     li.append(badge, title, body);
@@ -294,6 +322,115 @@ function renderThreats() {
     list.appendChild(li);
   }
   $('threat-count').textContent = `${state.risks.length} events`;
+}
+
+function openAnomalyDetail(identifier, returnFocusTo = document.activeElement) {
+  const anomaly = findAnomaly(identifier);
+  if (!anomaly) return;
+
+  anomalyModalCleanup?.();
+  document.getElementById('anomaly-detail-modal')?.remove();
+
+  const overlay = document.createElement('section');
+  overlay.id = 'anomaly-detail-modal';
+  overlay.className = 'anomaly-detail-modal';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-label', anomaly.title);
+
+  const sheet = document.createElement('article');
+  sheet.className = 'anomaly-detail-sheet';
+  sheet.addEventListener('click', (event) => event.stopPropagation());
+
+  const closeModal = ({ rerender = false, restoreFocus = true } = {}) => {
+    overlay.remove();
+    anomalyModalCleanup?.();
+    anomalyModalCleanup = null;
+    if (rerender) render();
+    if (restoreFocus && returnFocusTo?.isConnected && typeof returnFocusTo.focus === 'function') returnFocusTo.focus();
+  };
+
+  const onKeydown = (event) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    closeModal();
+  };
+  document.addEventListener('keydown', onKeydown);
+  anomalyModalCleanup = () => document.removeEventListener('keydown', onKeydown);
+
+  const close = document.createElement('button');
+  close.className = 'secondary-action';
+  close.type = 'button';
+  close.textContent = 'Close';
+  close.addEventListener('click', closeModal);
+
+  const badge = document.createElement('span');
+  badge.className = `badge ${anomaly.level === 'high' ? 'badge-threat' : anomaly.level === 'medium' ? 'badge-warning' : 'badge-neutral'}`;
+  badge.textContent = anomaly.level.toUpperCase();
+
+  const heading = document.createElement('h2');
+  heading.textContent = anomaly.title;
+
+  const summary = document.createElement('p');
+  summary.textContent = anomaly.summary;
+
+  const reasons = document.createElement('ul');
+  reasons.className = 'anomaly-reasons';
+  for (const reason of anomaly.reasons) {
+    const item = document.createElement('li');
+    item.textContent = reason;
+    reasons.appendChild(item);
+  }
+
+  const meta = document.createElement('p');
+  meta.className = 'muted';
+  meta.textContent = `${anomaly.sourceId} · ${anomaly.t} · ${anomaly.signals.join(' + ')} · ${anomaly.recurrence}`;
+
+  const recommendation = document.createElement('p');
+  recommendation.className = 'anomaly-recommendation';
+  recommendation.textContent = `${anomaly.investigation} No actor identification or intent attribution.`;
+
+  const report = document.createElement('button');
+  report.className = 'secondary-action';
+  report.type = 'button';
+  report.textContent = 'Copy Report';
+  report.addEventListener('click', async () => {
+    const text = buildAnomalyReport(anomaly);
+    try {
+      const clipboard = window.navigator?.clipboard;
+      if (!clipboard?.writeText) throw new Error('Clipboard API unavailable');
+      await clipboard.writeText(text);
+      addEvent({ level: 'INFO', source: 'handoff', message: `report copied for ${anomaly.id}` });
+    } catch (error) {
+      report.textContent = 'Copy failed';
+      report.disabled = true;
+      addEvent({ level: 'WARN', source: 'handoff', message: `report copy failed for ${anomaly.id}: ${error?.message ?? error}` });
+      setTimeout(() => {
+        report.textContent = 'Copy Report';
+        report.disabled = false;
+      }, 2000);
+    }
+  });
+
+  const reviewed = document.createElement('button');
+  reviewed.className = 'primary-action';
+  reviewed.type = 'button';
+  reviewed.textContent = state.reviewedAnomalies.has(anomaly.id) ? 'Reviewed' : 'Mark Reviewed';
+  reviewed.addEventListener('click', () => {
+    state.reviewedAnomalies.add(anomaly.id);
+    addEvent({ level: 'INFO', source: 'handoff', message: `${anomaly.id} marked reviewed` }, false);
+    closeModal({ rerender: true });
+  });
+
+  const actions = document.createElement('div');
+  actions.className = 'anomaly-actions';
+  actions.append(report, reviewed, close);
+
+  overlay.addEventListener('click', closeModal);
+  sheet.append(badge, heading, meta, summary, reasons, recommendation, actions);
+  overlay.appendChild(sheet);
+  document.body.appendChild(overlay);
+  close.focus();
 }
 
 function renderCompanion() {
@@ -485,15 +622,21 @@ function wireSubscriptions() {
 
 function seedDemoIfEmpty() {
   if (state.aps.size) return;
-  [
-    { ssid: 'Home-5G', bssid: '9C:3A:AF:22:10:8B', rssi: -48, channel: 149, frequency: 5745, security: 'WPA3', risk: 'low', lastSeen: Date.now() - 2000, source: 'demo' },
-    { ssid: 'xfinitywifi', bssid: '1E:89:41:77:A0:2C', rssi: -69, channel: 11, frequency: 2462, security: 'open', risk: 'watch', lastSeen: Date.now() - 4200, source: 'demo' },
-    { ssid: 'Unknown_AP', bssid: 'F2:1D:02:90:11:FE', rssi: -57, channel: 1, frequency: 2412, security: 'WPA2', risk: 'high', lastSeen: Date.now() - 8000, source: 'demo' },
-    { ssid: 'PrinterNet', bssid: '58:EF:68:41:90:7A', rssi: -73, channel: 3, frequency: 2422, security: 'WPA2', risk: 'low', lastSeen: Date.now() - 21000, source: 'demo' },
-  ].forEach(upsertAp);
-  addRisk({ bssid: 'F2:1D:02:90:11:FE', ssid: 'Unknown_AP', severity: 'high', confidence: 82, reason: 'Unknown AP near trusted SSID pattern' });
-  state.companion = { status: 'offline', deviceId: '--', payloadRate: 0, rejects: 0 };
-  addEvent({ level: 'INFO', source: 'ui', message: 'demo data loaded until scanner emits AP state' }, false);
+  const session = summarizeHandoffSession();
+  handoffWifiAps().forEach(upsertAp);
+  handoffRisks().forEach((risk) => addRisk(risk, false));
+  state.companion = {
+    status: 'offline',
+    deviceId: 'handoff prototype',
+    payloadRate: 0,
+    rejects: 0,
+  };
+  addEvent({
+    level: 'INFO',
+    source: 'handoff',
+    message: `${session.title}: ${session.totalWifi} APs, ${session.totalAnomalies} anomalies seeded until live scanner data arrives`,
+  }, false);
+  $('workspace-subtitle').textContent = `${session.id} · ${session.duration} · ${session.totalAnomalies} anomalies · ${session.location}`;
 }
 
 async function boot() {

--- a/desktop/styles.css
+++ b/desktop/styles.css
@@ -258,8 +258,41 @@ dd { margin: 0; font-family: var(--mono); font-size: 12px; overflow-wrap: anywhe
 
 .threat-list { display: grid; gap: 10px; max-height: calc(100% - 40px); margin: 0; padding: 0; list-style: none; overflow: auto; }
 .threat-item { padding: 10px; border: 1px solid var(--line); border-radius: 12px; background: var(--bg); }
+.threat-item.reviewed { border-color: rgba(46, 125, 50, 0.42); background: rgba(46, 125, 50, 0.08); }
+.threat-item[role="button"] { cursor: pointer; }
+.threat-item[role="button"]:hover,
+.threat-item[role="button"]:focus-visible { border-color: rgba(33, 150, 243, 0.62); outline: none; background: rgba(33, 150, 243, 0.08); }
 .threat-item strong { display: block; margin: 6px 0 3px; font-size: 13px; }
 .threat-item p { color: var(--muted); font-size: 12px; line-height: 1.4; }
+
+.anomaly-detail-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: end center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.58);
+}
+
+.anomaly-detail-sheet {
+  display: grid;
+  gap: 12px;
+  width: min(680px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.42);
+}
+
+.anomaly-detail-sheet h2 { font-size: 22px; }
+.anomaly-detail-sheet p { line-height: 1.5; }
+.anomaly-reasons { display: grid; gap: 8px; margin: 0; padding-left: 18px; color: var(--text); font-size: 13px; }
+.anomaly-recommendation { padding: 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--bg); color: var(--muted); }
+.anomaly-actions { display: flex; flex-wrap: wrap; gap: 10px; justify-content: flex-end; }
 
 .event-console { grid-area: console; min-height: 0; padding: 12px 16px; border-radius: 18px; background: rgba(5, 7, 11, 0.96); overflow: hidden; }
 .console-header { height: 24px; margin-bottom: 8px; }
@@ -284,4 +317,23 @@ dd { margin: 0; font-family: var(--mono); font-size: 12px; overflow-wrap: anywhe
     min-height: 100vh;
   }
   .inspector { grid-template-columns: repeat(3, minmax(220px, 1fr)); grid-template-rows: none; }
+}
+
+@media (max-width: 760px) {
+  .topbar, .workspace-header, .status-strip { align-items: flex-start; flex-direction: column; }
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "topbar" "sidebar" "workspace" "inspector" "console";
+    grid-template-rows: auto auto auto auto 180px;
+    gap: 12px;
+    padding: 0 12px 12px;
+  }
+  .topbar { gap: 12px; margin: 0 -12px; padding: 12px; }
+  .workspace, .workspace-with-demo-banner { grid-template-rows: none; }
+  .metrics-grid, .lower-grid, .inspector { grid-template-columns: minmax(0, 1fr); }
+  .control-row { justify-content: flex-start; width: 100%; }
+  .status-strip { width: 100%; }
+  .primary-action, .secondary-action { flex: 1 1 120px; }
+  .anomaly-detail-modal { align-items: end; padding: 12px; }
+  .anomaly-detail-sheet { max-height: calc(100vh - 24px); border-radius: 14px; }
 }


### PR DESCRIPTION
## What changed and why

Wires the T-handoff prototype data into the desktop renderer, replacing the old hardcoded BSSID demo placeholders with realistic session content drawn from the handoff model.

### New files

- **`desktop/handoffPrototypeModel.js`** — structured data model: 8 WiFi APs, 4 anomaly entries (one high, two medium, one low). Exports `handoffWifiAps()`, `handoffRisks()`, `findAnomaly()`, `summarizeHandoffSession()`, `buildAnomalyReport()`. All threat data is fictional demo content.
- **`desktop/handoffPrototypeModel.test.js`** — 5 unit tests covering all exports.

### Updated files

- **`desktop/renderer.mjs`** — anomaly detail modal (keyboard-accessible, Escape-to-close, focus-managed, `role=dialog`/`aria-modal`). Threat list items with a matching anomaly become clickable. "Mark Reviewed" updates the badge to REVIEWED. "Copy Report" writes the structured report to clipboard.
- **`desktop/demoMode.js`** — replaces hardcoded BSSID Set with `data-source="handoff"` attribute check; text copy updated from "demo" to "handoff". Fixed unused module-level `domObserver` variable (lint).
- **`desktop/styles.css`** — anomaly modal overlay + sheet, reviewed threat state, mobile-responsive shell breakpoint.

### Depends on

PR #347 (`@babel/preset-react`, `react`, `react-dom` devDeps) — can be merged independently; the handoff model does not use those packages at runtime.

## Rules applied

- No Android changes
- No Google Maps or paid map provider
- No secrets, no device identifiers
- Gemini/Vertex integration untouched
- ESM only — all new files use `export`/`import`
- `.env` / `local.properties` NOT committed

## PR checklist

- [x] Made by: Claude
- [x] References exactly one GitHub Issue — Closes #349
- [ ] CI is green before marking Ready for Review
- [x] One feature (handoff implementation)
- [x] All 52 desktop tests pass, lint clean
- [x] Errors logged, not silently swallowed
- [x] `.env` / `local.properties` NOT committed
- [x] Gemini/Vertex integration untouched
- [ ] Merged via squash only

Closes #349

---
_Generated by [Claude Code](https://claude.ai/code/session_019CsDaNB5Wm5zVEkdofk1gn)_