### PR TITLE
fix(cti): replace org.json with kotlinx.serialization in CrowdSecSmokeParser

### DIFF
--- a/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/WatchdogService.kt
@@ -45,6 +45,7 @@ import com.wscanplus.core.scanner.ScannerChain
 import com.wscanplus.core.scanner.WifiScanResult
 import com.wscanplus.core.scanner.toScanInput
 import com.wscanplus.core.threat.BssidFingerprintHeuristic
+import com.wscanplus.core.threat.BssidProfile
 import com.wscanplus.core.threat.EncryptionDowngradeHeuristic
 import com.wscanplus.core.threat.EnvironmentType
 import com.wscanplus.core.threat.EvilTwinHeuristic
@@ -714,7 +715,7 @@ class WatchdogService : Service() {
 
     private fun persistResults(
         results: List<WifiScanResult>,
-        filteredSignals: List<com.wscanplus.core.threat.ThreatSignal>,
+        filteredSignals: List<ThreatSignal>,
     ) {
         val sessionId = currentSessionId ?: return
         val locationSample = latestLocationSample
@@ -772,7 +773,7 @@ class WatchdogService : Service() {
     private val scanAnalysisCacheTtlMs = 60_000L
     private val scanAnalysisCacheLock = Any()
 
-    @Volatile private var knownProfilesCache: Map<String, com.wscanplus.core.threat.BssidProfile> = emptyMap()
+    @Volatile private var knownProfilesCache: Map<String, BssidProfile> = emptyMap()
 
     @Volatile private var knownProfilesCacheAtMillis: Long = 0L
 
@@ -780,7 +781,7 @@ class WatchdogService : Service() {
 
     @Volatile private var baselineStatsCacheAtMillis: Long = 0L
 
-    private fun buildKnownProfiles(): Map<String, com.wscanplus.core.threat.BssidProfile> {
+    private fun buildKnownProfiles(): Map<String, BssidProfile> {
         val now = System.currentTimeMillis()
         if (now - knownProfilesCacheAtMillis < scanAnalysisCacheTtlMs && knownProfilesCache.isNotEmpty()) {
             return knownProfilesCache
@@ -798,7 +799,7 @@ class WatchdogService : Service() {
                 val profiles =
                     entities.associate { entity ->
                         entity.bssid to
-                            com.wscanplus.core.threat.BssidProfile(
+                            BssidProfile(
                                 bssid = entity.bssid,
                                 firstSeenAt = entity.firstSeenAt,
                                 lastSeenAt = entity.lastSeenAt,

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
@@ -3,6 +3,7 @@ package com.wscanplus.app.cti
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 
 object CrowdSecSmokeParser {

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
@@ -3,6 +3,7 @@ package com.wscanplus.app.cti
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.parseToJsonElement
 
 /**
  * Parses CrowdSec CTI /v2/smoke response JSON.

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
@@ -4,31 +4,15 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.parseToJsonElement
 
-/**
- * Parses CrowdSec CTI /v2/smoke response JSON.
- *
- * Fields used:
- *  - aggressive_score  (0–100): frequency of attacks attributed to this IP. Higher = more aggressive.
- *  - background_noise_score (0–100): volume of background noise (scanning, probing). Higher = noisier.
- *
- * Both fields may be absent (null) for IPs with no CTI record — treated as no signal.
- * Confidence is derived by normalising the higher of the two scores to [0.0, 0.9].
- */
 object CrowdSecSmokeParser {
     data class ParsedScore(
         val aggressiveScore: Int?,
         val backgroundNoiseScore: Int?,
     ) {
-        /** True if either score is present and non-zero. */
         val hasSignal: Boolean
             get() = (aggressiveScore ?: 0) > 0 || (backgroundNoiseScore ?: 0) > 0
 
-        /**
-         * Confidence in [0.0, 0.9] derived from the higher of the two scores.
-         * Returns null when [hasSignal] is false.
-         */
         val confidence: Float?
             get() {
                 val max = maxOf(aggressiveScore ?: 0, backgroundNoiseScore ?: 0)
@@ -36,7 +20,6 @@ object CrowdSecSmokeParser {
                 return (max.toFloat() / 100f).coerceIn(0f, 0.9f)
             }
 
-        /** Human-readable reasons for UI / audit log (max 3). */
         fun reasons(): List<String> {
             val out = mutableListOf<String>()
             aggressiveScore?.let { if (it > 0) out.add("CrowdSec aggressive score: $it/100") }
@@ -45,13 +28,8 @@ object CrowdSecSmokeParser {
         }
     }
 
-    /** Returns true if the response body contains any CTI signal worth recording. */
     fun hasSignal(rawJson: String): Boolean = rawJson.isNotBlank()
 
-    /**
-     * Parses [rawJson] into a [ParsedScore].
-     * Returns [ParsedScore] with null fields if the JSON is malformed or fields are absent.
-     */
     fun parse(rawJson: String): ParsedScore {
         if (rawJson.isBlank()) return ParsedScore(null, null)
         return try {

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
@@ -1,7 +1,8 @@
 package com.wscanplus.app.cti
 
-import org.json.JSONException
-import org.json.JSONObject
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 
 /**
  * Parses CrowdSec CTI /v2/smoke response JSON.
@@ -52,12 +53,12 @@ object CrowdSecSmokeParser {
     fun parse(rawJson: String): ParsedScore {
         if (rawJson.isBlank()) return ParsedScore(null, null)
         return try {
-            val obj = JSONObject(rawJson)
+            val obj = Json.parseToJsonElement(rawJson).jsonObject
             ParsedScore(
-                aggressiveScore = obj.optInt("aggressive_score", -1).takeIf { it >= 0 },
-                backgroundNoiseScore = obj.optInt("background_noise_score", -1).takeIf { it >= 0 },
+                aggressiveScore = (obj["aggressive_score"] as? JsonPrimitive)?.intOrNull,
+                backgroundNoiseScore = (obj["background_noise_score"] as? JsonPrimitive)?.intOrNull,
             )
-        } catch (_: JSONException) {
+        } catch (_: Exception) {
             ParsedScore(null, null)
         }
     }

--- a/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
+++ b/android/app/src/main/kotlin/com/wscanplus/app/cti/CrowdSecSmokeParser.kt
@@ -1,5 +1,6 @@
 package com.wscanplus.app.cti
 
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
@@ -59,7 +60,7 @@ object CrowdSecSmokeParser {
                 aggressiveScore = (obj["aggressive_score"] as? JsonPrimitive)?.intOrNull,
                 backgroundNoiseScore = (obj["background_noise_score"] as? JsonPrimitive)?.intOrNull,
             )
-        } catch (_: Exception) {
+        } catch (_: SerializationException) {
             ParsedScore(null, null)
         }
     }


### PR DESCRIPTION
## Summary

- `CrowdSecSmokeParser.kt` used `org.json.JSONObject.optInt()` which, under `isReturnDefaultValues = true` (set in `android.testOptions.unitTests`), returns Java's default `0` instead of the provided fallback (`-1`). This caused `0.takeIf { it >= 0 }` to return `0` instead of `null` for absent fields, breaking 6 of 10 `CrowdSecSmokeParserTest` cases.
- Replaced with `kotlinx.serialization.json` (`Json.parseToJsonElement` + `JsonPrimitive.intOrNull`), which is already an `implementation` dependency and has no Android stub dependency in JVM tests. Behavior on Android runtime is unchanged.
- This is a pre-existing failure (same code on `main`); fixing it on the session branch so CI passes and APK artifacts are produced cleanly.

Closes #377

## Test plan

- [ ] CI Android (JDK 17, Gradle) job passes — `CrowdSecSmokeParserTest` 10/10 green
- [ ] `assembleDebug` succeeds and `wscanplus-debug-apk-ci-mock` artifact is uploaded
- [ ] No regressions in other test classes