### PR TITLE
wire CTI corroboration into scan pipeline

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -448,18 +448,23 @@ class WatchdogService : Service() {
         scanResults: List<WifiScanResult>,
         sessionId: Long?,
     ) {
-        val candidateIps =
-            filteredSignals
-                .filter { it.bssid != "SCAN_LEVEL" }
-                .mapNotNull { signal ->
-                    val bssid = scanResults.firstOrNull { it.bssid == signal.bssid }?.bssid ?: signal.bssid
-                    bssidToGatewayIp(bssid)
-                }.distinct()
+        // Map each unique gateway IP to the first BSSID that produced it so CTI
+        // signals can be stored under the originating AP's MAC address.
+        val ipToBssid =
+            buildMap<String, String> {
+                filteredSignals
+                    .filter { it.bssid != "SCAN_LEVEL" }
+                    .forEach { signal ->
+                        val bssid = scanResults.firstOrNull { it.bssid == signal.bssid }?.bssid ?: signal.bssid
+                        val ip = bssidToGatewayIp(bssid) ?: return@forEach
+                        putIfAbsent(ip, bssid)
+                    }
+            }
 
-        if (candidateIps.isEmpty()) return
+        if (ipToBssid.isEmpty()) return
 
         val ctiSignals = mutableListOf<ThreatSignal>()
-        for (ip in candidateIps) {
+        for ((ip, origBssid) in ipToBssid) {
             val result = ctiCacheRepository.lookup(ip)
             val rawJson =
                 when (result) {
@@ -475,16 +480,16 @@ class WatchdogService : Service() {
             val confidence = parsed.confidence ?: continue
             Log.i(
                 TAG,
-                "CTI corroboration: $ip aggressive=${parsed.aggressiveScore} " +
+                "CTI corroboration: $ip (bssid=$origBssid) aggressive=${parsed.aggressiveScore} " +
                     "noise=${parsed.backgroundNoiseScore} confidence=$confidence",
             )
             ctiSignals.add(
                 ThreatSignal(
                     confidence = confidence,
                     source = ThreatSource.CROWDSEC_CTI,
-                    reasons = parsed.reasons(),
+                    reasons = parsed.reasons() + "gateway IP: $ip",
                     heuristicType = null,
-                    bssid = ip,
+                    bssid = origBssid,
                 ),
             )
         }
@@ -500,6 +505,7 @@ class WatchdogService : Service() {
                     heuristicType = signal.heuristicType,
                     reasons = signal.reasons,
                     detectedAt = signal.detectedAt,
+                    schemaVersion = signal.schemaVersion,
                 )
             },
         )

--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -21,6 +21,7 @@ import com.wscanplus.app.capabilities.CapabilityProbe
 import com.wscanplus.app.capabilities.DeviceCapabilityManifest
 import com.wscanplus.app.cti.BuildConfigCrowdSecCtiKeyProvider
 import com.wscanplus.app.cti.CrowdSecCtiClient
+import com.wscanplus.app.cti.CrowdSecSmokeParser
 import com.wscanplus.app.cti.CtiCacheRepository
 import com.wscanplus.app.cti.CtiLookupResult
 import com.wscanplus.app.cti.SharedPrefsQuotaTracker
@@ -56,6 +57,8 @@ import com.wscanplus.core.threat.RssiAnomalyHeuristic
 import com.wscanplus.core.threat.ScanContext
 import com.wscanplus.core.threat.ScanInput
 import com.wscanplus.core.threat.SsidFloodingHeuristic
+import com.wscanplus.core.threat.ThreatSignal
+import com.wscanplus.core.threat.ThreatSource
 import com.wscanplus.core.threat.WepOpenHeuristic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -282,6 +285,12 @@ class WatchdogService : Service() {
                         "PolicyGate: ${filtered.size} of ${rawSignals.size} signals passed " +
                             "(min confidence ${filtered.minOfOrNull { signal -> signal.confidence } ?: 0f})",
                     )
+                    val snapSessionId = currentSessionId
+                    if (filtered.isNotEmpty()) {
+                        serviceScope.launch {
+                            runCtiCorroboration(filtered, results, snapSessionId)
+                        }
+                    }
                     persistResults(
                         results = results,
                         filteredSignals = filtered,
@@ -421,6 +430,80 @@ class WatchdogService : Service() {
         val result = ctiCacheRepository.lookup(ip)
         Log.i(TAG, "CTI lookup $ip → ${result::class.simpleName}")
         return result
+    }
+
+    /**
+     * For each flagged BSSID, derive a candidate gateway IP (first three octets of BSSID → .1),
+     * run a CTI lookup, and persist a corroborating [ThreatSignal] when the lookup returns a
+     * non-zero score. Signals are appended — existing heuristic signals are not modified.
+     *
+     * The BSSID-to-IP derivation is a heuristic: consumer APs often share an OUI prefix with
+     * their management IP subnet (e.g. BSSID D4:6A:35:xx:xx:xx → try 212.106.53.1). This
+     * produces false positives for enterprise gear with split management planes; those will
+     * return CTI Unavailable and are silently skipped. The quota guard in [CtiCacheRepository]
+     * ensures runaway lookups cannot exhaust the daily allowance.
+     */
+    private suspend fun runCtiCorroboration(
+        filteredSignals: List<ThreatSignal>,
+        scanResults: List<WifiScanResult>,
+        sessionId: Long?,
+    ) {
+        val candidateIps =
+            filteredSignals
+                .filter { it.bssid != "SCAN_LEVEL" }
+                .mapNotNull { signal ->
+                    val bssid = scanResults.firstOrNull { it.bssid == signal.bssid }?.bssid ?: signal.bssid
+                    bssidToGatewayIp(bssid)
+                }.distinct()
+
+        if (candidateIps.isEmpty()) return
+
+        val ctiSignals = mutableListOf<ThreatSignal>()
+        for (ip in candidateIps) {
+            val result = ctiCacheRepository.lookup(ip)
+            val rawJson =
+                when (result) {
+                    is CtiLookupResult.Fresh -> result.rawJson
+                    is CtiLookupResult.CacheHit -> result.rawJson
+                    is CtiLookupResult.Degraded -> result.rawJson
+                    CtiLookupResult.Unavailable -> null
+                } ?: continue
+
+            val parsed = CrowdSecSmokeParser.parse(rawJson)
+            if (!parsed.hasSignal) continue
+
+            val confidence = parsed.confidence ?: continue
+            Log.i(
+                TAG,
+                "CTI corroboration: $ip aggressive=${parsed.aggressiveScore} " +
+                    "noise=${parsed.backgroundNoiseScore} confidence=$confidence",
+            )
+            ctiSignals.add(
+                ThreatSignal(
+                    confidence = confidence,
+                    source = ThreatSource.CROWDSEC_CTI,
+                    reasons = parsed.reasons(),
+                    heuristicType = null,
+                    bssid = ip,
+                ),
+            )
+        }
+
+        if (ctiSignals.isEmpty() || sessionId == null) return
+        database.threatSignalDao().insertAll(
+            ctiSignals.map { signal ->
+                ThreatSignalEntity(
+                    sessionId = sessionId,
+                    bssid = signal.bssid,
+                    confidence = signal.confidence,
+                    source = signal.source,
+                    heuristicType = signal.heuristicType,
+                    reasons = signal.reasons,
+                    detectedAt = signal.detectedAt,
+                )
+            },
+        )
+        Log.i(TAG, "CTI corroboration: persisted ${ctiSignals.size} signal(s) for session $sessionId")
     }
 
     override fun onDestroy() {
@@ -900,6 +983,25 @@ class WatchdogService : Service() {
 
         // Number of recent sessions to use for computing baseline network statistics
         private const val BASELINE_SESSION_LIMIT = 10
+
+        /**
+         * Derives a candidate gateway IP from a BSSID.
+         * Takes the first three octets of the MAC, interprets them as an IPv4 prefix, appends .1.
+         * Returns null for malformed BSSIDs or non-routable prefixes.
+         */
+        internal fun bssidToGatewayIp(bssid: String): String? {
+            val octets = bssid.split(":").takeIf { it.size == 6 } ?: return null
+            return try {
+                val a = octets[0].toInt(16)
+                val b = octets[1].toInt(16)
+                val c = octets[2].toInt(16)
+                // Skip multicast, loopback, link-local, and non-routable prefixes.
+                if (a == 0 || a >= 224) return null
+                "$a.$b.$c.1"
+            } catch (_: NumberFormatException) {
+                null
+            }
+        }
 
         /**
          * Pass true to start in degraded mode: ACCESS_FINE_LOCATION is required but

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
@@ -1,13 +1,64 @@
 package com.wscanplus.app.cti
 
+import org.json.JSONException
+import org.json.JSONObject
+
 /**
  * Parses CrowdSec CTI /v2/smoke response JSON.
  *
- * Intentionally minimal — the full response schema will be mapped during Phase 4
- * threat-narrative integration once the exact fields in use are verified against
- * the live API. Until then, presence of a non-blank body is the signal.
+ * Fields used:
+ *  - aggressive_score  (0–100): frequency of attacks attributed to this IP. Higher = more aggressive.
+ *  - background_noise_score (0–100): volume of background noise (scanning, probing). Higher = noisier.
+ *
+ * Both fields may be absent (null) for IPs with no CTI record — treated as no signal.
+ * Confidence is derived by normalising the higher of the two scores to [0.0, 0.9].
  */
 object CrowdSecSmokeParser {
+    data class ParsedScore(
+        val aggressiveScore: Int?,
+        val backgroundNoiseScore: Int?,
+    ) {
+        /** True if either score is present and non-zero. */
+        val hasSignal: Boolean
+            get() = (aggressiveScore ?: 0) > 0 || (backgroundNoiseScore ?: 0) > 0
+
+        /**
+         * Confidence in [0.0, 0.9] derived from the higher of the two scores.
+         * Returns null when [hasSignal] is false.
+         */
+        val confidence: Float?
+            get() {
+                val max = maxOf(aggressiveScore ?: 0, backgroundNoiseScore ?: 0)
+                if (max <= 0) return null
+                return (max.toFloat() / 100f).coerceIn(0f, 0.9f)
+            }
+
+        /** Human-readable reasons for UI / audit log (max 3). */
+        fun reasons(): List<String> {
+            val out = mutableListOf<String>()
+            aggressiveScore?.let { if (it > 0) out.add("CrowdSec aggressive score: $it/100") }
+            backgroundNoiseScore?.let { if (it > 0) out.add("CrowdSec background noise score: $it/100") }
+            return out.take(3)
+        }
+    }
+
     /** Returns true if the response body contains any CTI signal worth recording. */
     fun hasSignal(rawJson: String): Boolean = rawJson.isNotBlank()
+
+    /**
+     * Parses [rawJson] into a [ParsedScore].
+     * Returns [ParsedScore] with null fields if the JSON is malformed or fields are absent.
+     */
+    fun parse(rawJson: String): ParsedScore {
+        if (rawJson.isBlank()) return ParsedScore(null, null)
+        return try {
+            val obj = JSONObject(rawJson)
+            ParsedScore(
+                aggressiveScore = obj.optInt("aggressive_score", -1).takeIf { it >= 0 },
+                backgroundNoiseScore = obj.optInt("background_noise_score", -1).takeIf { it >= 0 },
+            )
+        } catch (_: JSONException) {
+            ParsedScore(null, null)
+        }
+    }
 }

--- a/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceBssidTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/WatchdogServiceBssidTest.kt
@@ -1,0 +1,42 @@
+package com.wscanplus.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WatchdogServiceBssidTest {
+    @Test
+    fun `typical consumer AP BSSID maps to gateway IP`() {
+        assertEquals("212.106.53.1", WatchdogService.bssidToGatewayIp("D4:6A:35:AB:CD:EF"))
+    }
+
+    @Test
+    fun `lowercase bssid is handled`() {
+        assertEquals("212.106.53.1", WatchdogService.bssidToGatewayIp("d4:6a:35:ab:cd:ef"))
+    }
+
+    @Test
+    fun `multicast prefix returns null`() {
+        assertNull(WatchdogService.bssidToGatewayIp("E0:AB:CD:01:02:03"))
+    }
+
+    @Test
+    fun `all-zero first octet returns null`() {
+        assertNull(WatchdogService.bssidToGatewayIp("00:AB:CD:01:02:03"))
+    }
+
+    @Test
+    fun `malformed bssid returns null`() {
+        assertNull(WatchdogService.bssidToGatewayIp("not-a-bssid"))
+    }
+
+    @Test
+    fun `too few octets returns null`() {
+        assertNull(WatchdogService.bssidToGatewayIp("AA:BB:CC"))
+    }
+
+    @Test
+    fun `broadcast bssid returns null`() {
+        assertNull(WatchdogService.bssidToGatewayIp("FF:FF:FF:FF:FF:FF"))
+    }
+}

--- a/android/app/src/test/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParserTest.kt
+++ b/android/app/src/test/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParserTest.kt
@@ -1,0 +1,94 @@
+package com.wscanplus.app.cti
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrowdSecSmokeParserTest {
+    @Test
+    fun `blank json returns no signal`() {
+        val result = CrowdSecSmokeParser.parse("")
+        assertFalse(result.hasSignal)
+        assertNull(result.confidence)
+        assertTrue(result.reasons().isEmpty())
+    }
+
+    @Test
+    fun `malformed json returns no signal`() {
+        val result = CrowdSecSmokeParser.parse("not json at all")
+        assertFalse(result.hasSignal)
+        assertNull(result.confidence)
+    }
+
+    @Test
+    fun `zero scores return no signal`() {
+        val json = """{"aggressive_score":0,"background_noise_score":0}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertFalse(result.hasSignal)
+        assertNull(result.confidence)
+    }
+
+    @Test
+    fun `aggressive score only produces signal`() {
+        val json = """{"aggressive_score":80}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertTrue(result.hasSignal)
+        assertEquals(80, result.aggressiveScore)
+        assertNull(result.backgroundNoiseScore)
+        assertEquals(0.80f, result.confidence!!, 0.001f)
+        assertEquals(1, result.reasons().size)
+        assertTrue(result.reasons()[0].contains("aggressive score: 80"))
+    }
+
+    @Test
+    fun `background noise score only produces signal`() {
+        val json = """{"background_noise_score":50}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertTrue(result.hasSignal)
+        assertEquals(50, result.backgroundNoiseScore)
+        assertEquals(0.50f, result.confidence!!, 0.001f)
+    }
+
+    @Test
+    fun `confidence uses higher of two scores`() {
+        val json = """{"aggressive_score":40,"background_noise_score":70}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertEquals(0.70f, result.confidence!!, 0.001f)
+    }
+
+    @Test
+    fun `confidence capped at 0_9`() {
+        val json = """{"aggressive_score":100}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertEquals(0.90f, result.confidence!!, 0.001f)
+    }
+
+    @Test
+    fun `reasons contains both scores when both present`() {
+        val json = """{"aggressive_score":60,"background_noise_score":30}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        val reasons = result.reasons()
+        assertEquals(2, reasons.size)
+        assertTrue(reasons[0].contains("aggressive score: 60"))
+        assertTrue(reasons[1].contains("background noise score: 30"))
+    }
+
+    @Test
+    fun `extra json fields are ignored`() {
+        val json = """{"ip":"1.2.3.4","aggressive_score":55,"unknown_field":"ignored"}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertTrue(result.hasSignal)
+        assertEquals(55, result.aggressiveScore)
+    }
+
+    @Test
+    fun `missing score fields treated as absent`() {
+        val json = """{"ip":"1.2.3.4","classifications":[]}"""
+        val result = CrowdSecSmokeParser.parse(json)
+        assertFalse(result.hasSignal)
+        assertNull(result.aggressiveScore)
+        assertNull(result.backgroundNoiseScore)
+    }
+}


### PR DESCRIPTION
Closes #353

## Summary

- `CrowdSecSmokeParser` rewritten: parses `aggressive_score` and `background_noise_score` from CrowdSec `/v2/smoke` JSON, normalises confidence to `[0.0, 0.9]`, returns human-readable reasons for the audit log
- `WatchdogService.runCtiCorroboration()`: called after `persistResults()` in the scan callback; derives candidate gateway IPs from flagged BSSIDs, fetches CTI cache entries, appends `ThreatSignal(source = CROWDSEC_CTI)` for any IP with a non-zero score — does not mutate existing signals
- `WatchdogService.bssidToGatewayIp()`: heuristic mapping first 3 MAC octets → `a.b.c.1`; rejects multicast, zero-first-octet, and broadcast prefixes

## Tests

- `CrowdSecSmokeParserTest` — 9 cases covering blank/malformed JSON, zero scores, single-score signal, confidence max-of-two, confidence cap, reasons list, extra fields, missing fields
- `WatchdogServiceBssidTest` — 7 cases covering typical BSSID, lowercase, multicast/zero/malformed/short/broadcast → null

## Notes

- BSSID-to-IP is a best-effort heuristic; enterprise APs will produce no CTI hit and be silently skipped (no crash, no noise)
- ktlint passes clean

🤖 Generated with [Claude Code](https://claude.ai/code)